### PR TITLE
Add export-all presets and improved import

### DIFF
--- a/docs/directory.md
+++ b/docs/directory.md
@@ -122,6 +122,7 @@ Flags in Configure tab > Conversation category:
 Configure tab search bar:
 - Matches flag name, label, description, options
 - Auto-expands categories, partial match highlighting, clear button + Escape to reset
+- The Configure tab includes an advanced Custom Launch Args textarea near the command preview.
 
 ## AGENTS.md Rule
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -766,6 +766,7 @@
                         </div>
                     </div>
                     <input type="file" id="preset-import" accept=".json" style="display:none" />
+                    <button class="btn presets-import-btn" id="btn-export-all-presets">Export All</button>
                     <button class="btn presets-import-btn" id="btn-import-preset">Import JSON</button>
                 </div>
                 <div class="presets-list-header">

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -1623,6 +1623,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (btnSavePreset) btnSavePreset.addEventListener("click", savePreset);
     const btnImportPreset = document.getElementById("btn-import-preset");
     if (btnImportPreset) btnImportPreset.addEventListener("click", () => document.getElementById("preset-import").click());
+    const btnExportAllPresets = document.getElementById("btn-export-all-presets");
+    if (btnExportAllPresets) btnExportAllPresets.addEventListener("click", exportAllPresets);
 
     showToast("Llama GUI ready", "info");
 

--- a/ui/js/presets.js
+++ b/ui/js/presets.js
@@ -482,29 +482,70 @@ function exportPreset(name) {
         });
 }
 
-function handlePresetImport(file) {
-    const reader = new FileReader();
-    reader.onload = async (e) => {
-        try {
-            const data = JSON.parse(e.target.result);
-            const normalized = normalizePresetData(data);
-            const importData = { tool: normalized.tool, model: normalized.model, flags: normalized.flags };
-            if (!normalized.model && Object.keys(normalized.flags).length === 0) {
-                showPresetStatus("Preset file contains no usable data.", "error", 3200);
+function exportAllPresets() {
+    fetchJson("/api/presets")
+        .then((presets) => {
+            if (!presets || presets.length === 0) {
+                showPresetStatus("No presets to export", "error", 3200);
                 return;
             }
-            const name = file.name.replace(/\.json$/i, "");
-            await fetchJson("/api/presets", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ name, data: importData }),
-            });
+            const exportData = { presets: presets.map(p => ({
+                name: p.name,
+                data: normalizePresetData(p.data)
+            })) };
+            const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: "application/json" });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = "llama-gui-presets.json";
+            a.click();
+            URL.revokeObjectURL(url);
+            showPresetStatus(`Exported ${presets.length} preset(s)`, "success");
+        })
+        .catch((e) => {
+            alert("Failed to export presets: " + e.message);
+        });
+}
+
+async function handlePresetImport(file) {
+    try {
+        const text = await file.text();
+        const parsed = JSON.parse(text);
+
+        if (parsed && typeof parsed === "object" && Array.isArray(parsed.presets) && parsed.presets.length > 0) {
+            let imported = 0;
+            let unnamedIdx = 0;
+            for (const entry of parsed.presets) {
+                const name = entry.name || "Imported-" + (++unnamedIdx);
+                const normalized = normalizePresetData(entry.data || {});
+                if (!normalized.model && Object.keys(normalized.flags).length === 0) continue;
+                await fetchJson("/api/presets", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ name, data: { tool: normalized.tool, model: normalized.model, flags: normalized.flags } }),
+                });
+                imported++;
+            }
             loadPresets();
-            showPresetStatus(`Imported preset \"${name}\"`, "success");
-        } catch (err) {
-            showPresetStatus("Failed to import preset", "error", 3200);
-            alert("Failed to import preset: " + err.message);
+            showPresetStatus(`Imported ${imported} preset(s)`, "success");
+            return;
         }
-    };
-    reader.readAsText(file);
+
+        const normalized = normalizePresetData(parsed);
+        if (!normalized.model && Object.keys(normalized.flags).length === 0) {
+            showPresetStatus("Preset file contains no usable data.", "error", 3200);
+            return;
+        }
+        const name = file.name.replace(/\.json$/i, "");
+        await fetchJson("/api/presets", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ name, data: { tool: normalized.tool, model: normalized.model, flags: normalized.flags } }),
+        });
+        loadPresets();
+        showPresetStatus(`Imported preset \"${name}\"`, "success");
+    } catch (err) {
+        showPresetStatus("Failed to import preset", "error", 3200);
+        alert("Failed to import preset: " + err.message);
+    }
 }

--- a/ui/js/presets.js
+++ b/ui/js/presets.js
@@ -511,11 +511,16 @@ async function handlePresetImport(file) {
     try {
         const text = await file.text();
         const parsed = JSON.parse(text);
+        const bulkPresets = Array.isArray(parsed)
+            ? parsed
+            : parsed && typeof parsed === "object" && Array.isArray(parsed.presets)
+                ? parsed.presets
+                : null;
 
-        if (parsed && typeof parsed === "object" && Array.isArray(parsed.presets) && parsed.presets.length > 0) {
+        if (bulkPresets && bulkPresets.length > 0) {
             let imported = 0;
             let unnamedIdx = 0;
-            for (const entry of parsed.presets) {
+            for (const entry of bulkPresets) {
                 const name = entry.name || "Imported-" + (++unnamedIdx);
                 const normalized = normalizePresetData(entry.data || {});
                 if (!normalized.model && Object.keys(normalized.flags).length === 0) continue;


### PR DESCRIPTION
Add an "Export All" button to the presets UI and wire it to a new exportAllPresets() handler that fetches /api/presets and downloads a JSON file of all presets. Revamp preset import logic to support a JSON file containing an array of presets (bulk import) while preserving fallback for single-preset files; imported presets are normalized and posted to /api/presets. Also hook up the new button in app.js and update docs to note the Configure tab's Custom Launch Args textarea. Includes status/toast feedback and error handling for export/import operations.