### PR TITLE
Enforce request body size and validate tools

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -78,6 +78,10 @@ def create_ssl_context():
 
 SSL_CONTEXT = create_ssl_context()
 
+# Sentinel returned by read_body() when a 413 response has already been sent.
+# Callers must treat this the same as None (abort without sending another response).
+_BODY_TOO_LARGE = object()
+
 
 def urlopen_with_ssl(request, timeout):
     return urllib.request.urlopen(request, timeout=timeout, context=SSL_CONTEXT)
@@ -575,9 +579,13 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         Response(self).bytes(body, content_type="text/html; charset=utf-8")
 
     def read_body(self):
+        MAX_BODY_SIZE = 10 * 1024 * 1024  # 10 MB
         length = int(self.headers.get("Content-Length", 0))
         if length == 0:
             return {}
+        if length > MAX_BODY_SIZE:
+            self.send_error_json(f"Request body too large (max {MAX_BODY_SIZE // (1024 * 1024)} MB)", 413)
+            return _BODY_TOO_LARGE
         try:
             return json.loads(self.rfile.read(length))
         except (json.JSONDecodeError, UnicodeDecodeError):
@@ -760,6 +768,9 @@ class Handler(http.server.SimpleHTTPRequestHandler):
 
         body = self.read_body()
 
+        if body is _BODY_TOO_LARGE:
+            return
+
         if body is None:
             self.send_error_json("Invalid or malformed JSON body", 400)
             return
@@ -773,6 +784,9 @@ class Handler(http.server.SimpleHTTPRequestHandler):
     def do_DELETE(self):
         parsed = urllib.parse.urlparse(self.path)
         body = self.read_body()
+
+        if body is _BODY_TOO_LARGE:
+            return
 
         if not self.is_safe_request_origin():
             self.send_error_json("Request origin not allowed", 403)

--- a/backend/routes/process.py
+++ b/backend/routes/process.py
@@ -11,6 +11,10 @@ def launch(request, response, ctx):
     body = request.body or {}
     tool = body.get("tool", "llama-cli")
     args = body.get("args", [])
+    allowed_tools = ctx.services.llama_tools or []
+    if tool not in allowed_tools:
+        response.error(f"Unknown tool: {tool!r}", 400)
+        return
     result = process_manager.launch_process(ctx, tool, args)
     if "error" in result:
         response.error(result.get("error", "Launch failed"), 400)

