### PR TITLE
Fixed install progress bugs, etc.

### DIFF
--- a/server.py
+++ b/server.py
@@ -2268,8 +2268,12 @@ class Handler(http.server.SimpleHTTPRequestHandler):
                     ).start()
                     self.send_json({"status": "started", "from": tag, "to": latest})
                 else:
+                    with install_lock:
+                        install_in_progress = False
                     self.send_json({"status": "already_latest"})
             except Exception as e:
+                with install_lock:
+                    install_in_progress = False
                 self.send_json({"error": str(e)}, 500)
             return
 

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -2837,11 +2837,14 @@ function escapeHtml(text) {
 
 function renderMarkdown(text) {
     let html = escapeHtml(text);
+    const codeBlocks = [];
 
     // Fenced code blocks ``` ... ```
     html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_, lang, code) => {
         const langAttr = lang ? ` data-lang="${lang}"` : "";
-        return `<pre${langAttr}><code>${code.replace(/\n$/, "")}</code></pre>`;
+        const index = codeBlocks.length;
+        codeBlocks.push(`<pre${langAttr}><code>${code.replace(/\n$/, "")}</code></pre>`);
+        return `\u0000CODE_BLOCK_${index}\u0000`;
     });
 
     // Inline code `...`
@@ -2863,12 +2866,13 @@ function renderMarkdown(text) {
     html = blocks.map(block => {
         block = block.trim();
         if (!block) return "";
-        // Don't wrap pre blocks in p tags
-        if (block.startsWith("<pre")) return block;
+        if (/^\u0000CODE_BLOCK_\d+\u0000$/.test(block)) return block;
         // Convert single newlines to <br>
         block = block.replace(/\n/g, "<br>");
         return `<p>${block}</p>`;
     }).join("");
+
+    html = html.replace(/\u0000CODE_BLOCK_(\d+)\u0000/g, (_, index) => codeBlocks[Number(index)] || "");
 
     return html;
 }


### PR DESCRIPTION
In server.py (line 2271), /api/update now clears install_in_progress when the update is already current or when release fetching fails, so the app won’t get stuck thinking an install is still running.

In app.js (line 2838), fenced code blocks are now protected before inline markdown formatting runs, then restored afterward. Code like **literal** inside triple backticks stays literal, while normal prose markdown still renders.