### PR TITLE
Extract HF download UI to separate module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,10 +190,10 @@ with the primary file and only touch secondary files if the change requires it.
 | Chat sidebar samplers | `ui/js/app.js` | `ui/js/flag-core.js` (state) |
 | Chat markdown/rendering helpers | `ui/js/chat-rendering.js` | `ui/js/app.js` (chat state/controller) |
 | API tab docs/snippets | `ui/js/api-tab.js` | `ui/js/app.js` (status/init), `ui/js/flag-core.js` (state reads) |
+| HF download UI | `ui/js/hf-download-ui.js` | `ui/js/app.js` (callbacks), `ui/js/manager.js` (fetchJson) |
 | Chat template presets | `ui/js/flags.js` | `ui/js/app.js` (mapping helpers) |
 | Sampler presets | `ui/js/app.js` | `ui/js/flag-core.js` (apply) |
 | Preset save/load/import/export | `ui/js/presets.js` | `ui/js/flag-core.js` (collect/apply) |
-| HF download UI | `ui/js/app.js` | `ui/js/manager.js` (fetchJson) |
 | Install/update UI | `ui/js/manager.js` | — |
 | Backend routes | `backend/routes/*.py` | `backend/services/*.py` |
 | Backend state/locks | `backend/state.py` | `backend/context.py` |
@@ -215,7 +215,8 @@ The frontend loads scripts in a strict dependency order via `ui/index.html`:
 7. `app-data.js` — shared Quick Launch, context, sampler, and chat slider data
 8. `chat-rendering.js` — markdown and low-level chat DOM rendering helpers (`window.LlamaGui.chatRendering`)
 9. `api-tab.js` — API endpoint/snippet rendering helpers (`window.LlamaGui.apiTab`)
-10. `app.js` — main orchestration (wires everything together)
+10. `hf-download-ui.js` — Quick Launch Hugging Face downloader UI (`window.LlamaGui.hfDownloadUi`)
+11. `app.js` — main orchestration (wires everything together)
 
 **Do not change this order.** Each file depends on the ones above it. If you
 add a new module, place it after its dependencies and before its consumers.
@@ -277,9 +278,10 @@ private closure variables.
 
 ### Frontend
 - **`ui/index.html`**: HTML template defining the tabbed layout and UI structure.
-- **`ui/js/app.js`**: Main UI orchestration. Manages tab switching, server launch/stop, output polling, stats polling, chat state/controller (streaming, web search, conversation history), Quick Launch profiles/HF download/sampler presets, remote tunnel, toasts, and cache-busting reload.
+- **`ui/js/app.js`**: Main UI orchestration. Manages tab switching, server launch/stop, output polling, stats polling, chat state/controller (streaming, web search, conversation history), Quick Launch profiles/sampler presets, remote tunnel, toasts, and cache-busting reload.
 - **`ui/js/chat-rendering.js`**: Markdown and low-level chat DOM rendering helpers exposed as `window.LlamaGui.chatRendering`.
 - **`ui/js/api-tab.js`**: API tab endpoint/snippet data, base URL helpers, and rendering exposed as `window.LlamaGui.apiTab`; reads shared state through injected `flagCore`.
+- **`ui/js/hf-download-ui.js`**: Quick Launch Hugging Face downloader controls, status rendering, progress polling, cancel handling, and completion flow exposed as `window.LlamaGui.hfDownloadUi`; receives shared utilities and `flagCore` from `app.js`.
 - **`ui/js/flags.js`**: Single source of truth for exposed `llama.cpp` flags, flag categories, data types, built-in chat templates, chat template presets, sampler presets, and quick launch profiles.
 - **`ui/js/flag-core.js`**: Shared frontend flag state and launch-argument core. Owns `currentTool`, selected model, `flagValues`, shared setters, custom launch args parsing, preset apply/collect helpers, `getLaunchArgs()`, and command preview generation.
 - **`ui/js/config-flags-ui.js`**: Configure tab flag rendering, search/filtering, expand/collapse state, type-specific flag input builders, input restoration, and high-risk `multi_enum` warnings.
