### PR TITLE
Add polling retry and error feedback for output, install, and HF down…

### DIFF
--- a/docs/may_codereview.md
+++ b/docs/may_codereview.md
@@ -78,11 +78,13 @@ These work today but are fragile if files are ever wrapped in IIFEs.
 ### Host/port extraction repeated 6-7 times (LOW)
 `app.js` contains repeated inline host+port extraction from flag values (in `updateServerAddressPreview`, `getServerBaseUrl`, post-launch banner, `pollStats`, `getChatApiUrl`, `sendChatMessage`, `startRemoteTunnel`). A shared helper `getServerBaseUrl()` was partially added but is not reused by most call sites. Use a shared helper consistently.
 
-### `pollOutput` stops on single transient error (MEDIUM)
-`app.js:2239-2280` - A single network blip permanently kills output polling. Retry 2-3 times before giving up.
+### ~~`pollOutput` stops on single transient error (MEDIUM)~~ FIXED
+~~`app.js:2239-2280` - A single network blip permanently kills output polling. Retry 2-3 times before giving up.~~
+`pollOutput` now retries up to 5 times (~1.5s) before giving up. Transient errors show a retry message in the terminal; only sustained failures trigger the full "connection lost" shutdown.
 
-### `pollInstallProgress` / `pollHfDownloadProgress` swallow errors (MEDIUM)
-`manager.js:432-467`, `app.js:1074-1095` - Server crashes during install/download leave the user waiting with little feedback until timeout. Count consecutive failures and show a visible warning/error after a threshold.
+### ~~`pollInstallProgress` / `pollHfDownloadProgress` swallow errors (MEDIUM)~~ FIXED
+~~`manager.js:432-467`, `app.js:1074-1095` - Server crashes during install/download leave the user waiting with little feedback until timeout. Count consecutive failures and show a visible warning/error after a threshold.~~
+Both pollers now count consecutive fetch failures and stop with a visible error after 5 consecutive misses (~2.5s). `pollHfDownloadProgress` also gained a 30-minute timeout safety net.
 
 ### XSS: Safe (NONE)
 The `renderMarkdown` function uses an escape-first approach (`escapeHtml()` runs on all input before any processing). All observed `innerHTML` usage operates on escaped or hardcoded content. No XSS vulnerabilities found in the reviewed paths.
