### PR TITLE
Move Quick Launch UI into quick-launch-ui.js

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,7 @@ If a shared control becomes unreliable, prefer removing the duplicate UI over ke
 
 ### Adding a New Quick Launch Profile
 
-1. Add an entry to `QUICK_PROFILES` in `app.js`.
+1. Add an entry to `QUICK_PROFILES` in `ui/js/app-data.js`.
 2. Set `tool`, `flagValues`, `fitLinked`, and `samplerPresetName`.
 3. Verify applying the profile updates Configure, Chat, and command preview.
 4. Verify the profile summary text is accurate.
@@ -186,11 +186,11 @@ with the primary file and only touch secondary files if the change requires it.
 | Shared flag state | `ui/js/flag-core.js` | `ui/js/app.js` (callbacks) |
 | Launch args / command preview | `ui/js/flag-core.js` | `ui/js/app.js` (render) |
 | Configure tab rendering | `ui/js/config-flags-ui.js` | `ui/js/flag-core.js` (state) |
-| Quick Launch controls | `ui/js/app.js` | `ui/js/flag-core.js` (state) |
+| Quick Launch controls | `ui/js/quick-launch-ui.js` | `ui/js/app.js` (init/callbacks), `ui/js/flag-core.js` (state) |
 | Chat sidebar samplers | `ui/js/app.js` | `ui/js/flag-core.js` (state) |
 | Chat markdown/rendering helpers | `ui/js/chat-rendering.js` | `ui/js/app.js` (chat state/controller) |
 | API tab docs/snippets | `ui/js/api-tab.js` | `ui/js/app.js` (status/init), `ui/js/flag-core.js` (state reads) |
-| HF download UI | `ui/js/hf-download-ui.js` | `ui/js/app.js` (callbacks), `ui/js/manager.js` (fetchJson) |
+| HF download UI | `ui/js/hf-download-ui.js` | `ui/js/quick-launch-ui.js` (init), `ui/js/app.js` (callbacks), `ui/js/manager.js` (fetchJson) |
 | Remote tunnel UI | `ui/js/remote-tunnel-ui.js` | `ui/js/app.js` (init), `ui/js/api-tab.js` (endpoint config), `ui/js/manager.js` (fetchJson) |
 | Chat template presets | `ui/js/flags.js` | `ui/js/app.js` (mapping helpers) |
 | Sampler presets | `ui/js/app.js` | `ui/js/flag-core.js` (apply) |
@@ -218,7 +218,8 @@ The frontend loads scripts in a strict dependency order via `ui/index.html`:
 9. `api-tab.js` — API endpoint/snippet rendering helpers (`window.LlamaGui.apiTab`)
 10. `hf-download-ui.js` — Quick Launch Hugging Face downloader UI (`window.LlamaGui.hfDownloadUi`)
 11. `remote-tunnel-ui.js` — API tab Cloudflare tunnel UI (`window.LlamaGui.remoteTunnelUi`)
-12. `app.js` — main orchestration (wires everything together)
+12. `quick-launch-ui.js` — Quick Launch controls and shared-state UI sync (`window.LlamaGui.quickLaunchUi`)
+13. `app.js` — main orchestration (wires everything together)
 
 **Do not change this order.** Each file depends on the ones above it. If you
 add a new module, place it after its dependencies and before its consumers.
@@ -280,11 +281,12 @@ private closure variables.
 
 ### Frontend
 - **`ui/index.html`**: HTML template defining the tabbed layout and UI structure.
-- **`ui/js/app.js`**: Main UI orchestration. Manages tab switching, server launch/stop, output polling, stats polling, chat state/controller (streaming, web search, conversation history), Quick Launch profiles/sampler presets, toasts, and cache-busting reload.
+- **`ui/js/app.js`**: Main UI orchestration. Manages tab switching, server launch/stop, output polling, stats polling, chat state/controller (streaming, web search, conversation history), shared sampler/template helpers, toasts, and cache-busting reload.
 - **`ui/js/chat-rendering.js`**: Markdown and low-level chat DOM rendering helpers exposed as `window.LlamaGui.chatRendering`.
 - **`ui/js/api-tab.js`**: API tab endpoint/snippet data, base URL helpers, and rendering exposed as `window.LlamaGui.apiTab`; reads shared state through injected `flagCore`.
 - **`ui/js/hf-download-ui.js`**: Quick Launch Hugging Face downloader controls, status rendering, progress polling, cancel handling, and completion flow exposed as `window.LlamaGui.hfDownloadUi`; receives shared utilities and `flagCore` from `app.js`.
 - **`ui/js/remote-tunnel-ui.js`**: API tab Cloudflare tunnel controls, status rendering, URL rendering, copy wiring, start/stop actions, and polling exposed as `window.LlamaGui.remoteTunnelUi`; receives shared utilities and endpoint helpers from `app.js`.
+- **`ui/js/quick-launch-ui.js`**: Quick Launch profile, context, GPU, template, sampler, metrics, command preview mirror, action buttons, and event wiring exposed as `window.LlamaGui.quickLaunchUi`; reads and writes launch state through injected `flagCore`.
 - **`ui/js/flags.js`**: Single source of truth for exposed `llama.cpp` flags, flag categories, data types, built-in chat templates, chat template presets, sampler presets, and quick launch profiles.
 - **`ui/js/flag-core.js`**: Shared frontend flag state and launch-argument core. Owns `currentTool`, selected model, `flagValues`, shared setters, custom launch args parsing, preset apply/collect helpers, `getLaunchArgs()`, and command preview generation.
 - **`ui/js/config-flags-ui.js`**: Configure tab flag rendering, search/filtering, expand/collapse state, type-specific flag input builders, input restoration, and high-risk `multi_enum` warnings.
@@ -515,7 +517,7 @@ The Quick Launch tab (`section-quick-launch`) provides a simplified launch inter
 
 ### Profiles
 
-`QUICK_PROFILES` in `app.js` provides preconfigured setups:
+`QUICK_PROFILES` in `ui/js/app-data.js` provides preconfigured setups consumed by `ui/js/quick-launch-ui.js`:
 - `safe-defaults` / `balanced`: 16K context, auto GPU, auto-fit, Balanced sampler preset
 - `low-memory`: 8K context, smaller batch sizes, Precise sampler preset
 - `long-context`: 32K context, auto-fit