@@ -542,6 +544,8 @@ The Quick Launch tab includes a full HF model downloader section:
 - Model and mmproj file selectors
 - Download progress bar with cancel support
 - Auto-selects downloaded model on completion
+
+Frontend downloader controls, status rendering, progress polling, cancel handling, and completion flow live in `ui/js/hf-download-ui.js`. `app.js` injects `fetchJson`, confirmation/model callbacks, and `flagCore`; the module must not mutate `flagValues` directly.
 
 ## Chat Tab
 

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -27,7 +27,8 @@
 | `ui/js/app-data.js` | Shared Quick Launch profile, context preset, sampler preset, and chat sampler slider data consumed by `app.js` |
 | `ui/js/chat-rendering.js` | Markdown and low-level chat DOM rendering helpers exposed as `window.LlamaGui.chatRendering` |
 | `ui/js/api-tab.js` | API tab endpoint/snippet data, base URL helpers, and rendering exposed as `window.LlamaGui.apiTab` |
-| `ui/js/app.js` | Main UI orchestration: tab switching, launch/stop flow, chat state/controller (streaming, web search, history), Quick Launch/HF download/sampler preset behavior, remote tunnel, stats polling, toasts |
+| `ui/js/hf-download-ui.js` | Quick Launch Hugging Face downloader controls, status rendering, progress polling, cancel handling, and completion flow exposed as `window.LlamaGui.hfDownloadUi` |
+| `ui/js/app.js` | Main UI orchestration: tab switching, launch/stop flow, chat state/controller (streaming, web search, history), Quick Launch/sampler preset behavior, remote tunnel, stats polling, toasts |
 | `ui/js/flags/` | Ordered flag modules for exposed llama.cpp flag categories, option lists, chat template presets, flag definitions, and flag helpers |
 | `ui/js/flag-core.js` | Shared frontend flag state and launch-argument core (`currentTool`, selected model, `flagValues`, setters, preset apply/collect helpers, command preview generation) |
 | `ui/js/config-flags-ui.js` | Configure tab flag rendering, search/filtering, expand/collapse state, type-specific flag input builders, input restoration, and high-risk `multi_enum` warnings |
@@ -77,6 +78,7 @@ Frontend modules are still loaded as ordered global scripts rather than ES modul
 ## Hugging Face Download
 
 Integrated model downloader in the Quick Launch tab:
+- Frontend controls, status rendering, progress polling, cancel handling, and completion flow live in `ui/js/hf-download-ui.js`
 - Browse HF repos for GGUF files via `/api/hf/repo-files`
 - Download models + optional mmproj files with progress bar and cancel support
 - Path/filename validation prevents traversal attacks

--- a/refactor_appjs.md
+++ b/refactor_appjs.md
@@ -101,9 +101,11 @@ The API tab is another low-risk boundary because most of it is static endpoint/s
 - Confirm no launch argument or flag state generation moved into the API module.
 - Confirm script order is correct and there are no new globals outside `window.LlamaGui`.
 
-## Phase 3: Extract Hugging Face Download UI
+## Phase 3: Extract Hugging Face Download UI - Done
 
 The Hugging Face downloader has a clear boundary around its backend endpoints, progress timer, form controls, and status rendering.
+
+Status: Completed. `ui/js/hf-download-ui.js` now owns the Hugging Face downloader controls, status rendering, progress polling, cancel handling, and completion flow through `window.LlamaGui.hfDownloadUi`, with shared utilities injected from `app.js`.
 
 ### Implementation
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -820,6 +820,7 @@
 <script src="/js/app-data.js?v=revamp-1"></script>
 <script src="/js/chat-rendering.js?v=revamp-1"></script>
 <script src="/js/api-tab.js?v=revamp-1"></script>
