### PR TITLE
Honor LLAMA_GUI_HOST/PORT in start scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ If a shared control becomes unreliable, prefer removing the duplicate UI over ke
 - Frontend-only internal refactors, such as changes inside `ui/js/flag-core.js` or `ui/js/config-flags-ui.js`, are usually compatible as long as `ui/index.html` script loading and the `python server.py` entrypoint still work.
 
 ### Architecture
-- A static web UI served by a Python `http.server` backend on port 5240.
+- A static web UI served by a Python `http.server` backend on `127.0.0.1:5240` by default; `LLAMA_GUI_HOST` and `LLAMA_GUI_PORT` can override the bind address for headless/LAN access.
 - The backend handles `llama.cpp` installation, process management, API proxying, model downloading, remote tunnels, and web search.
 - `llama-server` runs separately (default port 8080) as a subprocess.
 - `config.json` persists application state (installed version, active backend, tag).
@@ -56,7 +56,7 @@ If a shared control becomes unreliable, prefer removing the duplicate UI over ke
 - Cloudflare tunnel management (auto-downloads `cloudflared`, starts/stops tunnel, returns public URL).
 - Git-based app auto-updating (checks status, pulls, reinstalls dependencies, restarts server).
 - Native file picker (tkinter) for selecting model files and paths.
-- CORS origin validation restricts API access to `127.0.0.1:5240`, `localhost:5240`, and active tunnel URL.
+- CORS origin validation restricts API access to loopback origins for the configured GUI port, trusted `LLAMA_GUI_ALLOWED_HOSTS` entries when wildcard-bound, and the active tunnel URL.
 - Graceful shutdown/restart with port availability polling.
 
 ### Frontend
@@ -403,7 +403,7 @@ The API tab includes Cloudflare tunnel integration for exposing `llama-server` t
 
 - `cloudflared` binary is auto-downloaded on first use to `tools/cloudflared/`.
 - Platform-specific assets: Windows `.exe`, macOS `.tgz`, Linux binary.
-- Tunnel process runs `cloudflared tunnel --url http://127.0.0.1:5240`.
+- Tunnel process runs `cloudflared tunnel --url` against the configured GUI port, using loopback when the GUI is wildcard-bound.
 - Status polling detects the `trycloudflare.com` URL from stderr.
 - Thread-safe state management with start/stop lifecycle.
 - CORS origin is updated to include the active tunnel URL.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ LLAMA_GUI_HOST=0.0.0.0 LLAMA_GUI_PORT=5240 python server.py
 
 Then open `http://<server-ip>:5240` from another machine. `LLAMA_GUI_PORT` is optional and defaults to `5240`.
 