@@ -541,7 +543,7 @@ All controls write through `window.LlamaGui.flagCore` setters (`setFlagValue()` 
 
 ### Hugging Face Download Integration
 
-The Quick Launch tab includes a full HF model downloader section:
+The Quick Launch tab includes a full HF model downloader section initialized by `ui/js/quick-launch-ui.js` and implemented in `ui/js/hf-download-ui.js`:
 - Repo ID + revision + token inputs
 - "Find Files" button fetches GGUF file listing from `/api/hf/repo-files`
 - Model and mmproj file selectors

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -24,12 +24,13 @@
 | `backend/routing.py` | Dispatch-table route matching for API routes |
 | `backend/routes/` | 14 route handler modules grouped by feature (status, models, presets, metrics, chat, search, hf_download, file_picker, process, install, tunnel, git_update, lifecycle) |
 | `backend/services/` | 10 service modules (llama_manager, process_manager, hf_download, web_search, tunnel, git_update, lifecycle, file_picker, chat) |
-| `ui/js/app-data.js` | Shared Quick Launch profile, context preset, sampler preset, and chat sampler slider data consumed by `app.js` |
+| `ui/js/app-data.js` | Shared Quick Launch profile, context preset, sampler preset, and chat sampler slider data |
 | `ui/js/chat-rendering.js` | Markdown and low-level chat DOM rendering helpers exposed as `window.LlamaGui.chatRendering` |
 | `ui/js/api-tab.js` | API tab endpoint/snippet data, base URL helpers, and rendering exposed as `window.LlamaGui.apiTab` |
 | `ui/js/hf-download-ui.js` | Quick Launch Hugging Face downloader controls, status rendering, progress polling, cancel handling, and completion flow exposed as `window.LlamaGui.hfDownloadUi` |
 | `ui/js/remote-tunnel-ui.js` | API tab Cloudflare tunnel controls, status rendering, URL rendering, copy wiring, start/stop actions, and polling exposed as `window.LlamaGui.remoteTunnelUi` |
-| `ui/js/app.js` | Main UI orchestration: tab switching, launch/stop flow, chat state/controller (streaming, web search, history), Quick Launch/sampler preset behavior, stats polling, toasts |
+| `ui/js/quick-launch-ui.js` | Quick Launch profile, context, GPU, template, sampler, metrics, command preview mirror, action buttons, and event wiring exposed as `window.LlamaGui.quickLaunchUi` |
+| `ui/js/app.js` | Main UI orchestration: tab switching, launch/stop flow, chat state/controller (streaming, web search, history), shared sampler/template helpers, stats polling, toasts |
 | `ui/js/flags/` | Ordered flag modules for exposed llama.cpp flag categories, option lists, chat template presets, flag definitions, and flag helpers |
 | `ui/js/flag-core.js` | Shared frontend flag state and launch-argument core (`currentTool`, selected model, `flagValues`, setters, preset apply/collect helpers, command preview generation) |
 | `ui/js/config-flags-ui.js` | Configure tab flag rendering, search/filtering, expand/collapse state, type-specific flag input builders, input restoration, and high-risk `multi_enum` warnings |
@@ -80,6 +81,7 @@ Frontend modules are still loaded as ordered global scripts rather than ES modul
 
 Integrated model downloader in the Quick Launch tab:
 - Frontend controls, status rendering, progress polling, cancel handling, and completion flow live in `ui/js/hf-download-ui.js`
+- Quick Launch initializes the downloader from `ui/js/quick-launch-ui.js`
 - Browse HF repos for GGUF files via `/api/hf/repo-files`
 - Download models + optional mmproj files with progress bar and cancel support
 - Path/filename validation prevents traversal attacks

--- a/refactor_appjs.md
+++ b/refactor_appjs.md
@@ -188,9 +188,11 @@ Remote tunnel controls are a good next extraction because they own a distinct ti
 - Confirm copy buttons still use the same public URL and OpenAI-compatible base URL formats.
 - Confirm no unrelated API tab or launch logic moved with this phase.
 
-## Phase 5: Extract Quick Launch UI
+## Phase 5: Extract Quick Launch UI - Done
 
 Quick Launch is high-value but riskier because it touches mirrored controls, shared flag state, sampler presets, profiles, templates, command preview, and launch buttons.
+
+Status: Completed. `ui/js/quick-launch-ui.js` now owns Quick Launch local UI state, profile/context/GPU/template/sampler controls, command preview mirroring, action button sync, and event wiring through `window.LlamaGui.quickLaunchUi`. `app.js` keeps small compatibility wrappers and shared sampler/template helpers for now.
 
 ### Implementation
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -822,6 +822,7 @@
 <script src="/js/api-tab.js?v=revamp-1"></script>
 <script src="/js/hf-download-ui.js?v=revamp-1"></script>
 <script src="/js/remote-tunnel-ui.js?v=revamp-1"></script>
+<script src="/js/quick-launch-ui.js?v=revamp-1"></script>
 <script src="/js/app.js?v=revamp-1"></script>
 </body>
 </html>

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -30,9 +30,6 @@ const CHAT_WEB_SEARCH_DEFAULT_MAX_RESULTS = 5;
 const CHAT_WEB_SEARCH_MIN_RESULTS = 1;
 const CHAT_WEB_SEARCH_MAX_RESULTS = 10;
 // Shared Quick Launch and sampler data is defined in app-data.js.
-
-let quickLaunchFitCtxLinked = true;
-let quickLaunchGpuCustomSelected = false;
 const apiTab = window.LlamaGui.apiTab;
 apiTab.configure({
     flagCore,
@@ -51,6 +48,7 @@ remoteTunnelUi.configure({
     copyText,
     getServerEndpointConfig,
 });
+const quickLaunchUi = window.LlamaGui.quickLaunchUi;
 const hfDownloadUi = window.LlamaGui.hfDownloadUi;
 hfDownloadUi.configure({
     flagCore,
@@ -59,6 +57,29 @@ hfDownloadUi.configure({
     refreshModels,
     applyPresetModel,
     refreshQuickLaunchUI,
+});
+quickLaunchUi.configure({
+    flagCore,
+    configFlagsUi,
+    hfDownloadUi,
+    debounce,
+    refreshModels,
+    applyPresetModel,
+    switchTab,
+    launchLlama,
+    stopLlama,
+    copyQuickServerUrl,
+    updateQuickServerAddressPreview,
+    setChatTemplateValue,
+    getSelectedChatTemplateDropdownValue,
+    getQuickTemplateSummaryText,
+    getAllSamplerPresets,
+    applySamplerPresetValues,
+    loadSamplerPresetStore,
+    saveSamplerPresetStore,
+    normalizeSamplerPresetValues,
+    collectSamplerValues,
+    confirmAction,
 });
 
 function getSamplerFlags() {
@@ -473,23 +494,7 @@ flagCore.configure({
         }
     },
     afterPatch(patch, options) {
-        if (Object.prototype.hasOwnProperty.call(options, "quickLaunchFitCtxLinked")) {
-            quickLaunchFitCtxLinked = options.quickLaunchFitCtxLinked;
-        } else if (Object.prototype.hasOwnProperty.call(patch || {}, "fit_ctx")
-            || Object.prototype.hasOwnProperty.call(patch || {}, "ctx_size")) {
-            const values = flagCore.getFlagValues();
-            const fitCtx = values.fit_ctx;
-            const ctxSize = values.ctx_size;
-            quickLaunchFitCtxLinked = fitCtx === undefined || fitCtx === ctxSize;
-        }
-
-        if (Object.prototype.hasOwnProperty.call(options, "quickLaunchGpuCustomSelected")) {
-            quickLaunchGpuCustomSelected = options.quickLaunchGpuCustomSelected;
-        } else if (Object.prototype.hasOwnProperty.call(patch || {}, "gpu_layers")) {
-            const values = flagCore.getFlagValues();
-            const gpuLayers = String(values.gpu_layers ?? "auto");
-            quickLaunchGpuCustomSelected = gpuLayers !== "auto" && gpuLayers !== "0" && gpuLayers !== "all";
-        }
+        quickLaunchUi.afterPatch(patch, options);
     },
     afterApply(values) {
         selectedChatTemplatePresetValue = "";
@@ -500,9 +505,7 @@ flagCore.configure({
             const builtin = getChatTemplatePresetByBuiltinName(values.chat_template);
             if (builtin) selectedChatTemplatePresetValue = builtin.value;
         }
-        const fitCtx = values.fit_ctx;
-        const ctxSize = values.ctx_size;
-        quickLaunchFitCtxLinked = fitCtx === undefined || fitCtx === ctxSize;
+        quickLaunchUi.afterApply(values);
     },
     postUpdate: syncUiAfterSharedStateChange,
 });
@@ -522,111 +525,6 @@ async function browseForPathFlag(flag) {
     });
     if (!result || !result.selected || !result.path) return "";
     return String(result.path);
-}
-
-function populateQuickTemplatePackOptions() {
-    const select = document.getElementById("quick-template-pack");
-    if (!select) return;
-
-    select.innerHTML = "";
-    const chatTemplateFlag = FLAGS.find((f) => f.id === "chat_template");
-    for (const pack of chatTemplateFlag?.options || []) {
-        const opt = document.createElement("option");
-        opt.value = pack.value;
-        opt.textContent = pack.label;
-        select.appendChild(opt);
-    }
-}
-
-function syncQuickLaunchModelOptions() {
-    const mainSelect = document.getElementById("model-select");
-    const quickSelect = document.getElementById("quick-model-select");
-    if (!mainSelect || !quickSelect) return;
-
-    const currentQuickValue = quickSelect.value;
-    quickSelect.innerHTML = "";
-    for (const option of Array.from(mainSelect.options)) {
-        quickSelect.appendChild(option.cloneNode(true));
-    }
-
-    const preferredValue = mainSelect.value || currentQuickValue || "";
-    const hasPreferredValue = Array.from(quickSelect.options).some((opt) => opt.value === preferredValue);
-    quickSelect.value = hasPreferredValue ? preferredValue : "";
-    flagCore.setSelectedModelValue(mainSelect.value || "");
-}
-
-function applyQuickTemplatePack(templateValue) {
-    setChatTemplateValue(templateValue);
-}
-
-function getSelectedQuickSamplerEntry() {
-    const select = document.getElementById("quick-sampler-select");
-    if (!select || !select.value) return null;
-    const [source, ...nameParts] = String(select.value).split("|");
-    const name = nameParts.join("|");
-    return getAllSamplerPresets().find((entry) => entry.source === source && entry.name === name) || null;
-}
-
-function refreshQuickSamplerPresetSelect() {
-    const select = document.getElementById("quick-sampler-select");
-    if (!select) return;
-
-    const previous = select.value;
-    const entries = getAllSamplerPresets();
-    const builtins = entries.filter((entry) => entry.source === "builtin");
-    const customs = entries.filter((entry) => entry.source === "custom");
-
-    select.innerHTML = "";
-
-    const placeholder = document.createElement("option");
-    placeholder.value = "";
-    placeholder.textContent = entries.length ? "-- Select Sampler Preset --" : "No sampler presets";
-    select.appendChild(placeholder);
-
-    if (builtins.length) {
-        const group = document.createElement("optgroup");
-        group.label = "Built-in";
-        for (const preset of builtins) {
-            const opt = document.createElement("option");
-            opt.value = `builtin|${preset.name}`;
-            opt.textContent = preset.name;
-            group.appendChild(opt);
-        }
-        select.appendChild(group);
-    }
-
-    if (customs.length) {
-        const group = document.createElement("optgroup");
-        group.label = "Custom";
-        for (const preset of customs) {
-            const opt = document.createElement("option");
-            opt.value = `custom|${preset.name}`;
-            opt.textContent = preset.name;
-            group.appendChild(opt);
-        }
-        select.appendChild(group);
-    }
-
-    const hasPrevious = Array.from(select.options).some((opt) => opt.value === previous);
-    if (hasPrevious) {
-        select.value = previous;
-    }
-}
-
-function applyQuickProfile(profileId) {
-    const profile = QUICK_PROFILES[profileId];
-    if (!profile) return;
-
-    flagCore.setCurrentTool(profile.tool || "llama-server");
-    flagCore.setMultipleFlagValues(profile.flags || {}, { quickLaunchFitCtxLinked: true });
-
-    if (profile.samplerPresetName) {
-        const preset = getAllSamplerPresets().find((entry) => entry.name === profile.samplerPresetName);
-        if (preset) {
-            applySamplerPresetValues(preset.values);
-            return;
-        }
-    }
 }
 
 function normalizeTemplatePathValue(value) {
@@ -745,375 +643,24 @@ function setReasoningMode(value, options = {}) {
     flagCore.setFlagValue("reasoning", normalized, options);
 }
 
-function setQuickLaunchContextValue(rawValue, options = {}) {
-    const parsed = rawValue === "" || rawValue === null || rawValue === undefined
-        ? undefined
-        : parseInt(rawValue, 10);
-    const nextCtxSize = Number.isFinite(parsed) ? parsed : undefined;
-    const patch = { ctx_size: nextCtxSize };
-
-    if (quickLaunchFitCtxLinked || options.forceFitSync) {
-        patch.fit_ctx = nextCtxSize;
-    }
-
-    flagCore.setMultipleFlagValues(patch);
-}
-
-function setQuickLaunchGpuLayers(value) {
-    if (value === "custom") {
-        const customInput = document.getElementById("quick-gpu-custom");
-        const customValue = String(customInput && customInput.value ? customInput.value : "").trim();
-        const normalized = flagCore.normalizeGpuLayersValue(customValue);
-        if (customInput) {
-            customInput.setCustomValidity(customValue && normalized === undefined ? "Use auto, all, 0, or a non-negative integer." : "");
-        }
-        if (normalized !== undefined) {
-            flagCore.setFlagValue("gpu_layers", normalized, { quickLaunchGpuCustomSelected: true });
-        } else {
-            quickLaunchGpuCustomSelected = true;
-            flagCore.setFlagValue("gpu_layers", undefined, { quickLaunchGpuCustomSelected: true });
-        }
-    } else {
-        flagCore.setFlagValue("gpu_layers", value || "auto", { quickLaunchGpuCustomSelected: false });
-    }
-}
-
 function updateQuickLaunchActionButtons() {
-    const quickLaunchBtn = document.getElementById("btn-quick-launch");
-    const quickStopBtn = document.getElementById("btn-quick-stop");
-    const mainLaunchBtn = document.getElementById("btn-launch");
-    const mainStopBtn = document.getElementById("btn-stop");
-    if (!quickLaunchBtn || !quickStopBtn || !mainLaunchBtn || !mainStopBtn) return;
+    quickLaunchUi.updateActionButtons();
+}
 
-    quickLaunchBtn.classList.toggle("hidden", mainLaunchBtn.classList.contains("hidden"));
-    quickStopBtn.classList.toggle("hidden", mainStopBtn.classList.contains("hidden"));
+function syncQuickLaunchModelOptions() {
+    quickLaunchUi.syncModelOptions();
+}
+
+function refreshQuickSamplerPresetSelect() {
+    quickLaunchUi.refreshSamplerPresetSelect();
 }
 
 function refreshQuickLaunchUI() {
-    const quickCommand = document.getElementById("quick-command-preview");
-    if (!quickCommand) return;
-    const values = flagCore.getFlagValues();
-    const tool = flagCore.getCurrentTool();
-
-    if (quickLaunchFitCtxLinked !== false) {
-        quickLaunchFitCtxLinked = values.fit_ctx === undefined || values.fit_ctx === values.ctx_size;
-    }
-    syncQuickLaunchModelOptions();
-    refreshQuickSamplerPresetSelect();
-
-    const mainModelSelect = document.getElementById("model-select");
-    const quickModelSelect = document.getElementById("quick-model-select");
-    if (quickModelSelect && mainModelSelect) {
-        quickModelSelect.value = mainModelSelect.value || "";
-        flagCore.setSelectedModelValue(mainModelSelect.value || "");
-    }
-
-    for (const radio of document.querySelectorAll('input[name="quick-launch-mode"]')) {
-        radio.checked = radio.value === tool;
-    }
-
-    const modeSummary = document.getElementById("quick-mode-summary");
-    if (modeSummary) {
-        modeSummary.textContent = tool === "llama-server"
-            ? "API Server is selected. This exposes the web UI and OpenAI-compatible endpoints."
-            : "Chat mode is selected. The process runs as an interactive local terminal chat.";
-    }
-
-    const ctxValue = values.ctx_size ?? 16000;
-    const contextPreset = document.getElementById("quick-context-preset");
-    const contextCustom = document.getElementById("quick-context-custom");
-    if (contextPreset && contextCustom) {
-        const ctxString = String(ctxValue);
-        if (QUICK_CONTEXT_PRESETS.includes(ctxString)) {
-            contextPreset.value = ctxString;
-            contextCustom.value = "";
-            contextCustom.disabled = true;
-        } else {
-            contextPreset.value = "custom";
-            contextCustom.value = ctxString;
-            contextCustom.disabled = false;
-        }
-    }
-
-    const gpuMode = document.getElementById("quick-gpu-mode");
-    const gpuCustom = document.getElementById("quick-gpu-custom");
-    const gpuLayers = String(values.gpu_layers ?? "auto");
-    if (gpuMode && gpuCustom) {
-        const hasCustomGpuValue = gpuLayers !== "auto" && gpuLayers !== "0" && gpuLayers !== "all";
-        if (hasCustomGpuValue) {
-            quickLaunchGpuCustomSelected = true;
-        } else if (!quickLaunchGpuCustomSelected) {
-            quickLaunchGpuCustomSelected = false;
-        }
-
-        if (!quickLaunchGpuCustomSelected && (gpuLayers === "auto" || gpuLayers === "0" || gpuLayers === "all")) {
-            gpuMode.value = gpuLayers;
-            gpuCustom.value = "";
-            gpuCustom.disabled = true;
-        } else {
-            gpuMode.value = "custom";
-            gpuCustom.value = hasCustomGpuValue ? gpuLayers : "";
-            gpuCustom.disabled = false;
-        }
-    }
-
-    const fitToggle = document.getElementById("quick-fit-toggle");
-    const fitTarget = document.getElementById("quick-fit-target");
-    const fitCtx = document.getElementById("quick-fit-ctx");
-    if (fitToggle) fitToggle.value = String(values.fit ?? "on");
-    if (fitTarget) fitTarget.value = String(values.fit_target ?? "1024");
-    if (fitCtx) fitCtx.value = values.fit_ctx ?? "";
-
-    const fitSummary = document.getElementById("quick-fit-summary");
-    if (fitSummary) {
-        fitSummary.textContent = String(values.fit ?? "on") === "on"
-            ? `Auto Fit will leave about ${values.fit_target ?? "1024"} MiB free and will not shrink below ${values.fit_ctx ?? ctxValue} context.`
-            : "Auto Fit is off, so llama.cpp will use your manual memory settings as-is.";
-    }
-
-    const templateSelect = document.getElementById("quick-template-pack");
-    const templateSummary = document.getElementById("quick-template-summary");
-    const selectedTemplateValue = getSelectedChatTemplateDropdownValue();
-    if (templateSelect) {
-        const hasOption = Array.from(templateSelect.options).some((opt) => opt.value === selectedTemplateValue);
-        templateSelect.value = hasOption ? selectedTemplateValue : "";
-    }
-    if (templateSummary) {
-        templateSummary.textContent = getQuickTemplateSummaryText();
-    }
-
-    const temperature = document.getElementById("quick-temperature");
-    const topK = document.getElementById("quick-top-k");
-    const topP = document.getElementById("quick-top-p");
-    const minP = document.getElementById("quick-min-p");
-    const repeatPenalty = document.getElementById("quick-repeat-penalty");
-    if (temperature) temperature.value = values.temperature ?? "";
-    if (topK) topK.value = values.top_k ?? "";
-    if (topP) topP.value = values.top_p ?? "";
-    if (minP) minP.value = values.min_p ?? "";
-    if (repeatPenalty) repeatPenalty.value = values.repeat_penalty ?? "";
-
-    const profileSummary = document.getElementById("quick-profile-summary");
-    const profileSelect = document.getElementById("quick-profile-select");
-    if (profileSummary && profileSelect) {
-        const profile = QUICK_PROFILES[profileSelect.value];
-        profileSummary.textContent = profile
-            ? profile.summary
-            : "Profiles apply a full starter setup, including context, Auto Fit, GPU offload, and sampler settings.";
-    }
-
-    const quickMetricsToggle = document.getElementById("quick-metrics-toggle");
-    if (quickMetricsToggle) quickMetricsToggle.checked = values.metrics === true;
-
-    quickCommand.textContent = document.getElementById("command-preview-text").textContent || "";
-    quickCommand.classList.toggle("command-preview-error", document.getElementById("command-preview-text").classList.contains("command-preview-error"));
-    updateQuickServerAddressPreview();
-    updateQuickLaunchActionButtons();
-}
-
-function populateQuickProfileOptions() {
-    const select = document.getElementById("quick-profile-select");
-    if (!select) return;
-
-    const previous = select.value;
-    select.innerHTML = "";
-
-    const placeholder = document.createElement("option");
-    placeholder.value = "";
-    placeholder.textContent = "Choose a profile...";
-    select.appendChild(placeholder);
-
-    for (const [profileId, profile] of Object.entries(QUICK_PROFILES)) {
-        const opt = document.createElement("option");
-        opt.value = profileId;
-        opt.textContent = profile.label;
-        select.appendChild(opt);
-    }
-
-    select.value = Object.prototype.hasOwnProperty.call(QUICK_PROFILES, previous) ? previous : "";
+    quickLaunchUi.refresh();
 }
 
 function initQuickLaunch() {
-    const on = (id, event, handler) => {
-        const el = document.getElementById(id);
-        if (el) el.addEventListener(event, handler);
-    };
-
-    populateQuickTemplatePackOptions();
-    populateQuickProfileOptions();
-    refreshQuickSamplerPresetSelect();
-    syncQuickLaunchModelOptions();
-    hfDownloadUi.init();
-
-    on("btn-open-configure", "click", () => {
-        switchTab("configure");
-    });
-
-    on("btn-quick-refresh-models", "click", () => {
-        refreshModels();
-    });
-
-    on("quick-model-select", "change", (e) => {
-        applyPresetModel(e.target.value);
-        flagCore.updateCommandPreview();
-    });
-
-    for (const radio of document.querySelectorAll('input[name="quick-launch-mode"]')) {
-        radio.addEventListener("change", () => {
-            if (radio.checked) {
-                flagCore.setCurrentTool(radio.value);
-            }
-        });
-    }
-
-    on("quick-profile-select", "change", (e) => {
-        applyQuickProfile(e.target.value);
-        refreshQuickLaunchUI();
-    });
-
-    on("quick-context-preset", "change", (e) => {
-        const customInput = document.getElementById("quick-context-custom");
-        if (e.target.value === "custom") {
-            if (customInput) { customInput.disabled = false; customInput.focus(); }
-            return;
-        }
-
-        if (customInput) { customInput.disabled = true; customInput.value = ""; }
-        setQuickLaunchContextValue(e.target.value);
-    });
-
-    on("quick-context-custom", "input", (e) => {
-        const rawValue = e.target.value.trim();
-        if (rawValue === "") return;
-        setQuickLaunchContextValue(rawValue);
-    });
-
-    on("quick-gpu-mode", "change", (e) => {
-        const gpuCustom = document.getElementById("quick-gpu-custom");
-        if (gpuCustom) {
-            gpuCustom.disabled = e.target.value !== "custom";
-            if (e.target.value === "custom") gpuCustom.focus();
-        }
-        setQuickLaunchGpuLayers(e.target.value);
-    });
-
-    on("quick-gpu-custom", "input", () => {
-        const gpuMode = document.getElementById("quick-gpu-mode");
-        if (gpuMode && gpuMode.value === "custom") {
-            setQuickLaunchGpuLayers("custom");
-        }
-    });
-
-    on("quick-fit-toggle", "change", (e) => {
-        flagCore.setFlagValue("fit", e.target.value || "on");
-    });
-
-    on("quick-fit-target", "input", (e) => {
-        flagCore.setFlagValue("fit_target", e.target.value.trim() || undefined);
-    });
-
-    on("quick-fit-ctx", "input", (e) => {
-        const rawValue = e.target.value.trim();
-        const nextFitCtx = rawValue === "" ? undefined : parseInt(rawValue, 10);
-        flagCore.setFlagValue("fit_ctx", nextFitCtx, { quickLaunchFitCtxLinked: false });
-    });
-
-    on("btn-quick-fit-sync", "click", () => {
-        const values = flagCore.getFlagValues();
-        flagCore.setFlagValue("fit_ctx", values.ctx_size ?? 16000, { quickLaunchFitCtxLinked: true });
-    });
-
-    on("quick-template-pack", "change", (e) => {
-        applyQuickTemplatePack(e.target.value);
-    });
-
-    on("btn-quick-sampler-load", "click", () => {
-        const selected = getSelectedQuickSamplerEntry();
-        if (!selected) return;
-        applySamplerPresetValues(selected.values);
-        refreshQuickLaunchUI();
-    });
-
-    on("btn-quick-sampler-save", "click", () => {
-        const nameInput = document.getElementById("quick-sampler-name");
-        if (!nameInput) return;
-        const typedName = nameInput.value.trim();
-        const selected = getSelectedQuickSamplerEntry();
-        const name = typedName || (selected && selected.source === "custom" ? selected.name : "");
-        if (!name) {
-            nameInput.focus();
-            return;
-        }
-
-        const store = loadSamplerPresetStore();
-        store[name] = normalizeSamplerPresetValues(collectSamplerValues());
-        saveSamplerPresetStore(store);
-        nameInput.value = "";
-        refreshQuickSamplerPresetSelect();
-        configFlagsUi.renderFlags();
-        const samplerSelect = document.getElementById("quick-sampler-select");
-        if (samplerSelect) samplerSelect.value = `custom|${name}`;
-    });
-
-    on("btn-quick-sampler-delete", "click", async () => {
-        const selected = getSelectedQuickSamplerEntry();
-        if (!selected) return;
-        if (selected.source !== "custom") {
-            alert("Built-in sampler presets cannot be deleted.");
-            return;
-        }
-
-        const ok = await confirmAction(
-            "Delete Sampler Preset",
-            `Delete sampler preset "${selected.name}"? This cannot be undone.`,
-            "Delete"
-        );
-        if (!ok) return;
-
-        const store = loadSamplerPresetStore();
-        delete store[selected.name];
-        saveSamplerPresetStore(store);
-        refreshQuickSamplerPresetSelect();
-        configFlagsUi.renderFlags();
-    });
-
-    const quickSamplerFieldMap = {
-        "quick-temperature": "temperature",
-        "quick-top-k": "top_k",
-        "quick-top-p": "top_p",
-        "quick-min-p": "min_p",
-        "quick-repeat-penalty": "repeat_penalty",
-    };
-
-    for (const [elementId, flagId] of Object.entries(quickSamplerFieldMap)) {
-        on(elementId, "input", debounce((e) => {
-            const rawValue = e.target.value.trim();
-            let nextValue;
-            if (rawValue === "") {
-                nextValue = undefined;
-            } else if (flagId === "top_k") {
-                nextValue = parseInt(rawValue, 10);
-            } else {
-                nextValue = parseFloat(rawValue);
-            }
-            flagCore.setFlagValue(flagId, nextValue);
-        }, 200));
-    }
-
-    on("btn-copy-quick-server-url", "click", copyQuickServerUrl);
-
-    on("quick-metrics-toggle", "change", (e) => {
-        flagCore.setFlagValue("metrics", e.target.checked);
-    });
-
-    on("btn-quick-launch", "click", async () => {
-        switchTab("configure");
-        await launchLlama();
-    });
-
-    on("btn-quick-stop", "click", stopLlama);
-
-    refreshQuickLaunchUI();
+    quickLaunchUi.init();
 }
 
 document.addEventListener("DOMContentLoaded", async () => {

--- a/ui/js/quick-launch-ui.js
+++ b/ui/js/quick-launch-ui.js
@@ -1,0 +1,560 @@
+(function () {
+    const ns = window.LlamaGui = window.LlamaGui || {};
+
+    let flagCore;
+    let configFlagsUi;
+    let hfDownloadUi;
+    let debounce = (fn) => fn;
+    let refreshModels = () => {};
+    let applyPresetModel = () => {};
+    let switchTab = () => {};
+    let launchLlama = async () => {};
+    let stopLlama = () => {};
+    let copyQuickServerUrl = () => {};
+    let updateQuickServerAddressPreview = () => {};
+    let setChatTemplateValue = () => {};
+    let getSelectedChatTemplateDropdownValue = () => "";
+    let getQuickTemplateSummaryText = () => "";
+    let getAllSamplerPresets = () => [];
+    let applySamplerPresetValues = () => {};
+    let loadSamplerPresetStore = () => ({});
+    let saveSamplerPresetStore = () => {};
+    let normalizeSamplerPresetValues = (values) => values || {};
+    let collectSamplerValues = () => ({});
+    let confirmAction = async () => false;
+
+    let quickLaunchFitCtxLinked = true;
+    let quickLaunchGpuCustomSelected = false;
+
+    function configure(options = {}) {
+        flagCore = options.flagCore || flagCore;
+        configFlagsUi = options.configFlagsUi || configFlagsUi;
+        hfDownloadUi = options.hfDownloadUi || hfDownloadUi;
+        debounce = options.debounce || debounce;
+        refreshModels = options.refreshModels || refreshModels;
+        applyPresetModel = options.applyPresetModel || applyPresetModel;
+        switchTab = options.switchTab || switchTab;
+        launchLlama = options.launchLlama || launchLlama;
+        stopLlama = options.stopLlama || stopLlama;
+        copyQuickServerUrl = options.copyQuickServerUrl || copyQuickServerUrl;
+        updateQuickServerAddressPreview = options.updateQuickServerAddressPreview || updateQuickServerAddressPreview;
+        setChatTemplateValue = options.setChatTemplateValue || setChatTemplateValue;
+        getSelectedChatTemplateDropdownValue = options.getSelectedChatTemplateDropdownValue || getSelectedChatTemplateDropdownValue;
+        getQuickTemplateSummaryText = options.getQuickTemplateSummaryText || getQuickTemplateSummaryText;
+        getAllSamplerPresets = options.getAllSamplerPresets || getAllSamplerPresets;
+        applySamplerPresetValues = options.applySamplerPresetValues || applySamplerPresetValues;
+        loadSamplerPresetStore = options.loadSamplerPresetStore || loadSamplerPresetStore;
+        saveSamplerPresetStore = options.saveSamplerPresetStore || saveSamplerPresetStore;
+        normalizeSamplerPresetValues = options.normalizeSamplerPresetValues || normalizeSamplerPresetValues;
+        collectSamplerValues = options.collectSamplerValues || collectSamplerValues;
+        confirmAction = options.confirmAction || confirmAction;
+    }
+
+    function populateTemplatePackOptions() {
+        const select = document.getElementById("quick-template-pack");
+        if (!select) return;
+
+        select.innerHTML = "";
+        const chatTemplateFlag = FLAGS.find((f) => f.id === "chat_template");
+        for (const pack of chatTemplateFlag?.options || []) {
+            const opt = document.createElement("option");
+            opt.value = pack.value;
+            opt.textContent = pack.label;
+            select.appendChild(opt);
+        }
+    }
+
+    function syncModelOptions() {
+        const mainSelect = document.getElementById("model-select");
+        const quickSelect = document.getElementById("quick-model-select");
+        if (!mainSelect || !quickSelect) return;
+
+        const currentQuickValue = quickSelect.value;
+        quickSelect.innerHTML = "";
+        for (const option of Array.from(mainSelect.options)) {
+            quickSelect.appendChild(option.cloneNode(true));
+        }
+
+        const preferredValue = mainSelect.value || currentQuickValue || "";
+        const hasPreferredValue = Array.from(quickSelect.options).some((opt) => opt.value === preferredValue);
+        quickSelect.value = hasPreferredValue ? preferredValue : "";
+        flagCore.setSelectedModelValue(mainSelect.value || "");
+    }
+
+    function getSelectedSamplerEntry() {
+        const select = document.getElementById("quick-sampler-select");
+        if (!select || !select.value) return null;
+        const [source, ...nameParts] = String(select.value).split("|");
+        const name = nameParts.join("|");
+        return getAllSamplerPresets().find((entry) => entry.source === source && entry.name === name) || null;
+    }
+
+    function refreshSamplerPresetSelect() {
+        const select = document.getElementById("quick-sampler-select");
+        if (!select) return;
+
+        const previous = select.value;
+        const entries = getAllSamplerPresets();
+        const builtins = entries.filter((entry) => entry.source === "builtin");
+        const customs = entries.filter((entry) => entry.source === "custom");
+
+        select.innerHTML = "";
+
+        const placeholder = document.createElement("option");
+        placeholder.value = "";
+        placeholder.textContent = entries.length ? "-- Select Sampler Preset --" : "No sampler presets";
+        select.appendChild(placeholder);
+
+        if (builtins.length) {
+            const group = document.createElement("optgroup");
+            group.label = "Built-in";
+            for (const preset of builtins) {
+                const opt = document.createElement("option");
+                opt.value = `builtin|${preset.name}`;
+                opt.textContent = preset.name;
+                group.appendChild(opt);
+            }
+            select.appendChild(group);
+        }
+
+        if (customs.length) {
+            const group = document.createElement("optgroup");
+            group.label = "Custom";
+            for (const preset of customs) {
+                const opt = document.createElement("option");
+                opt.value = `custom|${preset.name}`;
+                opt.textContent = preset.name;
+                group.appendChild(opt);
+            }
+            select.appendChild(group);
+        }
+
+        const hasPrevious = Array.from(select.options).some((opt) => opt.value === previous);
+        if (hasPrevious) {
+            select.value = previous;
+        }
+    }
+
+    function applyProfile(profileId) {
+        const profile = QUICK_PROFILES[profileId];
+        if (!profile) return;
+
+        flagCore.setCurrentTool(profile.tool || "llama-server");
+        flagCore.setMultipleFlagValues(profile.flags || {}, { quickLaunchFitCtxLinked: true });
+
+        if (profile.samplerPresetName) {
+            const preset = getAllSamplerPresets().find((entry) => entry.name === profile.samplerPresetName);
+            if (preset) {
+                applySamplerPresetValues(preset.values);
+            }
+        }
+    }
+
+    function setContextValue(rawValue, options = {}) {
+        const parsed = rawValue === "" || rawValue === null || rawValue === undefined
+            ? undefined
+            : parseInt(rawValue, 10);
+        const nextCtxSize = Number.isFinite(parsed) ? parsed : undefined;
+        const patch = { ctx_size: nextCtxSize };
+
+        if (quickLaunchFitCtxLinked || options.forceFitSync) {
+            patch.fit_ctx = nextCtxSize;
+        }
+
+        flagCore.setMultipleFlagValues(patch);
+    }
+
+    function setGpuLayers(value) {
+        if (value === "custom") {
+            const customInput = document.getElementById("quick-gpu-custom");
+            const customValue = String(customInput && customInput.value ? customInput.value : "").trim();
+            const normalized = flagCore.normalizeGpuLayersValue(customValue);
+            if (customInput) {
+                customInput.setCustomValidity(customValue && normalized === undefined ? "Use auto, all, 0, or a non-negative integer." : "");
+            }
+            if (normalized !== undefined) {
+                flagCore.setFlagValue("gpu_layers", normalized, { quickLaunchGpuCustomSelected: true });
+            } else {
+                quickLaunchGpuCustomSelected = true;
+                flagCore.setFlagValue("gpu_layers", undefined, { quickLaunchGpuCustomSelected: true });
+            }
+        } else {
+            flagCore.setFlagValue("gpu_layers", value || "auto", { quickLaunchGpuCustomSelected: false });
+        }
+    }
+
+    function updateActionButtons() {
+        const quickLaunchBtn = document.getElementById("btn-quick-launch");
+        const quickStopBtn = document.getElementById("btn-quick-stop");
+        const mainLaunchBtn = document.getElementById("btn-launch");
+        const mainStopBtn = document.getElementById("btn-stop");
+        if (!quickLaunchBtn || !quickStopBtn || !mainLaunchBtn || !mainStopBtn) return;
+
+        quickLaunchBtn.classList.toggle("hidden", mainLaunchBtn.classList.contains("hidden"));
+        quickStopBtn.classList.toggle("hidden", mainStopBtn.classList.contains("hidden"));
+    }
+
+    function refresh() {
+        const quickCommand = document.getElementById("quick-command-preview");
+        if (!quickCommand) return;
+        const values = flagCore.getFlagValues();
+        const tool = flagCore.getCurrentTool();
+
+        if (quickLaunchFitCtxLinked !== false) {
+            quickLaunchFitCtxLinked = values.fit_ctx === undefined || values.fit_ctx === values.ctx_size;
+        }
+        syncModelOptions();
+        refreshSamplerPresetSelect();
+
+        const mainModelSelect = document.getElementById("model-select");
+        const quickModelSelect = document.getElementById("quick-model-select");
+        if (quickModelSelect && mainModelSelect) {
+            quickModelSelect.value = mainModelSelect.value || "";
+            flagCore.setSelectedModelValue(mainModelSelect.value || "");
+        }
+
+        for (const radio of document.querySelectorAll('input[name="quick-launch-mode"]')) {
+            radio.checked = radio.value === tool;
+        }
+
+        const modeSummary = document.getElementById("quick-mode-summary");
+        if (modeSummary) {
+            modeSummary.textContent = tool === "llama-server"
+                ? "API Server is selected. This exposes the web UI and OpenAI-compatible endpoints."
+                : "Chat mode is selected. The process runs as an interactive local terminal chat.";
+        }
+
+        const ctxValue = values.ctx_size ?? 16000;
+        const contextPreset = document.getElementById("quick-context-preset");
+        const contextCustom = document.getElementById("quick-context-custom");
+        if (contextPreset && contextCustom) {
+            const ctxString = String(ctxValue);
+            if (QUICK_CONTEXT_PRESETS.includes(ctxString)) {
+                contextPreset.value = ctxString;
+                contextCustom.value = "";
+                contextCustom.disabled = true;
+            } else {
+                contextPreset.value = "custom";
+                contextCustom.value = ctxString;
+                contextCustom.disabled = false;
+            }
+        }
+
+        const gpuMode = document.getElementById("quick-gpu-mode");
+        const gpuCustom = document.getElementById("quick-gpu-custom");
+        const gpuLayers = String(values.gpu_layers ?? "auto");
+        if (gpuMode && gpuCustom) {
+            const hasCustomGpuValue = gpuLayers !== "auto" && gpuLayers !== "0" && gpuLayers !== "all";
+            if (hasCustomGpuValue) {
+                quickLaunchGpuCustomSelected = true;
+            } else if (!quickLaunchGpuCustomSelected) {
+                quickLaunchGpuCustomSelected = false;
+            }
+
+            if (!quickLaunchGpuCustomSelected && (gpuLayers === "auto" || gpuLayers === "0" || gpuLayers === "all")) {
+                gpuMode.value = gpuLayers;
+                gpuCustom.value = "";
+                gpuCustom.disabled = true;
+            } else {
+                gpuMode.value = "custom";
+                gpuCustom.value = hasCustomGpuValue ? gpuLayers : "";
+                gpuCustom.disabled = false;
+            }
+        }
+
+        const fitToggle = document.getElementById("quick-fit-toggle");
+        const fitTarget = document.getElementById("quick-fit-target");
+        const fitCtx = document.getElementById("quick-fit-ctx");
+        if (fitToggle) fitToggle.value = String(values.fit ?? "on");
+        if (fitTarget) fitTarget.value = String(values.fit_target ?? "1024");
+        if (fitCtx) fitCtx.value = values.fit_ctx ?? "";
+
+        const fitSummary = document.getElementById("quick-fit-summary");
+        if (fitSummary) {
+            fitSummary.textContent = String(values.fit ?? "on") === "on"
+                ? `Auto Fit will leave about ${values.fit_target ?? "1024"} MiB free and will not shrink below ${values.fit_ctx ?? ctxValue} context.`
+                : "Auto Fit is off, so llama.cpp will use your manual memory settings as-is.";
+        }
+
+        const templateSelect = document.getElementById("quick-template-pack");
+        const templateSummary = document.getElementById("quick-template-summary");
+        const selectedTemplateValue = getSelectedChatTemplateDropdownValue();
+        if (templateSelect) {
+            const hasOption = Array.from(templateSelect.options).some((opt) => opt.value === selectedTemplateValue);
+            templateSelect.value = hasOption ? selectedTemplateValue : "";
+        }
+        if (templateSummary) {
+            templateSummary.textContent = getQuickTemplateSummaryText();
+        }
+
+        const temperature = document.getElementById("quick-temperature");
+        const topK = document.getElementById("quick-top-k");
+        const topP = document.getElementById("quick-top-p");
+        const minP = document.getElementById("quick-min-p");
+        const repeatPenalty = document.getElementById("quick-repeat-penalty");
+        if (temperature) temperature.value = values.temperature ?? "";
+        if (topK) topK.value = values.top_k ?? "";
+        if (topP) topP.value = values.top_p ?? "";
+        if (minP) minP.value = values.min_p ?? "";
+        if (repeatPenalty) repeatPenalty.value = values.repeat_penalty ?? "";
+
+        const profileSummary = document.getElementById("quick-profile-summary");
+        const profileSelect = document.getElementById("quick-profile-select");
+        if (profileSummary && profileSelect) {
+            const profile = QUICK_PROFILES[profileSelect.value];
+            profileSummary.textContent = profile
+                ? profile.summary
+                : "Profiles apply a full starter setup, including context, Auto Fit, GPU offload, and sampler settings.";
+        }
+
+        const quickMetricsToggle = document.getElementById("quick-metrics-toggle");
+        if (quickMetricsToggle) quickMetricsToggle.checked = values.metrics === true;
+
+        quickCommand.textContent = document.getElementById("command-preview-text").textContent || "";
+        quickCommand.classList.toggle("command-preview-error", document.getElementById("command-preview-text").classList.contains("command-preview-error"));
+        updateQuickServerAddressPreview();
+        updateActionButtons();
+    }
+
+    function populateProfileOptions() {
+        const select = document.getElementById("quick-profile-select");
+        if (!select) return;
+
+        const previous = select.value;
+        select.innerHTML = "";
+
+        const placeholder = document.createElement("option");
+        placeholder.value = "";
+        placeholder.textContent = "Choose a profile...";
+        select.appendChild(placeholder);
+
+        for (const [profileId, profile] of Object.entries(QUICK_PROFILES)) {
+            const opt = document.createElement("option");
+            opt.value = profileId;
+            opt.textContent = profile.label;
+            select.appendChild(opt);
+        }
+
+        select.value = Object.prototype.hasOwnProperty.call(QUICK_PROFILES, previous) ? previous : "";
+    }
+
+    function init() {
+        const on = (id, event, handler) => {
+            const el = document.getElementById(id);
+            if (el) el.addEventListener(event, handler);
+        };
+
+        populateTemplatePackOptions();
+        populateProfileOptions();
+        refreshSamplerPresetSelect();
+        syncModelOptions();
+        hfDownloadUi.init();
+
+        on("btn-open-configure", "click", () => {
+            switchTab("configure");
+        });
+
+        on("btn-quick-refresh-models", "click", () => {
+            refreshModels();
+        });
+
+        on("quick-model-select", "change", (e) => {
+            applyPresetModel(e.target.value);
+            flagCore.updateCommandPreview();
+        });
+
+        for (const radio of document.querySelectorAll('input[name="quick-launch-mode"]')) {
+            radio.addEventListener("change", () => {
+                if (radio.checked) {
+                    flagCore.setCurrentTool(radio.value);
+                }
+            });
+        }
+
+        on("quick-profile-select", "change", (e) => {
+            applyProfile(e.target.value);
+            refresh();
+        });
+
+        on("quick-context-preset", "change", (e) => {
+            const customInput = document.getElementById("quick-context-custom");
+            if (e.target.value === "custom") {
+                if (customInput) { customInput.disabled = false; customInput.focus(); }
+                return;
+            }
+
+            if (customInput) { customInput.disabled = true; customInput.value = ""; }
+            setContextValue(e.target.value);
+        });
+
+        on("quick-context-custom", "input", (e) => {
+            const rawValue = e.target.value.trim();
+            if (rawValue === "") return;
+            setContextValue(rawValue);
+        });
+
+        on("quick-gpu-mode", "change", (e) => {
+            const gpuCustom = document.getElementById("quick-gpu-custom");
+            if (gpuCustom) {
+                gpuCustom.disabled = e.target.value !== "custom";
+                if (e.target.value === "custom") gpuCustom.focus();
+            }
+            setGpuLayers(e.target.value);
+        });
+
+        on("quick-gpu-custom", "input", () => {
+            const gpuMode = document.getElementById("quick-gpu-mode");
+            if (gpuMode && gpuMode.value === "custom") {
+                setGpuLayers("custom");
+            }
+        });
+
+        on("quick-fit-toggle", "change", (e) => {
+            flagCore.setFlagValue("fit", e.target.value || "on");
+        });
+
+        on("quick-fit-target", "input", (e) => {
+            flagCore.setFlagValue("fit_target", e.target.value.trim() || undefined);
+        });
+
+        on("quick-fit-ctx", "input", (e) => {
+            const rawValue = e.target.value.trim();
+            const nextFitCtx = rawValue === "" ? undefined : parseInt(rawValue, 10);
+            flagCore.setFlagValue("fit_ctx", nextFitCtx, { quickLaunchFitCtxLinked: false });
+        });
+
+        on("btn-quick-fit-sync", "click", () => {
+            const values = flagCore.getFlagValues();
+            flagCore.setFlagValue("fit_ctx", values.ctx_size ?? 16000, { quickLaunchFitCtxLinked: true });
+        });
+
+        on("quick-template-pack", "change", (e) => {
+            setChatTemplateValue(e.target.value);
+        });
+
+        on("btn-quick-sampler-load", "click", () => {
+            const selected = getSelectedSamplerEntry();
+            if (!selected) return;
+            applySamplerPresetValues(selected.values);
+            refresh();
+        });
+
+        on("btn-quick-sampler-save", "click", () => {
+            const nameInput = document.getElementById("quick-sampler-name");
+            if (!nameInput) return;
+            const typedName = nameInput.value.trim();
+            const selected = getSelectedSamplerEntry();
+            const name = typedName || (selected && selected.source === "custom" ? selected.name : "");
+            if (!name) {
+                nameInput.focus();
+                return;
+            }
+
+            const store = loadSamplerPresetStore();
+            store[name] = normalizeSamplerPresetValues(collectSamplerValues());
+            saveSamplerPresetStore(store);
+            nameInput.value = "";
+            refreshSamplerPresetSelect();
+            configFlagsUi.renderFlags();
+            const samplerSelect = document.getElementById("quick-sampler-select");
+            if (samplerSelect) samplerSelect.value = `custom|${name}`;
+        });
+
+        on("btn-quick-sampler-delete", "click", async () => {
+            const selected = getSelectedSamplerEntry();
+            if (!selected) return;
+            if (selected.source !== "custom") {
+                alert("Built-in sampler presets cannot be deleted.");
+                return;
+            }
+
+            const ok = await confirmAction(
+                "Delete Sampler Preset",
+                `Delete sampler preset "${selected.name}"? This cannot be undone.`,
+                "Delete"
+            );
+            if (!ok) return;
+
+            const store = loadSamplerPresetStore();
+            delete store[selected.name];
+            saveSamplerPresetStore(store);
+            refreshSamplerPresetSelect();
+            configFlagsUi.renderFlags();
+        });
+
+        const quickSamplerFieldMap = {
+            "quick-temperature": "temperature",
+            "quick-top-k": "top_k",
+            "quick-top-p": "top_p",
+            "quick-min-p": "min_p",
+            "quick-repeat-penalty": "repeat_penalty",
+        };
+
+        for (const [elementId, flagId] of Object.entries(quickSamplerFieldMap)) {
+            on(elementId, "input", debounce((e) => {
+                const rawValue = e.target.value.trim();
+                let nextValue;
+                if (rawValue === "") {
+                    nextValue = undefined;
+                } else if (flagId === "top_k") {
+                    nextValue = parseInt(rawValue, 10);
+                } else {
+                    nextValue = parseFloat(rawValue);
+                }
+                flagCore.setFlagValue(flagId, nextValue);
+            }, 200));
+        }
+
+        on("btn-copy-quick-server-url", "click", copyQuickServerUrl);
+
+        on("quick-metrics-toggle", "change", (e) => {
+            flagCore.setFlagValue("metrics", e.target.checked);
+        });
+
+        on("btn-quick-launch", "click", async () => {
+            switchTab("configure");
+            await launchLlama();
+        });
+
+        on("btn-quick-stop", "click", stopLlama);
+
+        refresh();
+    }
+
+    function afterPatch(patch, options = {}) {
+        if (Object.prototype.hasOwnProperty.call(options, "quickLaunchFitCtxLinked")) {
+            quickLaunchFitCtxLinked = options.quickLaunchFitCtxLinked;
+        } else if (Object.prototype.hasOwnProperty.call(patch || {}, "fit_ctx")
+            || Object.prototype.hasOwnProperty.call(patch || {}, "ctx_size")) {
+            const values = flagCore.getFlagValues();
+            const fitCtx = values.fit_ctx;
+            const ctxSize = values.ctx_size;
+            quickLaunchFitCtxLinked = fitCtx === undefined || fitCtx === ctxSize;
+        }
+
+        if (Object.prototype.hasOwnProperty.call(options, "quickLaunchGpuCustomSelected")) {
+            quickLaunchGpuCustomSelected = options.quickLaunchGpuCustomSelected;
+        } else if (Object.prototype.hasOwnProperty.call(patch || {}, "gpu_layers")) {
+            const values = flagCore.getFlagValues();
+            const gpuLayers = String(values.gpu_layers ?? "auto");
+            quickLaunchGpuCustomSelected = gpuLayers !== "auto" && gpuLayers !== "0" && gpuLayers !== "all";
+        }
+    }
+
+    function afterApply(values) {
+        const fitCtx = values.fit_ctx;
+        const ctxSize = values.ctx_size;
+        quickLaunchFitCtxLinked = fitCtx === undefined || fitCtx === ctxSize;
+    }
+
+    ns.quickLaunchUi = {
+        configure,
+        init,
+        refresh,
+        syncModelOptions,
+        updateActionButtons,
+        refreshSamplerPresetSelect,
+        afterPatch,
+        afterApply,
+    };
+})();


### PR DESCRIPTION
Extract Quick Launch UI logic into a dedicated frontend module and update wiring and docs. Added ui/js/quick-launch-ui.js which implements Quick Launch controls, state sync, sampler/profile handling, and exposes window.LlamaGui.quickLaunchUi; refactored ui/js/app.js to delegate Quick Launch responsibilities (configure/init/refresh/afterPatch/afterApply/etc.) to the new module and removed the inlined Quick Launch functions/variables. Updated ui/index.html to load quick-launch-ui.js before app.js and revised AGENTS.md, docs/directory.md, and refactor_appjs.md to reflect the new module and its responsibilities.