### PR TITLE
Extract remote tunnel UI to module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,7 @@ with the primary file and only touch secondary files if the change requires it.
 | Chat markdown/rendering helpers | `ui/js/chat-rendering.js` | `ui/js/app.js` (chat state/controller) |
 | API tab docs/snippets | `ui/js/api-tab.js` | `ui/js/app.js` (status/init), `ui/js/flag-core.js` (state reads) |
 | HF download UI | `ui/js/hf-download-ui.js` | `ui/js/app.js` (callbacks), `ui/js/manager.js` (fetchJson) |
+| Remote tunnel UI | `ui/js/remote-tunnel-ui.js` | `ui/js/app.js` (init), `ui/js/api-tab.js` (endpoint config), `ui/js/manager.js` (fetchJson) |
 | Chat template presets | `ui/js/flags.js` | `ui/js/app.js` (mapping helpers) |
 | Sampler presets | `ui/js/app.js` | `ui/js/flag-core.js` (apply) |
 | Preset save/load/import/export | `ui/js/presets.js` | `ui/js/flag-core.js` (collect/apply) |
@@ -216,7 +217,8 @@ The frontend loads scripts in a strict dependency order via `ui/index.html`:
 8. `chat-rendering.js` — markdown and low-level chat DOM rendering helpers (`window.LlamaGui.chatRendering`)
 9. `api-tab.js` — API endpoint/snippet rendering helpers (`window.LlamaGui.apiTab`)
 10. `hf-download-ui.js` — Quick Launch Hugging Face downloader UI (`window.LlamaGui.hfDownloadUi`)
-11. `app.js` — main orchestration (wires everything together)
+11. `remote-tunnel-ui.js` — API tab Cloudflare tunnel UI (`window.LlamaGui.remoteTunnelUi`)
+12. `app.js` — main orchestration (wires everything together)
 
 **Do not change this order.** Each file depends on the ones above it. If you
 add a new module, place it after its dependencies and before its consumers.
@@ -278,10 +280,11 @@ private closure variables.
 
 ### Frontend
 - **`ui/index.html`**: HTML template defining the tabbed layout and UI structure.
-- **`ui/js/app.js`**: Main UI orchestration. Manages tab switching, server launch/stop, output polling, stats polling, chat state/controller (streaming, web search, conversation history), Quick Launch profiles/sampler presets, remote tunnel, toasts, and cache-busting reload.
+- **`ui/js/app.js`**: Main UI orchestration. Manages tab switching, server launch/stop, output polling, stats polling, chat state/controller (streaming, web search, conversation history), Quick Launch profiles/sampler presets, toasts, and cache-busting reload.
 - **`ui/js/chat-rendering.js`**: Markdown and low-level chat DOM rendering helpers exposed as `window.LlamaGui.chatRendering`.
 - **`ui/js/api-tab.js`**: API tab endpoint/snippet data, base URL helpers, and rendering exposed as `window.LlamaGui.apiTab`; reads shared state through injected `flagCore`.
 - **`ui/js/hf-download-ui.js`**: Quick Launch Hugging Face downloader controls, status rendering, progress polling, cancel handling, and completion flow exposed as `window.LlamaGui.hfDownloadUi`; receives shared utilities and `flagCore` from `app.js`.
+- **`ui/js/remote-tunnel-ui.js`**: API tab Cloudflare tunnel controls, status rendering, URL rendering, copy wiring, start/stop actions, and polling exposed as `window.LlamaGui.remoteTunnelUi`; receives shared utilities and endpoint helpers from `app.js`.
 - **`ui/js/flags.js`**: Single source of truth for exposed `llama.cpp` flags, flag categories, data types, built-in chat templates, chat template presets, sampler presets, and quick launch profiles.
 - **`ui/js/flag-core.js`**: Shared frontend flag state and launch-argument core. Owns `currentTool`, selected model, `flagValues`, shared setters, custom launch args parsing, preset apply/collect helpers, `getLaunchArgs()`, and command preview generation.
 - **`ui/js/config-flags-ui.js`**: Configure tab flag rendering, search/filtering, expand/collapse state, type-specific flag input builders, input restoration, and high-risk `multi_enum` warnings.
@@ -631,6 +634,8 @@ The API tab includes Cloudflare tunnel integration for exposing `llama-server` t
 - CORS origin is updated to include the active tunnel URL.
 
 ### Frontend
