### PR TITLE
Add Custom Launch Args textarea and parser

### DIFF
--- a/docs/improvements.md
+++ b/docs/improvements.md
@@ -27,7 +27,7 @@ The client code snippets always show `YOUR_API_KEY` as a placeholder even when n
 
 ## High Impact / Medium Effort
 
-### 6. Custom Launch Args textarea
+### 6. Custom Launch Args textarea [DONE]
 Already planned in `docs/todo.md`. A raw textarea that appends arbitrary flags to the generated command would cover all the flags not yet exposed in the UI — especially useful for newly added upstream features.
 
 ### 7. Improved Markdown rendering in Chat [DONE]
@@ -68,7 +68,7 @@ Dropping a `.gguf` file onto the page is a natural shortcut, especially for user
 ### 16. "Last used settings" persistence
 There is no record of what launch arguments were used in previous sessions (only presets, which require deliberate saving). Automatically restoring the last-used configuration on startup would reduce friction.
 
-### 17. Web search configuration
+### 17. Web search configuration [DONE]
 The max results (5) and page fetch limit (3) are hardcoded constants. A setting for result count would allow tuning for speed vs. context depth.
 
 ---

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -97,20 +97,20 @@ This backlog is ordered by implementation value. Prefer finishing the early safe
   - Do this opportunistically, not as a standalone churn task.
   - Group by route family or service boundary so failures are easier to navigate.
 
-## Phase 4 - Custom Launch Args
+## Phase 4 - Custom Launch Args [DONE]
 
 Goal: add an advanced Configure-tab textarea for raw `llama.cpp` flags that are not yet represented in `ui/js/flags.js`. This lets Llama GUI temporarily support new or renamed upstream flags without waiting for a full typed UI update.
 
 ### Behavior
 
-- [ ] Add a `Custom Launch Args` textarea near the Configure command preview.
-- [ ] Treat the value as shared launch state in `flagCore`, not as a per-tab scratch field.
-- [ ] Store the raw value in preset `flags` under reserved key `custom_args`.
-- [ ] Preserve `custom_args` through preset save, update, load, import, and export without a schema version bump.
-- [ ] Update command preview immediately as the textarea changes.
-- [ ] Parse shell-like tokens, including quoted values such as `--chat-template-kwargs '{"preserve_thinking":true}'`.
-- [ ] Show an advanced-use warning that custom args may conflict with UI controls and may enable risky `llama.cpp` features.
-- [ ] If parsing fails, show the parser error near the textarea and block launch with a clear command-preview status.
+- [x] Add a `Custom Launch Args` textarea near the Configure command preview.
+- [x] Treat the value as shared launch state in `flagCore`, not as a per-tab scratch field.
+- [x] Store the raw value in preset `flags` under reserved key `custom_args`.
+- [x] Preserve `custom_args` through preset save, update, load, import, and export without a schema version bump.
+- [x] Update command preview immediately as the textarea changes.
+- [x] Parse shell-like tokens, including quoted values such as `--chat-template-kwargs '{"preserve_thinking":true}'`.
+- [x] Show an advanced-use warning that custom args may conflict with UI controls and may enable risky `llama.cpp` features.
+- [x] If parsing fails, show the parser error near the textarea and block launch with a clear command-preview status.
 
 ### Implementation
 

--- a/tests/frontend/custom_launch_args_unit.cjs
+++ b/tests/frontend/custom_launch_args_unit.cjs
@@ -1,0 +1,34 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const source = fs.readFileSync(path.join(ROOT, "ui", "js", "flag-core.js"), "utf8");
+const context = {
+    window: {},
+};
+
+vm.createContext(context);
+vm.runInContext(source, context, { filename: "flag-core.js" });
+
+const parse = context.window.LlamaGui.flagCore.parseCustomLaunchArgs;
+
+function assertTokens(raw, expected) {
+    const result = parse(raw);
+    assert.equal(result.error, undefined);
+    assert.deepEqual(Array.from(result.tokens), expected);
+}
+
+assertTokens("--threads 8 --flash-attn --parallel 4", ["--threads", "8", "--flash-attn", "--parallel", "4"]);
+assertTokens("--threads 8\n--flash-attn\n--parallel 4", ["--threads", "8", "--flash-attn", "--parallel", "4"]);
+assertTokens("--chat-template-kwargs '{\"preserve_thinking\":true}'", ["--chat-template-kwargs", "{\"preserve_thinking\":true}"]);
+assertTokens('--log-prefix "my local test"', ["--log-prefix", "my local test"]);
+assertTokens('--label "say \\"hello\\""', ["--label", 'say "hello"']);
+assertTokens('--empty ""', ["--empty", ""]);
+
+assert.match(parse("--flag 'unterminated").error, /unmatched single quote/);
+assert.match(parse('--flag "unterminated').error, /unmatched double quote/);
+assert.match(parse("--flag \\").error, /unfinished escape/);
+
+console.log("custom launch args parser tests passed");