@@ -180,7 +182,7 @@ No `pyproject.toml`, `setup.py`, or `setup.cfg`. The `.gitignore` references `.r
 1. ~~**Add Content-Length cap** in `read_body()` - simple fix, prevents memory exhaustion~~ **FIXED**
 2. ~~**Validate `tool` parameter** against `LLAMA_TOOLS` allowlist in process launch~~ **FIXED**
 3. ~~**Pin dependencies** in `requirements.txt` with minimum versions~~ **FIXED**
-4. **Add retry/error feedback to polling** for `pollOutput`, install progress, and HF download progress
+4. ~~**Add retry/error feedback to polling** for `pollOutput`, install progress, and HF download progress~~ **FIXED**
 5. **Fix accessibility basics**: icon button `aria-label`s, chat slider labels, keyboard-accessible toggles, suggestion chips, and modal focus management
 6. **Consolidate host validation** into a single shared function
 7. ~~**Sanitize exception responses** so client-facing messages do not expose local internals~~ **FIXED**

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -2291,7 +2291,7 @@ async function pollOutput() {
         pollOutputFailCount = 0;
     } catch (e) {
         pollOutputFailCount++;
-        if (pollOutputFailCount < 5) {
+        if (pollOutputFailCount <= 5) {
             appendOutput("Output polling error (retry " + pollOutputFailCount + "/5): " + e.message);
         } else {
             appendOutput("Connection to server lost: " + e.message);

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -12,9 +12,15 @@ let lastOutputLen = 0;
 let statsTimer = null;
 let pollOutputActive = false;
 let pollStatsActive = false;
+let pollOutputFailCount = 0;
 let serverReadyNotified = false;
 let remoteTunnelTimer = null;
 let hfDownloadTimer = null;
+let hfDownloadFailCount = 0;
+let hfDownloadStartTime = null;
+
+const HF_DOWNLOAD_POLL_MAX_FAILS = 5;
+const HF_DOWNLOAD_TIMEOUT_MS = 30 * 60 * 1000;
 let selectedChatTemplatePresetValue = "";
 
 let chatMessages = [];
@@ -1073,9 +1079,19 @@ async function refreshHfDownloadStatus() {
 
 function pollHfDownloadProgress() {
     if (hfDownloadTimer) clearInterval(hfDownloadTimer);
+    hfDownloadFailCount = 0;
+    hfDownloadStartTime = Date.now();
     hfDownloadTimer = setInterval(async () => {
+        if (Date.now() - hfDownloadStartTime > HF_DOWNLOAD_TIMEOUT_MS) {
+            clearInterval(hfDownloadTimer);
+            hfDownloadTimer = null;
+            setHfDownloadBusy(false);
+            showHfDownloadStatus("error", "Download timed out. The server may have stopped responding.");
+            return;
+        }
         try {
             const prog = await fetchJson("/api/hf/download-status");
+            hfDownloadFailCount = 0;
             updateHfProgress(prog);
             if (prog.status === "done") {
                 clearInterval(hfDownloadTimer);
@@ -1088,7 +1104,13 @@ function pollHfDownloadProgress() {
                 showHfDownloadStatus(prog.status === "cancelled" ? "warning" : "error", prog.message || "Download stopped.");
             }
         } catch (e) {
-            // Ignore transient poll errors while the server is busy with a large download.
+            hfDownloadFailCount++;
+            if (hfDownloadFailCount >= HF_DOWNLOAD_POLL_MAX_FAILS) {
+                clearInterval(hfDownloadTimer);
+                hfDownloadTimer = null;
+                setHfDownloadBusy(false);
+                showHfDownloadStatus("error", "Lost contact with the server during download. The download may still be in progress \u2014 try restarting Llama GUI.");
+            }
         }
     }, 500);
 }
@@ -2147,6 +2169,7 @@ async function stopLlama() {
 function startOutputPolling() {
     lastOutputLen = 0;
     serverReadyNotified = false;
+    pollOutputFailCount = 0;
     if (outputTimer) clearInterval(outputTimer);
     outputTimer = setInterval(pollOutput, 300);
 }
@@ -2265,17 +2288,23 @@ async function pollOutput() {
             updateChatStatusBadge();
             setTimeout(() => checkStatus(), 500);
         }
+        pollOutputFailCount = 0;
     } catch (e) {
-        appendOutput("Connection to server lost: " + e.message);
-        stopOutputPolling();
-        stopStatsPolling();
-        document.getElementById("btn-launch").classList.remove("hidden");
-        document.getElementById("btn-stop").classList.add("hidden");
-        document.getElementById("input-row").classList.add("hidden");
-        document.getElementById("server-address").classList.add("hidden");
-        updateQuickLaunchActionButtons();
-        updateApiEndpoints();
-        updateChatStatusBadge();
+        pollOutputFailCount++;
+        if (pollOutputFailCount < 5) {
+            appendOutput("Output polling error (retry " + pollOutputFailCount + "/5): " + e.message);
+        } else {
+            appendOutput("Connection to server lost: " + e.message);
+            stopOutputPolling();
+            stopStatsPolling();
+            document.getElementById("btn-launch").classList.remove("hidden");
+            document.getElementById("btn-stop").classList.add("hidden");
+            document.getElementById("input-row").classList.add("hidden");
+            document.getElementById("server-address").classList.add("hidden");
+            updateQuickLaunchActionButtons();
+            updateApiEndpoints();
+            updateChatStatusBadge();
+        }
     } finally {
         pollOutputActive = false;
     }

--- a/ui/js/manager.js
+++ b/ui/js/manager.js
@@ -1,10 +1,12 @@
 let cachedReleases = null;
 let installPollTimer = null;
 let installPollStartTime = null;
+let installPollFailCount = 0;
 let latestStatus = null;
 let latestAppUpdateStatus = null;
 
 const INSTALL_POLL_TIMEOUT_MS = 10 * 60 * 1000;
+const INSTALL_POLL_MAX_FAILS = 5;
 
 function renderBackendOptions(status) {
     const backendSelect = document.getElementById("backend-select");
@@ -432,6 +434,7 @@ async function checkForUpdates() {
 function pollInstallProgress() {
     if (installPollTimer) clearInterval(installPollTimer);
     installPollStartTime = Date.now();
+    installPollFailCount = 0;
     installPollTimer = setInterval(async () => {
         if (Date.now() - installPollStartTime > INSTALL_POLL_TIMEOUT_MS) {
             clearInterval(installPollTimer);
@@ -443,6 +446,7 @@ function pollInstallProgress() {
         }
         try {
             const prog = await fetchJson("/api/download-progress");
+            installPollFailCount = 0;
             updateProgressBar(prog);
             if (prog.status === "done") {
                 clearInterval(installPollTimer);
@@ -459,7 +463,14 @@ function pollInstallProgress() {
                 setInstallButtonsDisabled(false);
             }
         } catch (e) {
-            // ignore transient poll errors
+            installPollFailCount++;
+            if (installPollFailCount >= INSTALL_POLL_MAX_FAILS) {
+                clearInterval(installPollTimer);
+                installPollTimer = null;
+                showStatus("error", "Lost contact with the server during installation. The install may still be in progress \u2014 try restarting Llama GUI.");
+                showProgress(false);
+                setInstallButtonsDisabled(false);
+            }
         }
     }, 500);
 }


### PR DESCRIPTION

pollOutput retries up to 5 times before giving up on transient errors. pollInstallProgress counts consecutive failures and shows an error after 5 misses. pollHfDownloadProgress counts consecutive failures and adds a 30-minute timeout. All counters reset on successful fetch. Docs updated.