### PR TITLE
Configural bind host plan implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,12 @@ LLAMA_GUI_HOST=0.0.0.0 LLAMA_GUI_PORT=5240 python server.py
 
 Then open `http://<server-ip>:5240` from another machine. `LLAMA_GUI_PORT` is optional and defaults to `5240`.
 
+Access by IP address works by default. If you want to open the UI through a LAN hostname, mDNS name, or reverse-proxy hostname, explicitly trust that browser hostname too:
+
+```bash
+LLAMA_GUI_HOST=0.0.0.0 LLAMA_GUI_ALLOWED_HOSTS=llama-box.local python server.py
+```
+
 Do not expose this admin UI directly to the public internet. Llama GUI does not enforce its own authentication layer; use a trusted network, VPN, or authenticated reverse proxy.
 
 ## First-Run Checklist (60 Seconds)
@@ -501,7 +507,7 @@ Fix:
 ## Security Notes
 
 - Llama GUI is intended for local use (`127.0.0.1`).
-- `LLAMA_GUI_HOST=0.0.0.0` allows LAN access, but should only be used on trusted networks or behind a VPN/authenticated reverse proxy.
+- `LLAMA_GUI_HOST=0.0.0.0` allows LAN access by IP address, but should only be used on trusted networks or behind a VPN/authenticated reverse proxy. Hostname access requires `LLAMA_GUI_ALLOWED_HOSTS`.
 - The wrapper does not enforce its own authentication layer.
 - The Cloudflare remote tunnel is opt-in and does not start automatically.
 - If exposing beyond localhost, anyone with the tunnel URL can control the running Llama GUI session until you stop the tunnel.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,18 @@ chmod +x install.sh mac_linux_start.sh mac_linux_silent_start.sh
 
 Note: some Linux accelerator backends may also require vendor drivers or runtime packages outside of Llama GUI itself.
 
+### Headless or LAN Access
+
+By default, Llama GUI only listens on `127.0.0.1:5240`. On a trusted LAN or VPN, you can opt in to remote browser access with environment variables:
+
+```bash
+LLAMA_GUI_HOST=0.0.0.0 LLAMA_GUI_PORT=5240 python server.py
+```
+
+Then open `http://<server-ip>:5240` from another machine. `LLAMA_GUI_PORT` is optional and defaults to `5240`.
+
+Do not expose this admin UI directly to the public internet. Llama GUI does not enforce its own authentication layer; use a trusted network, VPN, or authenticated reverse proxy.
+
 ## First-Run Checklist (60 Seconds)
 
 Use this as a quick onboarding flow for a fresh setup:
@@ -489,6 +501,7 @@ Fix:
 ## Security Notes
 
 - Llama GUI is intended for local use (`127.0.0.1`).
+- `LLAMA_GUI_HOST=0.0.0.0` allows LAN access, but should only be used on trusted networks or behind a VPN/authenticated reverse proxy.
 - The wrapper does not enforce its own authentication layer.
 - The Cloudflare remote tunnel is opt-in and does not start automatically.
 - If exposing beyond localhost, anyone with the tunnel URL can control the running Llama GUI session until you stop the tunnel.