--- a/tests/frontend/custom_launch_args_unit.cjs
+++ b/tests/frontend/custom_launch_args_unit.cjs
@@ -26,9 +26,13 @@ assertTokens("--chat-template-kwargs '{\"preserve_thinking\":true}'", ["--chat-t
 assertTokens('--log-prefix "my local test"', ["--log-prefix", "my local test"]);
 assertTokens('--label "say \\"hello\\""', ["--label", 'say "hello"']);
 assertTokens('--empty ""', ["--empty", ""]);
+assertTokens(String.raw`--log-file C:\temp\llama.log`, ["--log-file", String.raw`C:\temp\llama.log`]);
+assertTokens(String.raw`--log-prefix my\ local\ test`, ["--log-prefix", "my local test"]);
+assertTokens(String.raw`--label say\"hello\"`, ["--label", 'say"hello"']);
+assertTokens("--path C:\\temp\\", ["--path", "C:\\temp\\"]);
 
 assert.match(parse("--flag 'unterminated").error, /unmatched single quote/);
 assert.match(parse('--flag "unterminated').error, /unmatched double quote/);
-assert.match(parse("--flag \\").error, /unfinished escape/);
+assert.match(parse('--flag "unterminated\\').error, /unfinished escape/);
 
 console.log("custom launch args parser tests passed");

--- a/tests/frontend/flag_sync_smoke.cjs
+++ b/tests/frontend/flag_sync_smoke.cjs
@@ -81,6 +81,7 @@ async function main() {
     try {
         const page = await browser.newPage();
         const chatCompletionBodies = [];
+        const launchBodies = [];
 
         await page.route("**/api/**", async (route) => {
             const url = new URL(route.request().url());
@@ -96,6 +97,15 @@ async function main() {
                         "data: [DONE]",
                         "",
                     ].join("\n"),
+                });
+                return;
+            }
+            if (pathName === "/api/launch") {
+                launchBodies.push(JSON.parse(route.request().postData() || "{}"));
+                await route.fulfill({
+                    status: 200,
+                    contentType: "application/json",
+                    body: JSON.stringify({ pid: 123, command: "smoke launch" }),
                 });
                 return;
             }
@@ -266,6 +276,38 @@ async function main() {
         const launchArgs = await page.evaluate(() => window.LlamaGui.flagCore.getLaunchArgs().args.flat());
         assert.ok(launchArgs.includes("-c") && launchArgs.includes("12345"));
         assert.ok(launchArgs.includes("-ngl") && launchArgs.includes("9"));
+
+        await page.fill("#custom-launch-args", "--threads 8\n--chat-template-kwargs '{\"preserve_thinking\":true}'");
+        await page.dispatchEvent("#custom-launch-args", "input");
+        await page.waitForFunction(() => document.querySelector("#command-preview-text")?.textContent.includes("--threads 8"));
+        const customState = await page.evaluate(() => ({
+            raw: window.LlamaGui.flagCore.collectFlagValues().custom_args,
+            args: window.LlamaGui.flagCore.getLaunchArgs().args.flat(),
+        }));
+        assert.equal(customState.raw, "--threads 8\n--chat-template-kwargs '{\"preserve_thinking\":true}'");
+        assert.ok(customState.args.includes("--threads") && customState.args.includes("8"));
+        assert.ok(customState.args.includes("--chat-template-kwargs"));
+        assert.ok(customState.args.includes('{"preserve_thinking":true}'));
+
+        await page.evaluate(() => window.LlamaGui.flagCore.applyFlagValues({ custom_args: "--parallel 4" }));
+        await page.waitForFunction(() => document.querySelector("#custom-launch-args")?.value === "--parallel 4");
+        assert.match(await page.textContent("#command-preview-text"), /--parallel 4/);
+
+        await page.fill("#custom-launch-args", "--threads 'unterminated");
+        await page.dispatchEvent("#custom-launch-args", "input");
+        await page.waitForFunction(() => document.querySelector("#custom-launch-args-status")?.textContent.includes("unmatched single quote"));
+        assert.match(await page.textContent("#command-preview-text"), /Cannot launch:/);
+        await page.selectOption("#model-select", "smoke-model.gguf");
+        await page.dispatchEvent("#model-select", "change");
+        const launchCountBefore = launchBodies.length;
+        let launchDialogMessage = "";
+        page.once("dialog", async (dialog) => {
+            launchDialogMessage = dialog.message();
+            await dialog.accept();
+        });
+        await page.click("#btn-launch");
+        assert.match(launchDialogMessage, /unmatched single quote/);
+        assert.equal(launchBodies.length, launchCountBefore);
 
         console.log(`flag sync smoke passed on http://127.0.0.1:${port}/`);
     } finally {

--- a/ui/css/style.css
+++ b/ui/css/style.css
@@ -914,6 +914,51 @@ textarea { width: 100%; min-height: 60px; resize: vertical; }
     font-size: 13px;
 }
 
+.custom-launch-args-panel {
+    margin-top: var(--space-4);
+    padding: var(--space-4);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg-card);
+}
+
+.custom-args-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-3);
+    margin-bottom: var(--space-3);
+}
+
+#custom-launch-args {
+    width: 100%;
+    min-height: 96px;
+    resize: vertical;
+    font-family: var(--mono);
+    font-size: 12px;
+}
+
+.custom-args-warning,
+.custom-args-status {
+    margin: var(--space-2) 0 0;
+    font-size: 12px;
+    line-height: 1.45;
+}
+
+.custom-args-warning {
+    color: var(--yellow);
+}
+
+.custom-args-status.warning {
+    color: var(--yellow);
+}
+
+.custom-args-status.error,
+#command-preview-text.command-preview-error,
+#quick-command-preview.command-preview-error {
+    color: var(--red);
+}
+
 /* Launch bar */
 .launch-bar {
     display: flex;

--- a/ui/index.html
+++ b/ui/index.html
@@ -462,6 +462,23 @@
 
             <div id="flags-container"></div>
 
+            <div class="custom-launch-args-panel">
+                <div class="custom-args-header">
+                    <div>
+                        <label class="form-label" for="custom-launch-args">Custom Launch Args</label>
+                        <p class="help-text">
+                            Enter extra llama.cpp arguments like a shell command. Multiple args can be on one line or separate lines; quote values that contain spaces or JSON, such as <code>--chat-template-kwargs '{"preserve_thinking":true}'</code>.
+                        </p>
+                    </div>
+                    <span class="badge badge-neutral">Advanced</span>
+                </div>
+                <textarea id="custom-launch-args" rows="4" spellcheck="false" placeholder="--threads 8&#10;--flash-attn&#10;--chat-template-kwargs '{&quot;preserve_thinking&quot;:true}'"></textarea>
+                <p class="custom-args-warning">
+                    Custom args are appended after UI-managed flags and may conflict with visible controls or enable risky llama.cpp features.
+                </p>
+                <div id="custom-launch-args-status" class="custom-args-status" aria-live="polite"></div>
+            </div>
+
             <div id="server-address" class="server-address hidden">
                 <span class="server-label">Server Address:</span>
                 <a id="server-url" href="#" target="_blank" class="server-link"></a>

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -651,8 +651,47 @@ function syncUiAfterToolChange(nextTool) {
 
 function syncUiAfterSharedStateChange() {
     configFlagsUi.restoreFlagInputs();
+    restoreCustomLaunchArgsInput();
     flagCore.updateCommandPreview();
     refreshChatSidebarUI();
+}
+
+function setCustomLaunchArgsMessages(result = {}) {
+    const status = document.getElementById("custom-launch-args-status");
+    if (!status) return;
+
+    status.textContent = "";
+    status.className = "custom-args-status";
+
+    if (result.error) {
+        status.textContent = result.error;
+        status.classList.add("error");
+        return;
+    }
+
+    if (Array.isArray(result.warnings) && result.warnings.length > 0) {
+        status.textContent = result.warnings.join(" ");
+        status.classList.add("warning");
+    }
+}
+
+function restoreCustomLaunchArgsInput() {
+    const textarea = document.getElementById("custom-launch-args");
+    if (!textarea) return;
+    const value = flagCore.getFlagValues().custom_args;
+    const nextValue = value !== undefined && value !== null ? String(value) : "";
+    if (textarea.value !== nextValue) {
+        textarea.value = nextValue;
+    }
+}
+
+function initCustomLaunchArgsControls() {
+    const textarea = document.getElementById("custom-launch-args");
+    if (!textarea) return;
+    textarea.addEventListener("input", () => {
+        flagCore.setFlagValue("custom_args", textarea.value.trim() ? textarea.value : undefined);
+    });
+    restoreCustomLaunchArgsInput();
 }
 
 configFlagsUi.configure({
@@ -679,8 +718,11 @@ flagCore.configure({
         typeof isSupportedChatTemplateValue === "function" ? isSupportedChatTemplateValue(value) : true
     ),
     getToolBinaryName,
-    renderCommandPreview(command) {
-        document.getElementById("command-preview-text").textContent = command;
+    renderCommandPreview(command, result) {
+        const preview = document.getElementById("command-preview-text");
+        preview.textContent = result && result.error ? `Cannot launch: ${result.error}` : command;
+        preview.classList.toggle("command-preview-error", Boolean(result && result.error));
+        setCustomLaunchArgsMessages(result || {});
         updateServerAddressPreview();
         updateApiEndpoints();
         refreshQuickLaunchUI();
@@ -1353,6 +1395,7 @@ function refreshQuickLaunchUI() {
     if (quickMetricsToggle) quickMetricsToggle.checked = values.metrics === true;
 
     quickCommand.textContent = document.getElementById("command-preview-text").textContent || "";
+    quickCommand.classList.toggle("command-preview-error", document.getElementById("command-preview-text").classList.contains("command-preview-error"));
     updateQuickServerAddressPreview();
     updateQuickLaunchActionButtons();
 }
@@ -1547,6 +1590,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     initTabs();
     initToolSelect();
     initConfigControls();
+    initCustomLaunchArgsControls();
     initInstallButtons();
     initApiTab();
     initPresetImport();
@@ -2019,7 +2063,10 @@ async function launchLlama() {
     const args = result.args;
     const tool = flagCore.getCurrentTool();
     const values = flagCore.getFlagValues();
-    const hasModel = args.some(a => a[0] === "-m" || a[0] === "-hf");
+    const hasModel = args.some(a => {
+        const entryValues = Array.isArray(a) ? a : [a];
+        return entryValues.includes("-m") || entryValues.includes("-hf");
+    });
     if (!hasModel) {
         alert("Select a model or provide an HF repo before launching.");
         return;

--- a/ui/js/flag-core.js
+++ b/ui/js/flag-core.js
@@ -159,8 +159,94 @@
         return String(value) === String(expected);
     }
 
+    function parseCustomLaunchArgs(raw) {
+        const input = String(raw || "");
+        const tokens = [];
+        let token = "";
+        let tokenStarted = false;
+        let quote = null;
+        let escaping = false;
+
+        for (let i = 0; i < input.length; i += 1) {
+            const ch = input[i];
+
+            if (escaping) {
+                token += ch;
+                tokenStarted = true;
+                escaping = false;
+                continue;
+            }
+
+            if (quote === "\"") {
+                if (ch === "\\") {
+                    escaping = true;
+                    continue;
+                }
+                if (ch === "\"") {
+                    quote = null;
+                    continue;
+                }
+                token += ch;
+                tokenStarted = true;
+                continue;
+            }
+
+            if (quote === "'") {
+                if (ch === "'") {
+                    quote = null;
+                    continue;
+                }
+                token += ch;
+                tokenStarted = true;
+                continue;
+            }
+
+            if (/\s/.test(ch)) {
+                if (tokenStarted) {
+                    tokens.push(token);
+                    token = "";
+                    tokenStarted = false;
+                }
+                continue;
+            }
+
+            if (ch === "'" || ch === "\"") {
+                quote = ch;
+                tokenStarted = true;
+                continue;
+            }
+
+            if (ch === "\\") {
+                escaping = true;
+                continue;
+            }
+
+            token += ch;
+            tokenStarted = true;
+        }
+
+        if (escaping) {
+            return { error: "Custom launch args end with an unfinished escape." };
+        }
+        if (quote) {
+            return { error: `Custom launch args contain an unmatched ${quote === "'" ? "single" : "double"} quote.` };
+        }
+        if (tokenStarted) tokens.push(token);
+        return { tokens };
+    }
+
+    function getKnownCliFlags() {
+        const names = new Set();
+        for (const f of getFlags()) {
+            if (f.flag) names.add(String(f.flag));
+            if (f.false_flag) names.add(String(f.false_flag));
+        }
+        return names;
+    }
+
     function getLaunchArgs() {
         const args = [];
+        const warnings = [];
         const toolBase = currentTool.replace("llama-", "");
 
         for (const f of getFlags()) {
@@ -204,15 +290,30 @@
             }
         }
 
+        const customRaw = flagValues.custom_args;
+        if (customRaw !== undefined && customRaw !== null && String(customRaw).trim()) {
+            const parsedCustom = parseCustomLaunchArgs(customRaw);
+            if (parsedCustom.error) {
+                return { args, error: parsedCustom.error, warnings };
+            }
+
+            const knownCliFlags = getKnownCliFlags();
+            const duplicates = Array.from(new Set(parsedCustom.tokens.filter(token => knownCliFlags.has(token))));
+            if (duplicates.length > 0) {
+                warnings.push(`Custom launch args duplicate UI-managed flags: ${duplicates.join(", ")}`);
+            }
+            args.push(...parsedCustom.tokens);
+        }
+
         const modelName = selectedModel;
         if (modelName) {
             if (modelName.includes("..") || modelName.includes("/") || modelName.includes("\\")) {
-                return { args, error: "Invalid model filename." };
+                return { args, error: "Invalid model filename.", warnings };
             }
             args.push(["-m", "models/" + modelName]);
         }
 
-        return { args, error: null };
+        return { args, error: null, warnings };
     }
 
     function updateCommandPreview() {
@@ -255,6 +356,7 @@
         shouldOmitFlagValue,
         isValidGpuLayersValue,
         normalizeGpuLayersValue,
+        parseCustomLaunchArgs,
         getLaunchArgs,
         updateCommandPreview,
         registerApi,

--- a/ui/js/flag-core.js
+++ b/ui/js/flag-core.js
@@ -217,7 +217,13 @@
             }
 
             if (ch === "\\") {
-                escaping = true;
+                const nextCh = input[i + 1];
+                if (nextCh !== undefined && (/[\s'"\\]/.test(nextCh))) {
+                    escaping = true;
+                    continue;
+                }
+                token += ch;
+                tokenStarted = true;
                 continue;
             }
 

--- a/ui/js/presets.js
+++ b/ui/js/presets.js
@@ -62,6 +62,10 @@ function getPresetWarnings(presetData) {
         warnings.push(`Uses outdated or unsupported chat template "${chatTemplate}". It will be ignored and Auto from model is safer.`);
     }
 
+    if (typeof flags.custom_args === "string" && flags.custom_args.trim()) {
+        warnings.push("Includes custom launch args. Review them before launching because they may override UI controls.");
+    }
+
     return warnings;
 }
 


### PR DESCRIPTION
Introduce a Custom Launch Args textarea for entering raw llama.cpp flags and wire it into flag handling and previews. Adds a shell-like parser (with quotes/escapes and error reporting) in ui/js/flag-core.js, integrates parsed tokens into getLaunchArgs (blocks launch on parse errors and emits warnings for duplicate UI-managed flags), and exposes parser/util helpers. UI changes: textarea and status/warning UI in index.html plus styles in ui/css/style.css, live validation/messages and command-preview error state in app.js, and preset handling/warnings in presets.js. Tests: new unit test for the parser and extended frontend smoke test to cover entering, applying, and erroring custom args. Also fixes model-detection logic when launching (handle nested arg arrays).