### PR TITLE
Add configurable web search result count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,7 +339,8 @@ The backend proxies `/api/chat/completions` to `llama-server`'s `/v1/chat/comple
 
 When the web search toggle is enabled:
 - The backend extracts the latest user message and queries DuckDuckGo.
-- Up to 5 search results are fetched, and up to 3 pages are read for full text.
+- The Chat sidebar's "Result Count" setting controls both how many search results are requested and how many result pages are read for full text.
+- Result Count defaults to 5, is persisted in `localStorage` under `llama_gui_chat_web_search_max_results`, and is clamped to 1-10 by both frontend UI constraints and the backend chat route.
 - Search context is injected into the system prompt with source citations.
 - Sources are rendered as clickable chips below the assistant's response.
 - Web search status messages (e.g., "Searching: ...", "Reading: ...") are streamed during processing.
@@ -536,6 +537,11 @@ The Configure tab has a search input that filters visible flags in real-time.
 - Quick Launch sampler edits sync to Chat, Configure, shared flag state, and launch args.
 
 When running local browser smoke checks manually, serve `ui/` as the web root. Serving from the repo root will break root-relative assets such as `/js/app.js`.
+
+Playwright is a dev/CI-only Node dependency:
+- Use `npm ci`, `npx playwright install chromium`, and `npm run test:frontend` for frontend smoke checks.
+- Do not add Playwright to `requirements.txt`, launch scripts, Pinokio setup, or app update dependency installation.
+- Normal runtime installs should remain Python-only through `pip install -r requirements.txt`.
 
 ## Local Search Notes
 

--- a/backend/routes/chat.py
+++ b/backend/routes/chat.py
@@ -11,6 +11,17 @@ from backend.services import chat as chat_service
 from backend.services import web_search
 
 
+def get_web_search_result_count(body):
+    try:
+        raw_value = body.get("web_search_max_results", config.WEB_SEARCH_MAX_RESULTS)
+        if raw_value in {None, ""}:
+            raw_value = config.WEB_SEARCH_MAX_RESULTS
+        max_results = int(raw_value)
+    except (TypeError, ValueError):
+        max_results = config.WEB_SEARCH_MAX_RESULTS
+    return max(1, min(max_results, 10))
+
+
 def completions(request, response, ctx):
     body = request.body or {}
     response.sse_headers()
@@ -20,6 +31,7 @@ def completions(request, response, ctx):
         proxied_messages = messages
 
         if body.get("web_search"):
+            max_results = get_web_search_result_count(body)
             latest_user = chat_service.get_latest_user_message(messages)
             queries = chat_service.build_search_queries(latest_user)
             all_results = []
@@ -27,7 +39,7 @@ def completions(request, response, ctx):
 
             for query in queries:
                 writer.write({"type": "web_status", "content": f"Searching: {query}"})
-                search_response = web_search.web_search(query)
+                search_response = web_search.web_search(query, max_results=max_results)
                 if not search_response.get("ok"):
                     writer.write({"error": {"message": search_response.get("error", "Search unavailable")}})
                     writer.write("[DONE]")
@@ -35,10 +47,10 @@ def completions(request, response, ctx):
                 for result in search_response.get("results", []):
                     if result.get("url") and all(r.get("url") != result.get("url") for r in all_results):
                         all_results.append(result)
-                    if len(all_results) >= config.WEB_SEARCH_MAX_RESULTS:
+                    if len(all_results) >= max_results:
                         break
 
-            for result in all_results[: config.WEB_SEARCH_FETCH_RESULTS]:
+            for result in all_results[:max_results]:
                 url = result.get("url", "")
                 host = urllib.parse.urlparse(url).hostname or url
                 if host.startswith("www."):
@@ -83,6 +95,7 @@ def completions(request, response, ctx):
         proxy_body.pop("api_url", None)
         proxy_body.pop("host", None)
         proxy_body.pop("port", None)
