### PR TITLE
Skip preset bundle files when listing presets

### DIFF
--- a/backend/routes/presets.py
+++ b/backend/routes/presets.py
@@ -10,6 +10,10 @@ def sanitize_preset_name(name):
     return safe_name.replace("..", "_").strip(". ")
 
 
+def is_preset_bundle(data):
+    return isinstance(data, dict) and isinstance(data.get("presets"), list)
+
+
 def list_presets(request, response, ctx):
     presets = []
     presets_dir = ctx.paths.presets
@@ -17,7 +21,10 @@ def list_presets(request, response, ctx):
         for path in sorted(presets_dir.glob("*.json")):
             try:
                 with open(path, "r") as preset_file:
-                    presets.append({"name": path.stem, "data": json.load(preset_file)})
+                    data = json.load(preset_file)
+                if is_preset_bundle(data):
+                    continue
+                presets.append({"name": path.stem, "data": data})
             except (json.JSONDecodeError, OSError):
                 pass
     response.json(presets)

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -160,6 +160,29 @@ class ExtractedRouteTests(unittest.TestCase):
             self.assertEqual(delete_response.payload, {"deleted": True})
             self.assertFalse((ctx.paths.presets / "__Odd Name.json").exists())
 
+    def test_presets_route_skips_bulk_export_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            ctx.paths.presets.mkdir(parents=True)
+            (ctx.paths.presets / "single.json").write_text(
+                json.dumps({"model": "model.gguf", "flags": {"ctx_size": 4096}})
+            )
+            (ctx.paths.presets / "llama-gui-presets.json").write_text(
+                json.dumps({
+                    "presets": [
+                        {"name": "single", "data": {"model": "model.gguf", "flags": {}}}
+                    ]
+                })
+            )
+
+            response = DummyResponse()
+            presets.list_presets(Request("GET", "/api/presets", "", {}), response, ctx)
+
+            self.assertEqual(
+                response.payload,
+                [{"name": "single", "data": {"model": "model.gguf", "flags": {"ctx_size": 4096}}}],
+            )
+
     def test_metrics_route_uses_context_service(self):
         with tempfile.TemporaryDirectory() as tmp:
             ctx = make_context(tmp)


### PR DESCRIPTION
Add is_preset_bundle helper and update list_presets to ignore JSON files that contain a top-level "presets" list (bulk export/bundle files). Add test_presets_route_skips_bulk_export_files to ensure bulk export files like llama-gui-presets.json are skipped and only individual preset files are returned. Existing JSON/OSError handling is preserved.