--- a/backend/app.py
+++ b/backend/app.py
@@ -31,6 +31,7 @@ from backend.http import (
     Request,
     Response,
     SseWriter,
+    WILDCARD_BIND_HOSTS,
     get_access_control_origin,
     get_allowed_request_origins,
     get_cors_methods,
@@ -546,7 +547,13 @@ class Handler(http.server.SimpleHTTPRequestHandler):
 
     def get_allowed_request_origins(self):
         tunnel_url = get_remote_tunnel_snapshot().get("url")
-        return get_allowed_request_origins(tunnel_url, GUI_HOST, GUI_PORT)
+        return get_allowed_request_origins(
+            tunnel_url,
+            GUI_HOST,
+            GUI_PORT,
+            request_host=self.headers.get("Host", ""),
+            allow_request_host_origin=GUI_HOST in WILDCARD_BIND_HOSTS,
+        )
 
     def get_access_control_origin(self):
         return get_access_control_origin(self.headers, self.get_allowed_request_origins())
@@ -776,7 +783,14 @@ def main():
         d.mkdir(parents=True, exist_ok=True)
 
     try:
-        APP_CONTEXT.state.gui_server = http.server.ThreadingHTTPServer((GUI_HOST, port), Handler)
+        server_class = http.server.ThreadingHTTPServer
+        if ":" in GUI_HOST:
+            server_class = type(
+                "ThreadingHTTPServerIPv6",
+                (http.server.ThreadingHTTPServer,),
+                {"address_family": socket.AF_INET6},
+            )
+        APP_CONTEXT.state.gui_server = server_class((GUI_HOST, port), Handler)
     except OSError as e:
         if "address already in use" in str(e).lower() or e.errno == 10048:
             print(f"ERROR: Port {port} is already in use.")
@@ -787,6 +801,8 @@ def main():
         sys.exit(1)
 
     print(f"Llama GUI running at http://{GUI_HOST}:{port}")
+    if GUI_HOST in WILDCARD_BIND_HOSTS:
+        print(f"Remote access enabled. Open http://<this-server-lan-ip>:{port} from a trusted machine.")
     print("Press Ctrl+C to stop the server.")
     try:
         APP_CONTEXT.state.gui_server.serve_forever()

--- a/backend/config.py
+++ b/backend/config.py
@@ -46,8 +46,20 @@ def parse_gui_port(value: object, default: int = DEFAULT_GUI_PORT) -> int:
     return port
 
 
+def parse_gui_allowed_hosts(value: object) -> tuple[str, ...]:
+    hosts = []
+    for raw_host in str(value or "").split(","):
+        host = parse_gui_host(raw_host, default="")
+        if host:
+            host = host.lower()
+        if host and host not in hosts:
+            hosts.append(host)
+    return tuple(hosts)
+
+
 GUI_HOST = parse_gui_host(os.environ.get("LLAMA_GUI_HOST"), DEFAULT_GUI_HOST)
 GUI_PORT = parse_gui_port(os.environ.get("LLAMA_GUI_PORT"), DEFAULT_GUI_PORT)
+GUI_ALLOWED_HOSTS = parse_gui_allowed_hosts(os.environ.get("LLAMA_GUI_ALLOWED_HOSTS"))
 LLAMA_HOST = "127.0.0.1"
 LLAMA_PORT = 8080
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -4,6 +4,7 @@ Keep this module free of optional third-party imports so the server can import i
 during startup on a minimal Python environment.
 """
 
+import os
 from pathlib import Path
 
 
@@ -20,8 +21,33 @@ APP_LOGO_FILE = ROOT_DIR / "Llama-GUI Logo.png"
 TOOLS_DIR = ROOT_DIR / "tools"
 CLOUDFLARED_DIR = TOOLS_DIR / "cloudflared"
 
-GUI_HOST = "127.0.0.1"
-GUI_PORT = 5240
+DEFAULT_GUI_HOST = "127.0.0.1"
+DEFAULT_GUI_PORT = 5240
+
+
+def parse_gui_host(value: object, default: str = DEFAULT_GUI_HOST) -> str:
+    host = str(value or "").strip()
+    if not host or any(ord(ch) < 32 for ch in host) or "/" in host:
+        return default
+    if host == "*":
+        return "0.0.0.0"
+    if host.startswith("[") and host.endswith("]"):
+        return host[1:-1]
+    return host
+
+
+def parse_gui_port(value: object, default: int = DEFAULT_GUI_PORT) -> int:
+    try:
+        port = int(str(value or "").strip())
+    except (TypeError, ValueError):
+        return default
+    if port < 1 or port > 65535:
+        return default
+    return port
+
+
+GUI_HOST = parse_gui_host(os.environ.get("LLAMA_GUI_HOST"), DEFAULT_GUI_HOST)
+GUI_PORT = parse_gui_port(os.environ.get("LLAMA_GUI_PORT"), DEFAULT_GUI_PORT)
 LLAMA_HOST = "127.0.0.1"
 LLAMA_PORT = 8080
 

--- a/backend/http.py
+++ b/backend/http.py
@@ -8,6 +8,9 @@ import urllib.parse
 
 from . import config
 
+WILDCARD_BIND_HOSTS = {"0.0.0.0", "::", "*"}
+LOCAL_BROWSER_HOSTS = ("127.0.0.1", "localhost", "::1")
+
 
 @dataclass(frozen=True)
 class Request:
@@ -27,11 +30,51 @@ def get_allowed_request_origins(
     tunnel_url: str = "",
     gui_host: str = config.GUI_HOST,
     gui_port: int = config.GUI_PORT,
+    request_host: str = "",
+    allow_request_host_origin: bool = False,
 ) -> tuple[str, ...]:
-    allowed = [f"http://{gui_host}:{gui_port}", f"http://localhost:{gui_port}"]
+    allowed = []
+    for host in LOCAL_BROWSER_HOSTS:
+        origin = build_http_origin(host, gui_port)
+        if origin not in allowed:
+            allowed.append(origin)
+
+    if gui_host and gui_host not in WILDCARD_BIND_HOSTS:
+        origin = build_http_origin(gui_host, gui_port)
+        if origin not in allowed:
+            allowed.append(origin)
+
+    if allow_request_host_origin:
+        request_origin = get_request_host_origin(request_host, gui_port)
+        if request_origin and request_origin not in allowed:
+            allowed.append(request_origin)
+
     if tunnel_url:
         allowed.append(tunnel_url)
     return tuple(allowed)
+
+
+def format_origin_host(host: str) -> str:
+    value = str(host or "").strip().strip("[]")
+    if ":" in value and value not in {"localhost"}:
+        return f"[{value}]"
+    return value
+
+
+def build_http_origin(host: str, port: int) -> str:
+    return f"http://{format_origin_host(host)}:{port}"
+
+
+def get_request_host_origin(host_header: str, gui_port: int) -> str:
+    value = str(host_header or "").strip()
+    if not value:
+        return ""
+    parsed = urllib.parse.urlparse(f"//{value}")
+    host = parsed.hostname
+    port = parsed.port or gui_port
+    if not host or host in WILDCARD_BIND_HOSTS or port != gui_port:
+        return ""
+    return build_http_origin(host, gui_port)
 
 
 def is_safe_request_origin(headers: Any, allowed_origins: Sequence[str]) -> bool:

--- a/backend/http.py
+++ b/backend/http.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 from email.message import Message
+import ipaddress
 import json
 from typing import Any, Mapping, Optional, Sequence
 import urllib.parse
@@ -32,6 +33,7 @@ def get_allowed_request_origins(
     gui_port: int = config.GUI_PORT,
     request_host: str = "",
     allow_request_host_origin: bool = False,
+    trusted_hosts: Sequence[str] = config.GUI_ALLOWED_HOSTS,
 ) -> tuple[str, ...]:
     allowed = []
     for host in LOCAL_BROWSER_HOSTS:
@@ -45,7 +47,7 @@ def get_allowed_request_origins(
             allowed.append(origin)
 
     if allow_request_host_origin:
-        request_origin = get_request_host_origin(request_host, gui_port)
+        request_origin = get_request_host_origin(request_host, gui_port, trusted_hosts)
         if request_origin and request_origin not in allowed:
             allowed.append(request_origin)
 
@@ -65,7 +67,25 @@ def build_http_origin(host: str, port: int) -> str:
     return f"http://{format_origin_host(host)}:{port}"
 
 
-def get_request_host_origin(host_header: str, gui_port: int) -> str:
+def is_ip_literal(host: str) -> bool:
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return True
+
+
+def is_trusted_request_host(host: str, trusted_hosts: Sequence[str]) -> bool:
+    if host in LOCAL_BROWSER_HOSTS or is_ip_literal(host):
+        return True
+    return host.lower() in trusted_hosts
+
+
+def get_request_host_origin(
+    host_header: str,
+    gui_port: int,
+    trusted_hosts: Sequence[str] = config.GUI_ALLOWED_HOSTS,
+) -> str:
     value = str(host_header or "").strip()
     if not value:
         return ""
@@ -73,6 +93,8 @@ def get_request_host_origin(host_header: str, gui_port: int) -> str:
     host = parsed.hostname
     port = parsed.port or gui_port
     if not host or host in WILDCARD_BIND_HOSTS or port != gui_port:
+        return ""
+    if not is_trusted_request_host(host, trusted_hosts):
         return ""
     return build_http_origin(host, gui_port)
 

--- a/backend/services/tunnel.py
+++ b/backend/services/tunnel.py
@@ -135,11 +135,15 @@ def _start_remote_tunnel_worker(ctx: AppContext) -> None:
         if ctx.services.current_platform.startswith("linux"):
             env.pop("LD_LIBRARY_PATH", None)
 
+        tunnel_host = ctx.config.gui_host
+        if tunnel_host in {"0.0.0.0", "::", "*"}:
+            tunnel_host = config.DEFAULT_GUI_HOST
+
         args = [
             str(binary_path),
             "tunnel",
             "--url",
-            f"http://{ctx.config.gui_host}:{ctx.config.gui_port}",
+            f"http://{tunnel_host}:{ctx.config.gui_port}",
         ]
         proc = subprocess.Popen(
             args,

--- a/tests/backend/test_backend_foundation.py
+++ b/tests/backend/test_backend_foundation.py
@@ -21,6 +21,19 @@ class BackendConfigTests(unittest.TestCase):
         self.assertEqual(server_config.llama_port, 8080)
         self.assertEqual(server_config.gui_host, "127.0.0.1")
 
+    def test_gui_env_parsers_accept_valid_values(self):
+        self.assertEqual(config.parse_gui_host("0.0.0.0"), "0.0.0.0")
+        self.assertEqual(config.parse_gui_host("*"), "0.0.0.0")
+        self.assertEqual(config.parse_gui_host("[::]"), "::")
+        self.assertEqual(config.parse_gui_host("192.168.1.10"), "192.168.1.10")
+        self.assertEqual(config.parse_gui_port("5250"), 5250)
+
+    def test_gui_env_parsers_fall_back_for_invalid_values(self):
+        self.assertEqual(config.parse_gui_host(""), "127.0.0.1")
+        self.assertEqual(config.parse_gui_host("192.168.1.0/24"), "127.0.0.1")
+        self.assertEqual(config.parse_gui_port("not-a-port"), 5240)
+        self.assertEqual(config.parse_gui_port("70000"), 5240)
+
 
 class AtomicDictTests(unittest.TestCase):
     def test_snapshot_is_a_copy(self):

--- a/tests/backend/test_backend_foundation.py
+++ b/tests/backend/test_backend_foundation.py
@@ -27,12 +27,17 @@ class BackendConfigTests(unittest.TestCase):
         self.assertEqual(config.parse_gui_host("[::]"), "::")
         self.assertEqual(config.parse_gui_host("192.168.1.10"), "192.168.1.10")
         self.assertEqual(config.parse_gui_port("5250"), 5250)
+        self.assertEqual(
+            config.parse_gui_allowed_hosts("Llama-Box.local, 192.168.1.20, [::1]"),
+            ("llama-box.local", "192.168.1.20", "::1"),
+        )
 
     def test_gui_env_parsers_fall_back_for_invalid_values(self):
         self.assertEqual(config.parse_gui_host(""), "127.0.0.1")
         self.assertEqual(config.parse_gui_host("192.168.1.0/24"), "127.0.0.1")
         self.assertEqual(config.parse_gui_port("not-a-port"), 5240)
         self.assertEqual(config.parse_gui_port("70000"), 5240)
+        self.assertEqual(config.parse_gui_allowed_hosts("192.168.1.0/24,,\n"), ())
 
 
 class AtomicDictTests(unittest.TestCase):

--- a/tests/backend/test_http_adapters.py
+++ b/tests/backend/test_http_adapters.py
@@ -40,7 +40,7 @@ class HttpCorsAdapterTests(unittest.TestCase):
         self.assertIn("http://localhost:5250", origins)
         self.assertIn("http://192.168.1.10:5250", origins)
 
-    def test_wildcard_bind_uses_request_host_origin_without_allowing_wildcard_origin(self):
+    def test_wildcard_bind_uses_ip_request_host_origin_without_allowing_wildcard_origin(self):
         origins = get_allowed_request_origins(
             gui_host="0.0.0.0",
             gui_port=5250,
@@ -52,6 +52,29 @@ class HttpCorsAdapterTests(unittest.TestCase):
         self.assertNotIn("http://0.0.0.0:5250", origins)
         self.assertTrue(is_safe_request_origin(self.make_headers(origin="http://192.168.1.20:5250"), origins))
         self.assertFalse(is_safe_request_origin(self.make_headers(origin="http://0.0.0.0:5250"), origins))
+
+    def test_wildcard_bind_rejects_untrusted_hostnames(self):
+        origins = get_allowed_request_origins(
+            gui_host="0.0.0.0",
+            gui_port=5250,
+            request_host="attacker.example:5250",
+            allow_request_host_origin=True,
+        )
+
+        self.assertNotIn("http://attacker.example:5250", origins)
+        self.assertFalse(is_safe_request_origin(self.make_headers(origin="http://attacker.example:5250"), origins))
+
+    def test_wildcard_bind_allows_explicitly_trusted_hostnames(self):
+        origins = get_allowed_request_origins(
+            gui_host="0.0.0.0",
+            gui_port=5250,
+            request_host="llama-box.local:5250",
+            allow_request_host_origin=True,
+            trusted_hosts=("llama-box.local",),
+        )
+
+        self.assertIn("http://llama-box.local:5250", origins)
+        self.assertTrue(is_safe_request_origin(self.make_headers(origin="http://llama-box.local:5250"), origins))
 
     def test_origin_and_referer_validation(self):
         allowed = get_allowed_request_origins()

--- a/tests/backend/test_http_adapters.py
+++ b/tests/backend/test_http_adapters.py
@@ -16,12 +16,14 @@ from backend.http import (
 
 
 class HttpCorsAdapterTests(unittest.TestCase):
-    def make_headers(self, origin="", referer=""):
+    def make_headers(self, origin="", referer="", host=""):
         headers = Message()
         if origin:
             headers["Origin"] = origin
         if referer:
             headers["Referer"] = referer
+        if host:
+            headers["Host"] = host
         return headers
 
     def test_allowed_origins_include_local_and_active_tunnel(self):
@@ -30,6 +32,26 @@ class HttpCorsAdapterTests(unittest.TestCase):
         self.assertIn("http://127.0.0.1:5240", origins)
         self.assertIn("http://localhost:5240", origins)
         self.assertIn("https://example.trycloudflare.com", origins)
+
+    def test_allowed_origins_include_explicit_gui_host(self):
+        origins = get_allowed_request_origins(gui_host="192.168.1.10", gui_port=5250)
+
+        self.assertIn("http://127.0.0.1:5250", origins)
+        self.assertIn("http://localhost:5250", origins)
+        self.assertIn("http://192.168.1.10:5250", origins)
+
+    def test_wildcard_bind_uses_request_host_origin_without_allowing_wildcard_origin(self):
+        origins = get_allowed_request_origins(
+            gui_host="0.0.0.0",
+            gui_port=5250,
+            request_host="192.168.1.20:5250",
+            allow_request_host_origin=True,
+        )
+
+        self.assertIn("http://192.168.1.20:5250", origins)
+        self.assertNotIn("http://0.0.0.0:5250", origins)
+        self.assertTrue(is_safe_request_origin(self.make_headers(origin="http://192.168.1.20:5250"), origins))
+        self.assertFalse(is_safe_request_origin(self.make_headers(origin="http://0.0.0.0:5250"), origins))
 
     def test_origin_and_referer_validation(self):
         allowed = get_allowed_request_origins()

--- a/tests/backend/test_server_baseline.py
+++ b/tests/backend/test_server_baseline.py
@@ -35,13 +35,15 @@ class ServerStateIsolationMixin:
 
 
 class HandlerCorsTests(ServerStateIsolationMixin, unittest.TestCase):
-    def make_handler(self, origin="", referer=""):
+    def make_handler(self, origin="", referer="", host=""):
         handler = object.__new__(server.Handler)
         headers = Message()
         if origin:
             headers["Origin"] = origin
         if referer:
             headers["Referer"] = referer
+        if host:
+            headers["Host"] = host
         handler.headers = headers
         return handler
 
@@ -62,6 +64,22 @@ class HandlerCorsTests(ServerStateIsolationMixin, unittest.TestCase):
 
         self.assertTrue(handler.is_safe_request_origin())
         self.assertIn("https://example.trycloudflare.com", handler.get_allowed_request_origins())
+
+    def test_wildcard_bind_allows_same_port_request_host_origin(self):
+        original_host = server.GUI_HOST
+        try:
+            server.GUI_HOST = "0.0.0.0"
+            handler = self.make_handler(
+                origin="http://192.168.1.20:5240",
+                host="192.168.1.20:5240",
+            )
+            wildcard = self.make_handler(origin="http://0.0.0.0:5240", host="0.0.0.0:5240")
+
+            self.assertTrue(handler.is_safe_request_origin())
+            self.assertIn("http://192.168.1.20:5240", handler.get_allowed_request_origins())
+            self.assertFalse(wildcard.is_safe_request_origin())
+        finally:
+            server.GUI_HOST = original_host
 
     def test_rejects_unknown_origin(self):
         handler = self.make_handler(origin="https://evil.example")

--- a/tests/backend/test_server_baseline.py
+++ b/tests/backend/test_server_baseline.py
@@ -65,7 +65,7 @@ class HandlerCorsTests(ServerStateIsolationMixin, unittest.TestCase):
         self.assertTrue(handler.is_safe_request_origin())
         self.assertIn("https://example.trycloudflare.com", handler.get_allowed_request_origins())
 
-    def test_wildcard_bind_allows_same_port_request_host_origin(self):
+    def test_wildcard_bind_allows_same_port_ip_request_host_origin(self):
         original_host = server.GUI_HOST
         try:
             server.GUI_HOST = "0.0.0.0"
@@ -74,10 +74,15 @@ class HandlerCorsTests(ServerStateIsolationMixin, unittest.TestCase):
                 host="192.168.1.20:5240",
             )
             wildcard = self.make_handler(origin="http://0.0.0.0:5240", host="0.0.0.0:5240")
+            untrusted = self.make_handler(
+                origin="http://attacker.example:5240",
+                host="attacker.example:5240",
+            )
 
             self.assertTrue(handler.is_safe_request_origin())
             self.assertIn("http://192.168.1.20:5240", handler.get_allowed_request_origins())
             self.assertFalse(wildcard.is_safe_request_origin())
+            self.assertFalse(untrusted.is_safe_request_origin())
         finally:
             server.GUI_HOST = original_host
 


### PR DESCRIPTION
Added LLAMA_GUI_HOST and LLAMA_GUI_PORT env parsing in backend/config.py. Updated server startup in backend/app.py to bind to the configured host/port, print a LAN access hint for wildcard binds, and support IPv6 bind hosts. Updated CORS/origin handling in backend/http.py so wildcard binds don’t allow 0.0.0.0 as a browser origin, but do allow the actual same-port Host origin. Kept Cloudflare compatible by having tunnels target 127.0.0.1 when the GUI is bound to a wildcard address. Added README docs for headless/LAN use and security warnings.