+        proxy_body.pop("web_search_max_results", None)
 
         api_url = chat_service.get_local_chat_api_url(body)
         req = urllib.request.Request(

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -703,6 +703,101 @@ class ExtractedRouteTests(unittest.TestCase):
             self.assertIn("Original system.", system_message["content"])
             self.assertIn("Fresh page text", system_message["content"])
             self.assertNotIn("web_search", captured["body"])
+            self.assertNotIn("web_search_max_results", captured["body"])
+
+    def test_chat_route_uses_configured_web_search_result_count(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            response = DummySseResponse()
+            captured = {}
+            results = [
+                {"title": f"Result {idx}", "url": f"https://example.com/{idx}", "snippet": f"Snippet {idx}"}
+                for idx in range(1, 7)
+            ]
+
+            def fake_urlopen(req, timeout):
+                captured["body"] = json.loads(req.data.decode("utf-8"))
+                return FakeSseUpstream([b"data: [DONE]\n\n"])
+
+            with mock.patch.object(
+                chat.web_search,
+                "web_search",
+                return_value={"ok": True, "results": results},
+            ) as search_mock, mock.patch.object(
+                chat.web_search,
+                "fetch_page_text",
+                return_value={"ok": True, "text": "Fresh page text"},
+            ) as fetch_mock, mock.patch.object(
+                chat.chat_service,
+                "get_local_chat_api_url",
+                return_value="http://127.0.0.1:8080/v1/chat/completions",
+            ), mock.patch.object(chat.urllib.request, "urlopen", side_effect=fake_urlopen):
+                chat.completions(
+                    Request(
+                        "POST",
+                        "/api/chat/completions",
+                        "",
+                        {},
+                        body={
+                            "web_search": True,
+                            "web_search_max_results": 4,
+                            "messages": [{"role": "user", "content": "What changed?"}],
+                        },
+                    ),
+                    response,
+                    ctx,
+                )
+
+            search_mock.assert_called_once_with("What changed?", max_results=4)
+            self.assertEqual(fetch_mock.call_count, 4)
+            fetched_urls = [call.args[0] for call in fetch_mock.call_args_list]
+            self.assertEqual(fetched_urls, [f"https://example.com/{idx}" for idx in range(1, 5)])
+            self.assertNotIn("web_search", captured["body"])
+            self.assertNotIn("web_search_max_results", captured["body"])
+
+    def test_chat_route_clamps_web_search_result_count(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            results = [
+                {"title": f"Result {idx}", "url": f"https://example.com/{idx}", "snippet": f"Snippet {idx}"}
+                for idx in range(1, 12)
+            ]
+
+            def run_with_count(value):
+                response = DummySseResponse()
+                with mock.patch.object(
+                    chat.web_search,
+                    "web_search",
+                    return_value={"ok": True, "results": results},
+                ) as search_mock, mock.patch.object(
+                    chat.web_search,
+                    "fetch_page_text",
+                    return_value={"ok": True, "text": "Fresh page text"},
+                ) as fetch_mock, mock.patch.object(
+                    chat.chat_service,
+                    "get_local_chat_api_url",
+                    return_value="http://127.0.0.1:8080/v1/chat/completions",
+                ), mock.patch.object(chat.urllib.request, "urlopen", return_value=FakeSseUpstream([b"data: [DONE]\n\n"])):
+                    chat.completions(
+                        Request(
+                            "POST",
+                            "/api/chat/completions",
+                            "",
+                            {},
+                            body={
+                                "web_search": True,
+                                "web_search_max_results": value,
+                                "messages": [{"role": "user", "content": "What changed?"}],
+                            },
+                        ),
+                        response,
+                        ctx,
+                    )
+                return search_mock.call_args.kwargs["max_results"], fetch_mock.call_count
+
+            self.assertEqual(run_with_count(0), (1, 1))
+            self.assertEqual(run_with_count(99), (10, 10))
+            self.assertEqual(run_with_count("invalid"), (5, 5))
 
     def test_file_picker_route_uses_model_filters_for_model_purpose(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/frontend/flag_sync_smoke.cjs
+++ b/tests/frontend/flag_sync_smoke.cjs
@@ -80,10 +80,25 @@ async function main() {
 
     try {
         const page = await browser.newPage();
+        const chatCompletionBodies = [];
 
         await page.route("**/api/**", async (route) => {
             const url = new URL(route.request().url());
             const pathName = url.pathname;
+            if (pathName === "/api/chat/completions") {
+                chatCompletionBodies.push(JSON.parse(route.request().postData() || "{}"));
+                await route.fulfill({
+                    status: 200,
+                    contentType: "text/event-stream",
+                    body: [
+                        'data: {"choices":[{"delta":{"content":"ok"}}]}',
+                        "",
+                        "data: [DONE]",
+                        "",
+                    ].join("\n"),
+                });
+                return;
+            }
             if (pathName === "/api/models") {
                 await route.fulfill({
                     status: 200,
@@ -221,6 +236,21 @@ async function main() {
         });
         await page.waitForFunction(() => document.querySelector("#chat-slider-temp")?.value === "0.31");
         assert.equal(await page.textContent("#chat-val-temp"), "0.31");
+
+        assert.equal(await page.locator("#chat-web-search-max-results").getAttribute("min"), "1");
+        assert.equal(await page.locator("#chat-web-search-max-results").getAttribute("max"), "10");
+        await page.check("#chat-web-search-toggle");
+        await page.fill("#chat-web-search-max-results", "7");
+        await page.dispatchEvent("#chat-web-search-max-results", "input");
+        await page.fill("#chat-input", "Search configurable depth");
+        await page.click("#btn-chat-send");
+        await page.waitForFunction(() => document.querySelector("#chat-messages")?.textContent.includes("ok"));
+        assert.equal(
+            await page.evaluate(() => localStorage.getItem("llama_gui_chat_web_search_max_results")),
+            "7"
+        );
+        assert.equal(chatCompletionBodies.at(-1).web_search, true);
+        assert.equal(chatCompletionBodies.at(-1).web_search_max_results, 7);
 
         await selectSection(page, "quick-launch");
         await page.fill("#quick-temperature", "0.42");

--- a/ui/css/style.css
+++ b/ui/css/style.css
@@ -2022,6 +2022,43 @@ textarea.sidebar-system-prompt::placeholder { color: var(--fg-faint); }
     margin-top: 3px;
 }
 
+.sidebar-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.sidebar-field-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--fg);
+}
+
+.sidebar-field-desc {
+    font-size: 10px;
+    color: var(--fg-muted);
+    line-height: 1.3;
+}
+
+.chat-sidebar input[type="number"] {
+    width: 100%;
+    height: 30px;
+    background: var(--bg-base);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    color: var(--fg);
+    padding: 0 var(--space-3);
+    font-family: var(--mono);
+    font-size: 12px;
+    outline: none;
+    transition: border-color var(--ease-fast), box-shadow var(--ease-fast);
+}
+
+.chat-sidebar input[type="number"]:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-subtle);
+}
+
 .sidebar-sampler-control { margin-bottom: var(--space-3); }
 .sidebar-sampler-control:last-child { margin-bottom: 0; }
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -595,6 +595,14 @@
                             <div class="sidebar-char-count" id="chat-sys-char-count">0 chars</div>
                         </div>
                         <div class="sidebar-section">
+                            <div class="sidebar-section-label"><span class="sidebar-icon"><svg viewBox="0 0 24 24" width="13" height="13"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg></span> Web Search</div>
+                            <div class="sidebar-field">
+                                <label class="sidebar-field-label" for="chat-web-search-max-results">Result Count</label>
+                                <input type="number" id="chat-web-search-max-results" min="1" max="10" step="1" value="5">
+                                <div class="sidebar-field-desc">More results add context but take longer to read.</div>
+                            </div>
+                        </div>
+                        <div class="sidebar-section">
                             <div class="sidebar-section-label"><span class="sidebar-icon"><svg viewBox="0 0 24 24" width="13" height="13"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg></span> Samplers</div>
                             <div class="sidebar-sampler-control">
                                 <div class="sidebar-sampler-label">

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -25,6 +25,10 @@ let chatStatsBaseline = { promptTokens: 0, genTokens: 0 };
 let chatStatsRaw = { promptTokens: 0, genTokens: 0 };
 const CHAT_CONVERSATIONS_STORAGE_KEY = "llama_gui_conversations";
 const CHAT_WEB_SEARCH_STORAGE_KEY = "llama_gui_chat_web_search_enabled";
+const CHAT_WEB_SEARCH_MAX_RESULTS_STORAGE_KEY = "llama_gui_chat_web_search_max_results";
+const CHAT_WEB_SEARCH_DEFAULT_MAX_RESULTS = 5;
+const CHAT_WEB_SEARCH_MIN_RESULTS = 1;
+const CHAT_WEB_SEARCH_MAX_RESULTS = 10;
 const CHAT_SAMPLER_SLIDER_MAP = {
     "chat-slider-temp": { flag: "temperature", decimals: 2 },
     "chat-slider-top-p": { flag: "top_p", decimals: 2 },
@@ -2511,6 +2515,17 @@ function isChatWebSearchEnabled() {
     return Boolean(toggle && toggle.checked);
 }
 
+function clampChatWebSearchMaxResults(value) {
+    const parsed = parseInt(value, 10);
+    if (!Number.isFinite(parsed)) return CHAT_WEB_SEARCH_DEFAULT_MAX_RESULTS;
+    return Math.max(CHAT_WEB_SEARCH_MIN_RESULTS, Math.min(parsed, CHAT_WEB_SEARCH_MAX_RESULTS));
+}
+
+function getChatWebSearchMaxResults() {
+    const input = document.getElementById("chat-web-search-max-results");
+    return clampChatWebSearchMaxResults(input ? input.value : localStorage.getItem(CHAT_WEB_SEARCH_MAX_RESULTS_STORAGE_KEY));
+}
+
 function getChatRequestMessages(messages) {
     return messages.map((msg) => ({
         role: msg.role,
@@ -2714,6 +2729,7 @@ async function sendChatMessage(userText) {
     const webSearchEnabled = isChatWebSearchEnabled();
     if (webSearchEnabled) {
         body.web_search = true;
+        body.web_search_max_results = getChatWebSearchMaxResults();
     }
 
     chatAbortController = new AbortController();
@@ -3093,6 +3109,7 @@ function initChatTab() {
     const btnCollapse = document.getElementById("btn-collapse-sidebar");
     const btnOpen = document.getElementById("btn-open-sidebar");
     const webSearchToggle = document.getElementById("chat-web-search-toggle");
+    const webSearchMaxResults = document.getElementById("chat-web-search-max-results");
 
     updateChatStatusBadge();
 
@@ -3100,6 +3117,21 @@ function initChatTab() {
         webSearchToggle.checked = localStorage.getItem(CHAT_WEB_SEARCH_STORAGE_KEY) === "true";
         webSearchToggle.addEventListener("change", () => {
             localStorage.setItem(CHAT_WEB_SEARCH_STORAGE_KEY, String(webSearchToggle.checked));
+        });
+    }
+
+    if (webSearchMaxResults) {
+        webSearchMaxResults.value = String(clampChatWebSearchMaxResults(
+            localStorage.getItem(CHAT_WEB_SEARCH_MAX_RESULTS_STORAGE_KEY)
+        ));
+        webSearchMaxResults.addEventListener("change", () => {
+            const value = clampChatWebSearchMaxResults(webSearchMaxResults.value);
+            webSearchMaxResults.value = String(value);
+            localStorage.setItem(CHAT_WEB_SEARCH_MAX_RESULTS_STORAGE_KEY, String(value));
+        });
+        webSearchMaxResults.addEventListener("input", () => {
+            const value = clampChatWebSearchMaxResults(webSearchMaxResults.value);
+            localStorage.setItem(CHAT_WEB_SEARCH_MAX_RESULTS_STORAGE_KEY, String(value));
         });
     }
 


### PR DESCRIPTION
Expose a "Result Count" control for chat web search and wire it end-to-end. Frontend: add UI input, styles, localStorage persistence (key: llama_gui_chat_web_search_max_results), clamp to 1–10 with default 5, and include value in outgoing chat requests. Backend: read and validate web_search_max_results, clamp to 1–10, pass max_results to web_search and limit fetched pages, and strip the field before proxying to the local LLM API. Tests: add/adjust unit and Playwright smoke tests to verify value propagation, clamping, and that the field is not forwarded downstream. Docs: note Playwright as a dev-only dependency and document the new Result Count behavior.