### PR TITLE
Restrict CI Node steps and run pretest script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
     branches: [main, master]
     paths-ignore:
       - '*.md'
-      - '.github/**'
       - 'docs/**'
       - 'docs/images/**'
   pull_request:
@@ -48,20 +47,20 @@ jobs:
         run: python -m unittest discover tests -v
 
       - name: Set up Node for frontend smoke test
-        if: matrix.python-version == '3.13'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: npm
 
       - name: Install frontend test dependencies
-        if: matrix.python-version == '3.13'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         run: npm ci
 
       - name: Install Playwright Chromium
-        if: matrix.python-version == '3.13'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         run: npx playwright install chromium
 
       - name: Run frontend smoke test
-        if: matrix.python-version == '3.13'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         run: npm test

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "llama-gui",
   "private": true,
   "scripts": {
-    "test": "npm run test:frontend",
+    "test": "node tests/frontend/custom_launch_args_unit.cjs && npm run test:frontend",
     "test:frontend": "node tests/frontend/flag_sync_smoke.cjs"
   },
   "devDependencies": {


### PR DESCRIPTION
Adjust CI workflow and test script: remove '.github/**' from workflow paths-ignore so workflow can trigger on .github changes; tighten Node-related job conditionals to require matrix.os == 'ubuntu-latest' && python 3.13 so Node setup/install/test only run on the Ubuntu runner; and update package.json test script to execute tests/frontend/custom_launch_args_unit.cjs before running the frontend smoke test. These changes limit unnecessary Node steps on non-Ubuntu runners and ensure the custom pre-test is executed.