+The bundled start scripts also honor these variables. If `LLAMA_GUI_HOST` is a wildcard bind address such as `0.0.0.0`, `::`, or `*`, the script still starts the server with that bind address but opens the local browser at `127.0.0.1:<port>`.
+
 Access by IP address works by default. If you want to open the UI through a LAN hostname, mDNS name, or reverse-proxy hostname, explicitly trust that browser hostname too:
 
 ```bash

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
 import http.server
 import json
 import platform
+import re
 import socket
 import ssl
 import sys
@@ -494,6 +495,39 @@ def write_sse(wfile, data):
     SseWriter(wfile).write(data)
 
 
+def get_ui_asset_version():
+    latest_mtime = 0
+    for path in (
+        UI_DIR / "index.html",
+        UI_DIR / "css" / "tokens.css",
+        UI_DIR / "css" / "style.css",
+        UI_DIR / "js" / "flags.js",
+        UI_DIR / "js" / "flag-validation.js",
+        UI_DIR / "js" / "flag-core.js",
+        UI_DIR / "js" / "config-flags-ui.js",
+        UI_DIR / "js" / "manager.js",
+        UI_DIR / "js" / "presets.js",
+        UI_DIR / "js" / "app.js",
+        APP_LOGO_FILE,
+    ):
+        try:
+            latest_mtime = max(latest_mtime, int(path.stat().st_mtime))
+        except OSError:
+            pass
+    return str(latest_mtime)
+
+
+def version_ui_asset_urls(html):
+    version = get_ui_asset_version()
+
+    def replace_asset_url(match):
+        attr = match.group(1)
+        asset_path = match.group(2).split("?", 1)[0]
+        return f'{attr}="{asset_path}?v={version}"'
+
+    return re.sub(r'(href|src)="(/(?:css|js|assets)/[^"?#]+(?:\?[^"#]*)?)"', replace_asset_url, html)
+
+
 class Handler(http.server.SimpleHTTPRequestHandler):
     def __init__(self, *a, **kw):
         super().__init__(*a, directory=str(UI_DIR), **kw)
@@ -529,6 +563,16 @@ class Handler(http.server.SimpleHTTPRequestHandler):
 
     def send_sse_headers(self, status=200):
         Response(self).sse_headers(status)
+
+    def send_versioned_index(self):
+        index_path = UI_DIR / "index.html"
+        try:
+            html = index_path.read_text(encoding="utf-8")
+        except OSError:
+            self.send_error(404, "index.html not found")
+            return
+        body = version_ui_asset_urls(html).encode("utf-8")
+        Response(self).bytes(body, content_type="text/html; charset=utf-8")
 
     def read_body(self):
         length = int(self.headers.get("Content-Length", 0))
@@ -693,7 +737,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             return
 
         if path == "/" or path == "/index.html":
-            super().do_GET()
+            self.send_versioned_index()
             return
 
         if path.startswith("/api/") and not self.is_safe_request_origin():

--- a/mac_linux_silent_start.sh
+++ b/mac_linux_silent_start.sh
@@ -3,7 +3,22 @@ set -eu
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 cd "$SCRIPT_DIR"
-APP_URL="http://127.0.0.1:5240"
+APP_HOST="${LLAMA_GUI_HOST:-127.0.0.1}"
+APP_PORT="${LLAMA_GUI_PORT:-5240}"
+APP_BROWSER_HOST="$APP_HOST"
+case "$APP_BROWSER_HOST" in
+    "0.0.0.0"|"::"|"*")
+        APP_BROWSER_HOST="127.0.0.1"
+        ;;
+    "["*"]")
+        APP_BROWSER_HOST=${APP_BROWSER_HOST#\[}
+        APP_BROWSER_HOST=${APP_BROWSER_HOST%\]}
+        ;;
+esac
+case "$APP_BROWSER_HOST" in
+    *:*) APP_URL="http://[$APP_BROWSER_HOST]:$APP_PORT" ;;
+    *) APP_URL="http://$APP_BROWSER_HOST:$APP_PORT" ;;
+esac
 
 PY_CMD=""
 if [ -x "$SCRIPT_DIR/.venv/bin/python" ]; then

--- a/mac_linux_start.sh
+++ b/mac_linux_start.sh
@@ -3,7 +3,22 @@ set -eu
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 cd "$SCRIPT_DIR"
-APP_URL="http://127.0.0.1:5240"
+APP_HOST="${LLAMA_GUI_HOST:-127.0.0.1}"
+APP_PORT="${LLAMA_GUI_PORT:-5240}"
+APP_BROWSER_HOST="$APP_HOST"
+case "$APP_BROWSER_HOST" in
+    "0.0.0.0"|"::"|"*")
+        APP_BROWSER_HOST="127.0.0.1"
+        ;;
+    "["*"]")
+        APP_BROWSER_HOST=${APP_BROWSER_HOST#\[}
+        APP_BROWSER_HOST=${APP_BROWSER_HOST%\]}
+        ;;
+esac
+case "$APP_BROWSER_HOST" in
+    *:*) APP_URL="http://[$APP_BROWSER_HOST]:$APP_PORT" ;;
+    *) APP_URL="http://$APP_BROWSER_HOST:$APP_PORT" ;;
+esac
 
 PY_CMD=""
 if [ -x "$SCRIPT_DIR/.venv/bin/python" ]; then

--- a/tests/backend/test_server_baseline.py
+++ b/tests/backend/test_server_baseline.py
@@ -176,6 +176,22 @@ class HandlerResponseTests(ServerStateIsolationMixin, unittest.TestCase):
             {"error": "upstream failed", "status": 502},
         )
 
+    def test_version_ui_asset_urls_rewrites_local_assets(self):
+        html = (
+            '<link rel="stylesheet" href="/css/style.css?v=revamp-1">'
+            '<script src="/js/app.js?v=revamp-1"></script>'
+            '<img src="/assets/app-logo.png" alt="logo">'
+            '<link rel="preconnect" href="https://fonts.googleapis.com">'
+        )
+
+        versioned = server.version_ui_asset_urls(html)
+
+        self.assertNotIn("revamp-1", versioned)
+        self.assertRegex(versioned, r'href="/css/style\.css\?v=\d+"')
+        self.assertRegex(versioned, r'src="/js/app\.js\?v=\d+"')
+        self.assertRegex(versioned, r'src="/assets/app-logo\.png\?v=\d+"')
+        self.assertIn('href="https://fonts.googleapis.com"', versioned)
+
     def test_api_router_knows_existing_endpoint(self):
         match = server.API_ROUTER.match("GET", "/api/status")
 

--- a/windows_start.bat
+++ b/windows_start.bat
@@ -1,7 +1,21 @@
 @echo off
-setlocal
+setlocal EnableExtensions EnableDelayedExpansion
 cd /d "%~dp0"
-set "APP_URL=http://127.0.0.1:5240"
+set "APP_HOST=%LLAMA_GUI_HOST%"
+if not defined APP_HOST set "APP_HOST=127.0.0.1"
+set "APP_PORT=%LLAMA_GUI_PORT%"
+if not defined APP_PORT set "APP_PORT=5240"
+
+set "APP_BROWSER_HOST=%APP_HOST%"
+if "%APP_BROWSER_HOST%"=="0.0.0.0" set "APP_BROWSER_HOST=127.0.0.1"
+if "%APP_BROWSER_HOST%"=="::" set "APP_BROWSER_HOST=127.0.0.1"
+if "%APP_BROWSER_HOST%"=="*" set "APP_BROWSER_HOST=127.0.0.1"
+if "%APP_BROWSER_HOST:~0,1%"=="[" if "%APP_BROWSER_HOST:~-1%"=="]" (
+    set "APP_BROWSER_HOST=%APP_BROWSER_HOST:~1,-1%"
+)
+set "APP_URL_HOST=%APP_BROWSER_HOST%"
+if not "!APP_URL_HOST::=!"=="!APP_URL_HOST!" set "APP_URL_HOST=[!APP_URL_HOST!]"
+set "APP_URL=http://!APP_URL_HOST!:%APP_PORT%"
 
 set "PY_CMD="
 if exist ".venv\Scripts\python.exe" (

--- a/windows_startsilent.bat
+++ b/windows_startsilent.bat
@@ -1,7 +1,21 @@
 @echo off
-setlocal
+setlocal EnableExtensions EnableDelayedExpansion
 cd /d "%~dp0"
-set "APP_URL=http://127.0.0.1:5240"
+set "APP_HOST=%LLAMA_GUI_HOST%"
+if not defined APP_HOST set "APP_HOST=127.0.0.1"
+set "APP_PORT=%LLAMA_GUI_PORT%"
+if not defined APP_PORT set "APP_PORT=5240"
+
+set "APP_BROWSER_HOST=%APP_HOST%"
+if "%APP_BROWSER_HOST%"=="0.0.0.0" set "APP_BROWSER_HOST=127.0.0.1"
+if "%APP_BROWSER_HOST%"=="::" set "APP_BROWSER_HOST=127.0.0.1"
+if "%APP_BROWSER_HOST%"=="*" set "APP_BROWSER_HOST=127.0.0.1"
+if "%APP_BROWSER_HOST:~0,1%"=="[" if "%APP_BROWSER_HOST:~-1%"=="]" (
+    set "APP_BROWSER_HOST=%APP_BROWSER_HOST:~1,-1%"
+)
+set "APP_URL_HOST=%APP_BROWSER_HOST%"
+if not "!APP_URL_HOST::=!"=="!APP_URL_HOST!" set "APP_URL_HOST=[!APP_URL_HOST!]"
+set "APP_URL=http://!APP_URL_HOST!:%APP_PORT%"
 
 set "PY_CMD="
 if exist ".venv\Scripts\python.exe" (


### PR DESCRIPTION
Make GUI host/port configurable and update docs. Start scripts (mac/linux and Windows, including silent variants) now read LLAMA_GUI_HOST and LLAMA_GUI_PORT, build the correct APP_URL, handle wildcard binds (0.0.0.0, ::, *) by opening the browser at 127.0.0.1, and properly format IPv6 bracketed addresses. Windows scripts enable delayed expansion to construct URLs. README and AGENTS.md were updated to document the default bind (127.0.0.1:5240), override env vars for headless/LAN access, and clarify CORS/tunnel behavior for wildcard or trusted hosts.