+<script src="/js/hf-download-ui.js?v=revamp-1"></script>
 <script src="/js/app.js?v=revamp-1"></script>
 </body>
 </html>

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -15,12 +15,7 @@ let pollStatsActive = false;
 let pollOutputFailCount = 0;
 let serverReadyNotified = false;
 let remoteTunnelTimer = null;
-let hfDownloadTimer = null;
-let hfDownloadFailCount = 0;
-let hfDownloadStartTime = null;
 
-const HF_DOWNLOAD_POLL_MAX_FAILS = 5;
-const HF_DOWNLOAD_TIMEOUT_MS = 30 * 60 * 1000;
 let selectedChatTemplatePresetValue = "";
 
 let chatMessages = [];
@@ -51,6 +46,15 @@ const {
 } = apiTab;
 const initApiTab = apiTab.init;
 const updateApiEndpoints = apiTab.updateEndpoints;
+const hfDownloadUi = window.LlamaGui.hfDownloadUi;
+hfDownloadUi.configure({
+    flagCore,
+    fetchJson,
+    confirmAction,
+    refreshModels,
+    applyPresetModel,
+    refreshQuickLaunchUI,
+});
 
 function getSamplerFlags() {
     return FLAGS.filter(f => f.category === "sampling");
@@ -604,245 +608,6 @@ function refreshQuickSamplerPresetSelect() {
     }
 }
 