+
+Frontend tunnel controls, status rendering, URL rendering, copy wiring, start/stop actions, and polling live in `ui/js/remote-tunnel-ui.js`. `app.js` injects `fetchJson`, `copyText`, and `getServerEndpointConfig`.
 
 - Start/stop buttons with disabled states during transitions.
 - Polls tunnel status every 2 seconds while running/starting.

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -28,7 +28,8 @@
 | `ui/js/chat-rendering.js` | Markdown and low-level chat DOM rendering helpers exposed as `window.LlamaGui.chatRendering` |
 | `ui/js/api-tab.js` | API tab endpoint/snippet data, base URL helpers, and rendering exposed as `window.LlamaGui.apiTab` |
 | `ui/js/hf-download-ui.js` | Quick Launch Hugging Face downloader controls, status rendering, progress polling, cancel handling, and completion flow exposed as `window.LlamaGui.hfDownloadUi` |
-| `ui/js/app.js` | Main UI orchestration: tab switching, launch/stop flow, chat state/controller (streaming, web search, history), Quick Launch/sampler preset behavior, remote tunnel, stats polling, toasts |
+| `ui/js/remote-tunnel-ui.js` | API tab Cloudflare tunnel controls, status rendering, URL rendering, copy wiring, start/stop actions, and polling exposed as `window.LlamaGui.remoteTunnelUi` |
+| `ui/js/app.js` | Main UI orchestration: tab switching, launch/stop flow, chat state/controller (streaming, web search, history), Quick Launch/sampler preset behavior, stats polling, toasts |
 | `ui/js/flags/` | Ordered flag modules for exposed llama.cpp flag categories, option lists, chat template presets, flag definitions, and flag helpers |
 | `ui/js/flag-core.js` | Shared frontend flag state and launch-argument core (`currentTool`, selected model, `flagValues`, setters, preset apply/collect helpers, command preview generation) |
 | `ui/js/config-flags-ui.js` | Configure tab flag rendering, search/filtering, expand/collapse state, type-specific flag input builders, input restoration, and high-risk `multi_enum` warnings |
@@ -73,7 +74,7 @@ Frontend modules are still loaded as ordered global scripts rather than ES modul
 
 - API endpoint cards and copy-ready snippets live in `ui/js/api-tab.js`
 - The module reads host, port, alias, selected model, API key, and current tool from shared `flagCore` state
-- `app.js` injects shared utilities/status access and still initializes remote tunnel controls until that later refactor phase
+- `app.js` injects shared utilities/status access and initializes the remote tunnel module
 
 ## Hugging Face Download
 
@@ -87,6 +88,7 @@ Integrated model downloader in the Quick Launch tab:
 ## Cloudflare Tunnel
 
 Remote tunnel in the API tab:
+- Frontend controls, status rendering, URL rendering, copy wiring, start/stop actions, and polling live in `ui/js/remote-tunnel-ui.js`
 - Auto-downloads `cloudflared` binary on first use
 - Tunnel URL is added to allowed CORS origins
 - Status polling every 2 seconds while running/starting

--- a/refactor_appjs.md
+++ b/refactor_appjs.md
@@ -152,7 +152,9 @@ Status: Completed. `ui/js/hf-download-ui.js` now owns the Hugging Face downloade
 - Confirm error/status messages are unchanged or clearer.
 - Confirm the module does not directly mutate `flagValues`.
 
-## Phase 4: Extract Remote Tunnel UI
+## Phase 4: Extract Remote Tunnel UI - Done
+
+Status: Completed. `ui/js/remote-tunnel-ui.js` now owns remote tunnel controls, status rendering, URL rendering, copy wiring, start/stop actions, and polling through `window.LlamaGui.remoteTunnelUi`, with shared utilities injected from `app.js`.
 
 Remote tunnel controls are a good next extraction because they own a distinct timer, status renderer, and backend route set.
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -821,6 +821,7 @@
 <script src="/js/chat-rendering.js?v=revamp-1"></script>
 <script src="/js/api-tab.js?v=revamp-1"></script>
 <script src="/js/hf-download-ui.js?v=revamp-1"></script>
+<script src="/js/remote-tunnel-ui.js?v=revamp-1"></script>
 <script src="/js/app.js?v=revamp-1"></script>
 </body>
 </html>

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -14,7 +14,6 @@ let pollOutputActive = false;
 let pollStatsActive = false;
 let pollOutputFailCount = 0;
 let serverReadyNotified = false;