--- a/docs/may_codereview.md
+++ b/docs/may_codereview.md
@@ -8,19 +8,19 @@ The codebase is well-structured with a clean backend separation (routes/services
 
 ## 1. Security Issues
 
-### HIGH: No Content-Length upper bound — memory exhaustion DoS
-`backend/app.py:577-584` — `read_body()` accepts arbitrary Content-Length without a cap. A malicious client can send a multi-GB body and OOM the server.
-**Fix:** Add a max body size check (e.g., 10 MB) and return 413.
+### ~~HIGH: No Content-Length upper bound — memory exhaustion DoS~~ FIXED
+~~`backend/app.py:577-584` — `read_body()` accepts arbitrary Content-Length without a cap. A malicious client can send a multi-GB body and OOM the server.~~
+`read_body()` now enforces a 10 MB cap and returns 413 on oversized requests. A `_BODY_TOO_LARGE` sentinel prevents double-responses in `do_POST` and `do_DELETE`.
 
-### HIGH: Path traversal via `tool` parameter in `/api/launch`
-`backend/services/process_manager.py:96-118` — The `tool` parameter from the request body is never validated against the `LLAMA_TOOLS` allowlist. A value like `../../Windows/System32/cmd` could resolve outside the bin directory.
-**Fix:** Validate `tool` against the allowlist before constructing the path.
+### ~~HIGH: Path traversal via `tool` parameter in `/api/launch`~~ FIXED
+~~`backend/services/process_manager.py:96-118` — The `tool` parameter from the request body is never validated against the `LLAMA_TOOLS` allowlist. A value like `../../Windows/System32/cmd` could resolve outside the bin directory.~~
+`backend/routes/process.py` now validates `tool` against `ctx.services.llama_tools` before calling `launch_process()`. Unknown tool values are rejected with a 400.
 
 ### MEDIUM: Unrestricted subprocess arguments
 `backend/routes/process.py:10-18` — The `args` list is passed verbatim to `subprocess.Popen`. Any local client can pass arbitrary CLI flags. Intentional for a local GUI tool, but should be documented clearly, especially for wildcard-bind/tunnel scenarios.
 
 ### MEDIUM: Exception details leaked to clients
-Multiple routes return raw `str(e)` in error responses (`routes/process.py:36`, `routes/lifecycle.py:25`, `routes/chat.py:126`, etc.). If exposed via tunnel, this reveals filesystem paths, Python versions, and package info.
+Multiple routes return raw `str(e)` in error responses (`routes/process.py:37`, `routes/lifecycle.py:26`, `routes/chat.py:126`, `routes/install.py:24,104`, `routes/git_update.py:10,25`, `routes/tunnel.py:15`, etc.). If exposed via tunnel, this reveals filesystem paths, Python versions, and package info.
 
 ### MEDIUM: `do_DELETE` reads body before origin check
 `backend/app.py:773-781` — Body is read from the socket before the CORS origin check, wasting resources on unauthorized requests. Compare with `do_POST` which checks validity first.
@@ -30,12 +30,11 @@ Multiple routes return raw `str(e)` in error responses (`routes/process.py:36`, 
 ## 2. Architecture & Backend Quality
 
 ### Duplicated host validation logic (MEDIUM)
-Three nearly identical functions validate local hosts:
+Two nearly identical functions independently validate local hosts:
 - `backend/app.py:453-466` (`get_metrics_host`)
-- `backend/app.py:226-233` (`normalize_local_proxy_host`)
 - `backend/services/chat.py:72-85` (`get_local_proxy_host`)
 
-Each does DNS resolution + local interface checks. Should be consolidated into one shared function.
+Both do DNS resolution + local interface checks. `backend/app.py:226-233` (`normalize_local_proxy_host`) is a thin wrapper around `get_metrics_host`, not a third independent implementation. Should be consolidated into one shared function.
 
 ### Duplicated `get_local_interface_addresses` (MEDIUM)
 `backend/app.py:441-450` and `backend/services/chat.py:59-69` — Two implementations of the same function. The `chat.py` version correctly uses `@lru_cache`; the `app.py` version does not.
@@ -73,8 +72,8 @@ These work today but are fragile if files are ever wrapped in IIFEs.
 ### `normalizeMultiEnumValue` defined twice (LOW)
 `flag-core.js:13` has a stub (arrays only), `config-flags-ui.js:638-647` has the full implementation. The stub is injected at runtime, but the duplication is a maintenance risk.
 
-### Host/port extraction repeated 4 times (LOW)
-`app.js:1867`, `:2191`, `:2554`, `:2769` — Each extracts host+port from flag values with identical logic. Should be a shared helper.
+### Host/port extraction repeated 6–7 times (LOW)
+`app.js` contains at least 6–7 inline host+port extractions from flag values (in `updateServerAddressPreview`, `getServerBaseUrl`, post-launch banner, `pollStats`, `getChatApiUrl`, `sendChatMessage`, `startRemoteTunnel`). A shared helper `getServerBaseUrl()` was partially added but is not reused by most call sites. Should be used consistently throughout.
 
 ### `pollOutput` stops on single transient error (MEDIUM)
 `app.js:2268-2278` — A single network blip permanently kills output polling. Should retry 2-3 times before giving up.
@@ -97,7 +96,7 @@ No conversation count or size limit. Practical conversations are unlikely to hit
 ## 4. HTML & CSS Issues
 
 ### Accessibility: Missing aria-labels on icon-only buttons (HIGH)
-~15+ buttons across `index.html` have only SVG icons with `title` (or nothing). Screen readers cannot identify them. Each needs `aria-label`.
+~13 buttons across `index.html` have only SVG icons with `title` (or nothing). Screen readers cannot identify them. Each needs `aria-label`.
 
 ### Accessibility: Toggle checkbox hidden with `display:none` (MEDIUM)
 `style.css:406` — `.toggle input { display: none; }` removes the checkbox from keyboard navigation entirely. Use the visually-hidden pattern instead.
@@ -164,8 +163,8 @@ huggingface_hub
 ```
 All three dependencies are completely unpinned. Any install could pull a breaking version. Minimum recommendation: `certifi>=2024.2.2`, `ddgs>=7.0.0`, `huggingface_hub>=0.20.0`.
 
-### `config.json` committed with hardcoded `cuda-13.1` (LOW)
-Listed in `.gitignore` but tracked in git. Every clone starts with a CUDA 13.1 backend config, which is wrong for non-CUDA users.
+### `config.json` not committed — claim retracted (LOW)
+~~Listed in `.gitignore` but tracked in git.~~ `config.json` is correctly listed in `.gitignore` and is not tracked. It is a local runtime file. This item is a false positive.
 
 ### No `npm test` script (LOW)
 `package.json` only has `test:frontend`. `npm test` fails with missing script error.
@@ -177,13 +176,13 @@ No `pyproject.toml`, `setup.py`, or `setup.cfg`. The `.gitignore` references `.r
 
 ## Prioritized Recommendations
 
-1. **Add Content-Length cap** in `read_body()` — simple fix, prevents memory exhaustion
-2. **Validate `tool` parameter** against `LLAMA_TOOLS` allowlist in process launch
+1. ~~**Add Content-Length cap** in `read_body()` — simple fix, prevents memory exhaustion~~ **FIXED**
+2. ~~**Validate `tool` parameter** against `LLAMA_TOOLS` allowlist in process launch~~ **FIXED**
 3. **Pin dependencies** in `requirements.txt` with minimum versions
 4. **Wrap `manager.js`/`presets.js`/`app.js` in IIFEs** attached to `window.LlamaGui` — biggest frontend architectural improvement
 5. **Add retry logic to `pollOutput`** — single transient errors shouldn't kill the output stream
 6. **Add `aria-label` to all icon-only buttons** — highest-impact accessibility fix
 7. **Write tests for `install_release()` and `download_file()`** — core flow with zero coverage
 8. **Consolidate host validation** into a single shared function
-9. **Extract host/port helper** to eliminate 4x duplication in `app.js`
+9. **Extract host/port helper** to eliminate 6–7x duplication in `app.js`
 10. **Make toggle checkbox keyboard-accessible** via visually-hidden pattern

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -386,6 +386,7 @@ class ExtractedRouteTests(unittest.TestCase):
                 current_platform="darwin",
                 find_tool_executable=lambda tool: ctx.paths.llama_bin / tool,
                 get_tool_filename=lambda tool: tool,
+                llama_tools=["llama-cli", "llama-server"],
                 validate_runtime_dependencies=lambda tools=None: {
                     "ok": False,
                     "checked": True,
@@ -409,6 +410,7 @@ class ExtractedRouteTests(unittest.TestCase):
                 current_platform="darwin",
                 find_tool_executable=lambda tool: ctx.paths.llama_bin / tool,
                 get_tool_filename=lambda tool: tool,
+                llama_tools=["llama-cli", "llama-server"],
                 validate_runtime_dependencies=lambda tools=None: {
                     "ok": False,
                     "checked": True,
@@ -433,6 +435,31 @@ class ExtractedRouteTests(unittest.TestCase):
             self.assertEqual(response.status, 400)
             self.assertIn("libllama-common.0.dylib", response.payload["error"])
             mock_popen.assert_not_called()
+
+    def test_process_launch_route_rejects_unknown_tool(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            ctx.services = BackendServices(
+                llama_tools=["llama-cli", "llama-server"],
+            )
+            response = DummyResponse()
+
+            with mock.patch.object(process_manager, "launch_process") as mock_launch_process:
+                process.launch(
+                    Request(
+                        "POST",
+                        "/api/launch",
+                        "",
+                        {},
+                        body={"tool": "../../cmd", "args": []},
+                    ),
+                    response,
+                    ctx,
+                )
+
+            self.assertEqual(response.status, 400)
+            self.assertEqual(response.payload["error"], "Unknown tool: '../../cmd'")
+            mock_launch_process.assert_not_called()
 
     def test_hf_download_status_route_reads_context_state(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Add a 10 MB Content-Length cap to backend/app.py (read_body) with a _BODY_TOO_LARGE sentinel to avoid double-responses and return 413 for oversized requests; handlers now early-return when the sentinel is seen. Add validation in backend/routes/process.py to reject unknown tools (using ctx.services.llama_tools) with a 400 error before launching processes. Update docs/may_codereview.md to mark these issues as fixed and adjust related notes.