-function formatHfBytes(bytes) {
-    const value = Number(bytes || 0);
-    if (!value) return "unknown size";
-    if (value >= 1073741824) return `${(value / 1073741824).toFixed(2)} GB`;
-    return `${(value / 1048576).toFixed(1)} MB`;
-}
-
-function showHfDownloadStatus(type, message) {
-    const el = document.getElementById("hf-download-status");
-    if (!el) return;
-    el.className = "hf-download-status" + (type ? " " + type : "");
-    el.textContent = message || "";
-}
-
-function setHfDownloadBusy(isBusy) {
-    const findBtn = document.getElementById("btn-hf-find-files");
-    const downloadBtn = document.getElementById("btn-hf-download");
-    const cancelBtn = document.getElementById("btn-hf-cancel");
-    if (findBtn) findBtn.disabled = isBusy;
-    if (downloadBtn) downloadBtn.disabled = isBusy;
-    if (cancelBtn) cancelBtn.classList.toggle("hidden", !isBusy);
-}
-
-function updateHfProgress(prog) {
-    const wrap = document.getElementById("hf-download-progress");
-    const fill = document.getElementById("hf-progress-fill");
-    const text = document.getElementById("hf-progress-text");
-    if (!wrap || !fill || !text) return;
-
-    const status = String(prog.status || "");
-    const active = ["starting", "downloading", "cancelling"].includes(status);
-    wrap.classList.toggle("hidden", !active && status !== "done");
-
-    if (prog.total > 0) {
-        const pct = Math.min(100, Math.round((prog.downloaded / prog.total) * 100));
-        fill.style.width = pct + "%";
-        text.textContent = `${prog.current_file || "Downloading"} ${pct}% (${formatHfBytes(prog.downloaded)} / ${formatHfBytes(prog.total)})`;
-    } else {
-        fill.style.width = active ? "25%" : "100%";
-        text.textContent = prog.message || status || "Working...";
-    }
-}
-
-function populateHfFileSelect(select, files, placeholder) {
-    if (!select) return;
-    select.innerHTML = "";
-    const first = document.createElement("option");
-    first.value = "";
-    first.textContent = placeholder;
-    select.appendChild(first);
-    for (const file of files || []) {
-        const opt = document.createElement("option");
-        opt.value = file.name;
-        opt.textContent = `${file.name}  (${formatHfBytes(file.size)})`;
-        select.appendChild(opt);
-    }
-}
-
-async function findHfFiles() {
-    const repoInput = document.getElementById("hf-repo-input");
-    const revisionInput = document.getElementById("hf-revision-input");
-    const tokenInput = document.getElementById("hf-token-input");
-    const options = document.getElementById("hf-file-options");
-    const modelSelect = document.getElementById("hf-model-file-select");
-    const mmprojSelect = document.getElementById("hf-mmproj-file-select");
-    const mmprojGroup = document.getElementById("hf-mmproj-group");
-    if (!repoInput || !modelSelect || !mmprojSelect) return;
-
-    const repoId = repoInput.value.trim();
-    if (!repoId) {
-        showHfDownloadStatus("warning", "Enter a Hugging Face repo ID first.");
-        return;
-    }
-
-    showHfDownloadStatus("info", "Looking for GGUF files...");
-    setHfDownloadBusy(true);
-    try {
-        const result = await fetchJson("/api/hf/repo-files", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                repo_id: repoId,
-                revision: revisionInput && revisionInput.value.trim() ? revisionInput.value.trim() : "main",
-                token: tokenInput ? tokenInput.value.trim() : "",
-            }),
-        });
-        populateHfFileSelect(modelSelect, result.models || [], "-- Select model file --");
-        populateHfFileSelect(mmprojSelect, result.mmproj || [], "None");
-        if (result.models && result.models.length === 1) modelSelect.value = result.models[0].name;
-        if (mmprojGroup) mmprojGroup.classList.toggle("hidden", !(result.mmproj && result.mmproj.length));
-        if (options) options.classList.remove("hidden");
-        const modelCount = (result.models || []).length;
-        const mmprojCount = (result.mmproj || []).length;
-        showHfDownloadStatus(
-            modelCount ? "success" : "warning",
-            modelCount
-                ? `Found ${modelCount} model file${modelCount === 1 ? "" : "s"}${mmprojCount ? ` and ${mmprojCount} mmproj companion${mmprojCount === 1 ? "" : "s"}` : ""}.`
-                : "No launchable GGUF model files were found in this repo."
-        );
-    } catch (e) {
-        if (options) options.classList.add("hidden");
-        showHfDownloadStatus("error", "Hugging Face lookup failed: " + e.message);
-    } finally {
-        setHfDownloadBusy(false);
-    }
-}
-
-async function startHfDownload(overwrite = false) {
-    const repoInput = document.getElementById("hf-repo-input");
-    const revisionInput = document.getElementById("hf-revision-input");
-    const tokenInput = document.getElementById("hf-token-input");
-    const modelSelect = document.getElementById("hf-model-file-select");
-    const mmprojSelect = document.getElementById("hf-mmproj-file-select");
-    if (!repoInput || !modelSelect) return;
-
-    const modelFile = modelSelect.value;
-    if (!modelFile) {
-        showHfDownloadStatus("warning", "Choose a model file to download.");
-        return;
-    }
-
-    showHfDownloadStatus("info", "Starting download...");
-    setHfDownloadBusy(true);
-    try {
-        await fetchJson("/api/hf/download", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                repo_id: repoInput.value.trim(),
-                revision: revisionInput && revisionInput.value.trim() ? revisionInput.value.trim() : "main",
-                token: tokenInput ? tokenInput.value.trim() : "",
-                model_file: modelFile,
-                mmproj_file: mmprojSelect ? mmprojSelect.value : "",
-                overwrite,
-            }),
-        });
-        pollHfDownloadProgress();
-    } catch (e) {
-        setHfDownloadBusy(false);
-        if (e.message && e.message.startsWith("Already exists:")) {
-            const ok = await confirmAction(`${e.message}. Replace the existing file?`);
-            if (ok) {
-                startHfDownload(true);
-                return;
-            }
-        }
-        showHfDownloadStatus("error", "Download failed to start: " + e.message);
-    }
-}
-
-async function finishHfDownload(prog) {
-    showHfDownloadStatus("success", prog.message || "Download complete.");
-    setHfDownloadBusy(false);
-    await refreshModels();
-    if (prog.model_name) {
-        applyPresetModel(prog.model_name);
-    }
-    if (prog.mmproj_path) {
-        flagCore.setPathFlagValue("mmproj", prog.mmproj_path);
-    }
-    flagCore.updateCommandPreview();
-    refreshQuickLaunchUI();
-}
-
-async function refreshHfDownloadStatus() {
-    try {
-        const prog = await fetchJson("/api/hf/download-status");
-        updateHfProgress(prog);
-
-        const status = String(prog.status || "");
-        const active = ["starting", "downloading", "cancelling"].includes(status);
-        setHfDownloadBusy(active);
-
-        if (prog.message) {
-            const type = status === "error"
-                ? "error"
-                : status === "cancelled"
-                    ? "warning"
-                    : status === "done"
-                        ? "success"
-                        : "info";
-            showHfDownloadStatus(type, prog.message);
-        }
-
-        if (active) {
-            pollHfDownloadProgress();
-        }
-    } catch (e) {
-        // Ignore initial status read failures; the panel remains available for manual use.
-    }
-}
-
-function pollHfDownloadProgress() {
-    if (hfDownloadTimer) clearInterval(hfDownloadTimer);
-    hfDownloadFailCount = 0;
-    hfDownloadStartTime = Date.now();
-    hfDownloadTimer = setInterval(async () => {
-        if (Date.now() - hfDownloadStartTime > HF_DOWNLOAD_TIMEOUT_MS) {
-            clearInterval(hfDownloadTimer);
-            hfDownloadTimer = null;
-            setHfDownloadBusy(false);
-            showHfDownloadStatus("error", "Download timed out. The server may have stopped responding.");
-            return;
-        }
-        try {
-            const prog = await fetchJson("/api/hf/download-status");
-            hfDownloadFailCount = 0;
-            updateHfProgress(prog);
-            if (prog.status === "done") {
-                clearInterval(hfDownloadTimer);
-                hfDownloadTimer = null;
-                await finishHfDownload(prog);
-            } else if (["error", "cancelled"].includes(prog.status)) {
-                clearInterval(hfDownloadTimer);
-                hfDownloadTimer = null;
-                setHfDownloadBusy(false);
-                showHfDownloadStatus(prog.status === "cancelled" ? "warning" : "error", prog.message || "Download stopped.");
-            }
-        } catch (e) {
-            hfDownloadFailCount++;
-            if (hfDownloadFailCount >= HF_DOWNLOAD_POLL_MAX_FAILS) {
-                clearInterval(hfDownloadTimer);
-                hfDownloadTimer = null;
-                setHfDownloadBusy(false);
-                showHfDownloadStatus("error", "Lost contact with the server during download. The download may still be in progress \u2014 try restarting Llama GUI.");
-            }
-        }
-    }, 500);
-}
-
-async function cancelHfDownload() {
-    try {
-        await fetchJson("/api/hf/download-cancel", { method: "POST" });
-        showHfDownloadStatus("warning", "Cancelling download...");
-    } catch (e) {
-        showHfDownloadStatus("error", "Failed to cancel download: " + e.message);
-    }
-}
-
 function applyQuickProfile(profileId) {
     const profile = QUICK_PROFILES[profileId];
     if (!profile) return;
@@ -1173,7 +938,7 @@ function initQuickLaunch() {
     populateQuickProfileOptions();
     refreshQuickSamplerPresetSelect();
     syncQuickLaunchModelOptions();
-    refreshHfDownloadStatus();
+    hfDownloadUi.init();
 
     on("btn-open-configure", "click", () => {
         switchTab("configure");
@@ -1182,10 +947,6 @@ function initQuickLaunch() {
     on("btn-quick-refresh-models", "click", () => {
         refreshModels();
     });
-
-    on("btn-hf-find-files", "click", findHfFiles);
-    on("btn-hf-download", "click", () => startHfDownload(false));
-    on("btn-hf-cancel", "click", cancelHfDownload);
 
     on("quick-model-select", "change", (e) => {
         applyPresetModel(e.target.value);

--- a/ui/js/hf-download-ui.js
+++ b/ui/js/hf-download-ui.js
@@ -1,0 +1,305 @@
+(function () {
+    "use strict";
+
+    const HF_DOWNLOAD_POLL_MAX_FAILS = 5;
+    const HF_DOWNLOAD_TIMEOUT_MS = 30 * 60 * 1000;
+
+    let hfDownloadTimer = null;
+    let hfDownloadFailCount = 0;
+    let hfDownloadStartTime = null;
+    let deps = {};
+
+    function requireDependency(name) {
+        const value = deps[name];
+        if (typeof value !== "function") {
+            throw new Error(`Hugging Face downloader dependency missing: ${name}`);
+        }
+        return value;
+    }
+
+    function configure(nextDeps) {
+        deps = Object.assign({}, deps, nextDeps || {});
+    }
+
+    function formatHfBytes(bytes) {
+        const value = Number(bytes || 0);
+        if (!value) return "unknown size";
+        if (value >= 1073741824) return `${(value / 1073741824).toFixed(2)} GB`;
+        return `${(value / 1048576).toFixed(1)} MB`;
+    }
+
+    function showStatus(type, message) {
+        const el = document.getElementById("hf-download-status");
+        if (!el) return;
+        el.className = "hf-download-status" + (type ? " " + type : "");
+        el.textContent = message || "";
+    }
+
+    function setBusy(isBusy) {
+        const findBtn = document.getElementById("btn-hf-find-files");
+        const downloadBtn = document.getElementById("btn-hf-download");
+        const cancelBtn = document.getElementById("btn-hf-cancel");
+        if (findBtn) findBtn.disabled = isBusy;
+        if (downloadBtn) downloadBtn.disabled = isBusy;
+        if (cancelBtn) cancelBtn.classList.toggle("hidden", !isBusy);
+    }
+
+    function updateProgress(prog) {
+        const wrap = document.getElementById("hf-download-progress");
+        const fill = document.getElementById("hf-progress-fill");
+        const text = document.getElementById("hf-progress-text");
+        if (!wrap || !fill || !text) return;
+
+        const status = String(prog.status || "");
+        const active = ["starting", "downloading", "cancelling"].includes(status);
+        wrap.classList.toggle("hidden", !active && status !== "done");
+
+        if (prog.total > 0) {
+            const pct = Math.min(100, Math.round((prog.downloaded / prog.total) * 100));
+            fill.style.width = pct + "%";
+            text.textContent = `${prog.current_file || "Downloading"} ${pct}% (${formatHfBytes(prog.downloaded)} / ${formatHfBytes(prog.total)})`;
+        } else {
+            fill.style.width = active ? "25%" : "100%";
+            text.textContent = prog.message || status || "Working...";
+        }
+    }
+
+    function populateFileSelect(select, files, placeholder) {
+        if (!select) return;
+        select.innerHTML = "";
+        const first = document.createElement("option");
+        first.value = "";
+        first.textContent = placeholder;
+        select.appendChild(first);
+        for (const file of files || []) {
+            const opt = document.createElement("option");
+            opt.value = file.name;
+            opt.textContent = `${file.name}  (${formatHfBytes(file.size)})`;
+            select.appendChild(opt);
+        }
+    }
+
+    async function findFiles() {
+        const fetchJson = requireDependency("fetchJson");
+        const repoInput = document.getElementById("hf-repo-input");
+        const revisionInput = document.getElementById("hf-revision-input");
+        const tokenInput = document.getElementById("hf-token-input");
+        const options = document.getElementById("hf-file-options");
+        const modelSelect = document.getElementById("hf-model-file-select");
+        const mmprojSelect = document.getElementById("hf-mmproj-file-select");
+        const mmprojGroup = document.getElementById("hf-mmproj-group");
+        if (!repoInput || !modelSelect || !mmprojSelect) return;
+
+        const repoId = repoInput.value.trim();
+        if (!repoId) {
+            showStatus("warning", "Enter a Hugging Face repo ID first.");
+            return;
+        }
+
+        showStatus("info", "Looking for GGUF files...");
+        setBusy(true);
+        try {
+            const result = await fetchJson("/api/hf/repo-files", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    repo_id: repoId,
+                    revision: revisionInput && revisionInput.value.trim() ? revisionInput.value.trim() : "main",
+                    token: tokenInput ? tokenInput.value.trim() : "",
+                }),
+            });
+            populateFileSelect(modelSelect, result.models || [], "-- Select model file --");
+            populateFileSelect(mmprojSelect, result.mmproj || [], "None");
+            if (result.models && result.models.length === 1) modelSelect.value = result.models[0].name;
+            if (mmprojGroup) mmprojGroup.classList.toggle("hidden", !(result.mmproj && result.mmproj.length));
+            if (options) options.classList.remove("hidden");
+            const modelCount = (result.models || []).length;
+            const mmprojCount = (result.mmproj || []).length;
+            showStatus(
+                modelCount ? "success" : "warning",
+                modelCount
+                    ? `Found ${modelCount} model file${modelCount === 1 ? "" : "s"}${mmprojCount ? ` and ${mmprojCount} mmproj companion${mmprojCount === 1 ? "" : "s"}` : ""}.`
+                    : "No launchable GGUF model files were found in this repo."
+            );
+        } catch (e) {
+            if (options) options.classList.add("hidden");
+            showStatus("error", "Hugging Face lookup failed: " + e.message);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    async function startDownload(overwrite = false) {
+        const fetchJson = requireDependency("fetchJson");
+        const confirmAction = requireDependency("confirmAction");
+        const repoInput = document.getElementById("hf-repo-input");
+        const revisionInput = document.getElementById("hf-revision-input");
+        const tokenInput = document.getElementById("hf-token-input");
+        const modelSelect = document.getElementById("hf-model-file-select");
+        const mmprojSelect = document.getElementById("hf-mmproj-file-select");
+        if (!repoInput || !modelSelect) return;
+
+        const modelFile = modelSelect.value;
+        if (!modelFile) {
+            showStatus("warning", "Choose a model file to download.");
+            return;
+        }
+
+        showStatus("info", "Starting download...");
+        setBusy(true);
+        try {
+            await fetchJson("/api/hf/download", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    repo_id: repoInput.value.trim(),
+                    revision: revisionInput && revisionInput.value.trim() ? revisionInput.value.trim() : "main",
+                    token: tokenInput ? tokenInput.value.trim() : "",
+                    model_file: modelFile,
+                    mmproj_file: mmprojSelect ? mmprojSelect.value : "",
+                    overwrite,
+                }),
+            });
+            pollProgress();
+        } catch (e) {
+            setBusy(false);
+            if (e.message && e.message.startsWith("Already exists:")) {
+                const ok = await confirmAction(`${e.message}. Replace the existing file?`);
+                if (ok) {
+                    startDownload(true);
+                    return;
+                }
+            }
+            showStatus("error", "Download failed to start: " + e.message);
+        }
+    }
+
+    async function finishDownload(prog) {
+        const refreshModels = requireDependency("refreshModels");
+        const applyPresetModel = requireDependency("applyPresetModel");
+        const refreshQuickLaunchUI = requireDependency("refreshQuickLaunchUI");
+        const flagCore = deps.flagCore;
+
+        showStatus("success", prog.message || "Download complete.");
+        setBusy(false);
+        await refreshModels();
+        if (prog.model_name) {
+            applyPresetModel(prog.model_name);
+        }
+        if (prog.mmproj_path && flagCore && typeof flagCore.setPathFlagValue === "function") {
+            flagCore.setPathFlagValue("mmproj", prog.mmproj_path);
+        }
+        if (flagCore && typeof flagCore.updateCommandPreview === "function") {
+            flagCore.updateCommandPreview();
+        }
+        refreshQuickLaunchUI();
+    }
+
+    async function refreshStatus() {
+        const fetchJson = requireDependency("fetchJson");
+        try {
+            const prog = await fetchJson("/api/hf/download-status");
+            updateProgress(prog);
+
+            const status = String(prog.status || "");
+            const active = ["starting", "downloading", "cancelling"].includes(status);
+            setBusy(active);
+
+            if (prog.message) {
+                const type = status === "error"
+                    ? "error"
+                    : status === "cancelled"
+                        ? "warning"
+                        : status === "done"
+                            ? "success"
+                            : "info";
+                showStatus(type, prog.message);
+            }
+
+            if (active) {
+                pollProgress();
+            }
+        } catch (e) {
+            // Ignore initial status read failures; the panel remains available for manual use.
+        }
+    }
+
+    function clearPollTimer() {
+        if (hfDownloadTimer) clearInterval(hfDownloadTimer);
+        hfDownloadTimer = null;
+    }
+
+    function pollProgress() {
+        const fetchJson = requireDependency("fetchJson");
+        clearPollTimer();
+        hfDownloadFailCount = 0;
+        hfDownloadStartTime = Date.now();
+        hfDownloadTimer = setInterval(async () => {
+            if (Date.now() - hfDownloadStartTime > HF_DOWNLOAD_TIMEOUT_MS) {
+                clearPollTimer();
+                setBusy(false);
+                showStatus("error", "Download timed out. The server may have stopped responding.");
+                return;
+            }
+            try {
+                const prog = await fetchJson("/api/hf/download-status");
+                hfDownloadFailCount = 0;
+                updateProgress(prog);
+                if (prog.status === "done") {
+                    clearPollTimer();
+                    await finishDownload(prog);
+                } else if (["error", "cancelled"].includes(prog.status)) {
+                    clearPollTimer();
+                    setBusy(false);
+                    showStatus(prog.status === "cancelled" ? "warning" : "error", prog.message || "Download stopped.");
+                }
+            } catch (e) {
+                hfDownloadFailCount++;
+                if (hfDownloadFailCount >= HF_DOWNLOAD_POLL_MAX_FAILS) {
+                    clearPollTimer();
+                    setBusy(false);
+                    showStatus("error", "Lost contact with the server during download. The download may still be in progress - try restarting Llama GUI.");
+                }
+            }
+        }, 500);
+    }
+
+    async function cancelDownload() {
+        const fetchJson = requireDependency("fetchJson");
+        try {
+            await fetchJson("/api/hf/download-cancel", { method: "POST" });
+            showStatus("warning", "Cancelling download...");
+        } catch (e) {
+            showStatus("error", "Failed to cancel download: " + e.message);
+        }
+    }
+
+    function init() {
+        const on = (id, event, handler) => {
+            const el = document.getElementById(id);
+            if (el) el.addEventListener(event, handler);
+        };
+
+        refreshStatus();
+        on("btn-hf-find-files", "click", findFiles);
+        on("btn-hf-download", "click", () => startDownload(false));
+        on("btn-hf-cancel", "click", cancelDownload);
+    }
+
+    window.LlamaGui = window.LlamaGui || {};
+    window.LlamaGui.hfDownloadUi = {
+        configure,
+        init,
+        formatHfBytes,
+        showStatus,
+        setBusy,
+        updateProgress,
+        populateFileSelect,
+        findFiles,
+        startDownload,
+        finishDownload,
+        refreshStatus,
+        pollProgress,
+        cancelDownload,
+    };
+})();


### PR DESCRIPTION
Move Hugging Face download UI logic out of ui/js/app.js into a new ui/js/hf-download-ui.js module, and wire it into the frontend. ui/js/app.js no longer contains the HF download state, timers, or functions; it now configures and initializes window.LlamaGui.hfDownloadUi. ui/index.html loads the new script, and documentation files (AGENTS.md, docs/directory.md, refactor_appjs.md) were updated to reflect the new module and responsibilities. The new module encapsulates status rendering, progress polling/cancel, file lookups, start/finish flows, and requires dependencies (fetchJson, confirmAction, refreshModels, applyPresetModel, refreshQuickLaunchUI, flagCore) injected via configure().