-let remoteTunnelTimer = null;
 
 let selectedChatTemplatePresetValue = "";
 
@@ -46,6 +45,12 @@ const {
 } = apiTab;
 const initApiTab = apiTab.init;
 const updateApiEndpoints = apiTab.updateEndpoints;
+const remoteTunnelUi = window.LlamaGui.remoteTunnelUi;
+remoteTunnelUi.configure({
+    fetchJson,
+    copyText,
+    getServerEndpointConfig,
+});
 const hfDownloadUi = window.LlamaGui.hfDownloadUi;
 hfDownloadUi.configure({
     flagCore,
@@ -1118,7 +1123,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     initCustomLaunchArgsControls();
     initInstallButtons();
     initApiTab();
-    initRemoteTunnelControls();
+    remoteTunnelUi.init();
     initPresetImport();
     initPresetLibraryControls();
     initQuickLaunch();
@@ -1186,7 +1191,7 @@ function switchTab(tabId) {
     if (tabId === "api") {
         Promise.resolve(checkStatus()).finally(() => {
             updateApiEndpoints();
-            refreshRemoteTunnelStatus();
+            remoteTunnelUi.refreshStatus();
         });
     }
 }
@@ -1197,143 +1202,6 @@ function initToolSelect() {
     toolSel.addEventListener("change", () => {
         flagCore.setCurrentTool(toolSel.value);
     });
-}
-
-function initRemoteTunnelControls() {
-    const startBtn = document.getElementById("btn-start-remote-tunnel");
-    const stopBtn = document.getElementById("btn-stop-remote-tunnel");
-    const copyBtn = document.getElementById("btn-copy-remote-tunnel");
-    const copyOpenAiBtn = document.getElementById("btn-copy-remote-openai");
-    if (!startBtn || !stopBtn) return;
-
-    startBtn.addEventListener("click", startRemoteTunnel);
-    stopBtn.addEventListener("click", stopRemoteTunnel);
-    if (copyBtn) {
-        copyBtn.addEventListener("click", () => {
-            const link = document.getElementById("remote-tunnel-url");
-            copyText(link ? link.href : "");
-        });
-    }
-    if (copyOpenAiBtn) {
-        copyOpenAiBtn.addEventListener("click", () => {
-            const link = document.getElementById("remote-openai-url");
-            copyText(link ? link.href : "");
-        });
-    }
-    refreshRemoteTunnelStatus();
-}
-
-function setRemoteTunnelPolling(enabled) {
-    if (enabled && !remoteTunnelTimer) {
-        remoteTunnelTimer = setInterval(refreshRemoteTunnelStatus, 2000);
-    } else if (!enabled && remoteTunnelTimer) {
-        clearInterval(remoteTunnelTimer);
-        remoteTunnelTimer = null;
-    }
-}
-
-function renderRemoteTunnelStatus(state) {
-    const status = state && state.status ? state.status : "idle";
-    const url = state && state.url ? state.url : "";
-    const message = state && state.message ? state.message : "Remote tunnel is not running.";
-    const startBtn = document.getElementById("btn-start-remote-tunnel");
-    const stopBtn = document.getElementById("btn-stop-remote-tunnel");
-    const badge = document.getElementById("remote-tunnel-badge");
-    const statusEl = document.getElementById("remote-tunnel-status");
-    const urlRow = document.getElementById("remote-tunnel-url-row");
-    const urlLink = document.getElementById("remote-tunnel-url");
-    const openAiRow = document.getElementById("remote-openai-url-row");
-    const openAiLink = document.getElementById("remote-openai-url");
-
-    const isWorking = status === "preparing" || status === "downloading" || status === "starting";
-    const isRunning = status === "running";
-    const isError = status === "error";
-
-    if (badge) {
-        badge.textContent = status.replace(/-/g, " ");
-        badge.classList.toggle("running", isRunning);
-        badge.classList.toggle("working", isWorking);
-        badge.classList.toggle("error", isError);
-    }
-    if (statusEl) {
-        statusEl.textContent = message;
-    }
-    if (urlRow && urlLink) {
-        if (url) {
-            urlLink.href = url;
-            urlLink.textContent = url;
-            urlRow.classList.remove("hidden");
-        } else {
-            urlLink.href = "#";
-            urlLink.textContent = "";
-            urlRow.classList.add("hidden");
-        }
-    }
-    if (openAiRow && openAiLink) {
-        if (url) {
-            const apiUrl = url.replace(/\/+$/, "") + "/v1";
-            openAiLink.href = apiUrl;
-            openAiLink.textContent = apiUrl;
-            openAiRow.classList.remove("hidden");
-        } else {
-            openAiLink.href = "#";
-            openAiLink.textContent = "";
-            openAiRow.classList.add("hidden");
-        }
-    }
-    if (startBtn) {
-        startBtn.disabled = isWorking || isRunning;
-        startBtn.textContent = isWorking ? "Starting..." : "Start Tunnel";
-    }
-    if (stopBtn) {
-        stopBtn.classList.toggle("hidden", !(isWorking || isRunning));
-        stopBtn.disabled = false;
-    }
-
-    setRemoteTunnelPolling(isWorking || isRunning);
-}
-
-async function refreshRemoteTunnelStatus() {
-    try {
-        const state = await fetchJson("/api/remote-tunnel/status");
-        renderRemoteTunnelStatus(state);
-        return state;
-    } catch (e) {
-        renderRemoteTunnelStatus({ status: "error", message: "Failed to read remote tunnel status: " + e.message });
-        return null;
-    }
-}
-
-async function startRemoteTunnel() {
-    renderRemoteTunnelStatus({ status: "starting", message: "Starting Cloudflare tunnel..." });
-    try {
-        const endpoint = getServerEndpointConfig();
-        const state = await fetchJson("/api/remote-tunnel/start", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                host: endpoint.host,
-                port: endpoint.port,
-            }),
-        });
-        renderRemoteTunnelStatus(state);
-        setRemoteTunnelPolling(true);
-    } catch (e) {
-        renderRemoteTunnelStatus({ status: "error", message: "Failed to start remote tunnel: " + e.message });
-    }
-}
-
-async function stopRemoteTunnel() {
-    try {
-        const state = await fetchJson("/api/remote-tunnel/stop", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({}),
-        });
-        renderRemoteTunnelStatus(state);
-    } catch (e) {
-        renderRemoteTunnelStatus({ status: "error", message: "Failed to stop remote tunnel: " + e.message });
-    }
 }
 
 function initConfigControls() {

--- a/ui/js/remote-tunnel-ui.js
+++ b/ui/js/remote-tunnel-ui.js
@@ -1,0 +1,172 @@
+(function () {
+    "use strict";
+
+    let remoteTunnelTimer = null;
+    let deps = {};
+
+    function configure(nextDeps) {
+        deps = Object.assign({}, deps, nextDeps || {});
+    }
+
+    function requireDependency(name) {
+        const value = deps[name];
+        if (typeof value !== "function") {
+            throw new Error(`Remote tunnel dependency missing: ${name}`);
+        }
+        return value;
+    }
+
+    function setPolling(enabled) {
+        if (enabled && !remoteTunnelTimer) {
+            remoteTunnelTimer = setInterval(refreshStatus, 2000);
+        } else if (!enabled && remoteTunnelTimer) {
+            clearInterval(remoteTunnelTimer);
+            remoteTunnelTimer = null;
+        }
+    }
+
+    function renderStatus(state) {
+        const status = state && state.status ? state.status : "idle";
+        const url = state && state.url ? state.url : "";
+        const message = state && state.message ? state.message : "Remote tunnel is not running.";
+        const startBtn = document.getElementById("btn-start-remote-tunnel");
+        const stopBtn = document.getElementById("btn-stop-remote-tunnel");
+        const badge = document.getElementById("remote-tunnel-badge");
+        const statusEl = document.getElementById("remote-tunnel-status");
+        const urlRow = document.getElementById("remote-tunnel-url-row");
+        const urlLink = document.getElementById("remote-tunnel-url");
+        const openAiRow = document.getElementById("remote-openai-url-row");
+        const openAiLink = document.getElementById("remote-openai-url");
+
+        const isWorking = status === "preparing" || status === "downloading" || status === "starting";
+        const isRunning = status === "running";
+        const isError = status === "error";
+
+        if (badge) {
+            badge.textContent = status.replace(/-/g, " ");
+            badge.classList.toggle("running", isRunning);
+            badge.classList.toggle("working", isWorking);
+            badge.classList.toggle("error", isError);
+        }
+        if (statusEl) {
+            statusEl.textContent = message;
+        }
+        if (urlRow && urlLink) {
+            if (url) {
+                urlLink.href = url;
+                urlLink.textContent = url;
+                urlRow.classList.remove("hidden");
+            } else {
+                urlLink.href = "#";
+                urlLink.textContent = "";
+                urlRow.classList.add("hidden");
+            }
+        }
+        if (openAiRow && openAiLink) {
+            if (url) {
+                const apiUrl = url.replace(/\/+$/, "") + "/v1";
+                openAiLink.href = apiUrl;
+                openAiLink.textContent = apiUrl;
+                openAiRow.classList.remove("hidden");
+            } else {
+                openAiLink.href = "#";
+                openAiLink.textContent = "";
+                openAiRow.classList.add("hidden");
+            }
+        }
+        if (startBtn) {
+            startBtn.disabled = isWorking || isRunning;
+            startBtn.textContent = isWorking ? "Starting..." : "Start Tunnel";
+        }
+        if (stopBtn) {
+            stopBtn.classList.toggle("hidden", !(isWorking || isRunning));
+            stopBtn.disabled = false;
+        }
+
+        setPolling(isWorking || isRunning);
+    }
+
+    async function refreshStatus() {
+        const fetchJson = requireDependency("fetchJson");
+        try {
+            const state = await fetchJson("/api/remote-tunnel/status");
+            renderStatus(state);
+            return state;
+        } catch (e) {
+            renderStatus({ status: "error", message: "Failed to read remote tunnel status: " + e.message });
+            return null;
+        }
+    }
+
+    async function start() {
+        const fetchJson = requireDependency("fetchJson");
+        const getServerEndpointConfig = requireDependency("getServerEndpointConfig");
+
+        renderStatus({ status: "starting", message: "Starting Cloudflare tunnel..." });
+        try {
+            const endpoint = getServerEndpointConfig();
+            const state = await fetchJson("/api/remote-tunnel/start", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    host: endpoint.host,
+                    port: endpoint.port,
+                }),
+            });
+            renderStatus(state);
+            setPolling(true);
+        } catch (e) {
+            renderStatus({ status: "error", message: "Failed to start remote tunnel: " + e.message });
+        }
+    }
+
+    async function stop() {
+        const fetchJson = requireDependency("fetchJson");
+        try {
+            const state = await fetchJson("/api/remote-tunnel/stop", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({}),
+            });
+            renderStatus(state);
+        } catch (e) {
+            renderStatus({ status: "error", message: "Failed to stop remote tunnel: " + e.message });
+        }
+    }
+
+    function init() {
+        const copyText = requireDependency("copyText");
+        const startBtn = document.getElementById("btn-start-remote-tunnel");
+        const stopBtn = document.getElementById("btn-stop-remote-tunnel");
+        const copyBtn = document.getElementById("btn-copy-remote-tunnel");
+        const copyOpenAiBtn = document.getElementById("btn-copy-remote-openai");
+        if (!startBtn || !stopBtn) return;
+
+        startBtn.addEventListener("click", start);
+        stopBtn.addEventListener("click", stop);
+        if (copyBtn) {
+            copyBtn.addEventListener("click", () => {
+                const link = document.getElementById("remote-tunnel-url");
+                copyText(link ? link.href : "");
+            });
+        }
+        if (copyOpenAiBtn) {
+            copyOpenAiBtn.addEventListener("click", () => {
+                const link = document.getElementById("remote-openai-url");
+                copyText(link ? link.href : "");
+            });
+        }
+        refreshStatus();
+    }
+
+    window.LlamaGui = window.LlamaGui || {};
+    window.LlamaGui.remoteTunnelUi = {
+        configure,
+        init,
+        setPolling,
+        renderStatus,
+        refreshStatus,
+        start,
+        stop,
+    };
+})();


### PR DESCRIPTION
Move remote tunnel UI logic into a new ui/js/remote-tunnel-ui.js module and wire it up from app.js. Removed remote tunnel functions/timer from ui/js/app.js and instead configure/init window.LlamaGui.remoteTunnelUi (injecting fetchJson, copyText, getServerEndpointConfig). Added script include in ui/index.html and updated docs (AGENTS.md, docs/directory.md, refactor_appjs.md) to reflect the new module and its responsibilities.