### PR TITLE
Extract sampler presets into module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ with the primary file and only touch secondary files if the change requires it.
 | HF download UI | `ui/js/hf-download-ui.js` | `ui/js/quick-launch-ui.js` (init), `ui/js/app.js` (callbacks), `ui/js/manager.js` (fetchJson) |
 | Remote tunnel UI | `ui/js/remote-tunnel-ui.js` | `ui/js/app.js` (init), `ui/js/api-tab.js` (endpoint config), `ui/js/manager.js` (fetchJson) |
 | Chat template presets | `ui/js/flags.js` | `ui/js/app.js` (mapping helpers) |
-| Sampler presets | `ui/js/app.js` | `ui/js/flag-core.js` (apply) |
+| Sampler presets | `ui/js/sampler-presets.js` | `ui/js/app-data.js` (built-ins), `ui/js/flag-core.js` (apply), `ui/js/app.js` (callbacks) |
 | Preset save/load/import/export | `ui/js/presets.js` | `ui/js/flag-core.js` (collect/apply) |
 | Install/update UI | `ui/js/manager.js` | — |
 | Backend routes | `backend/routes/*.py` | `backend/services/*.py` |
@@ -215,13 +215,14 @@ The frontend loads scripts in a strict dependency order via `ui/index.html`:
 5. `manager.js` — GitHub releases, install, update, shared `fetchJson()`
 6. `presets.js` — preset CRUD
 7. `app-data.js` — shared Quick Launch, context, sampler, and chat slider data
-8. `chat-rendering.js` — markdown and low-level chat DOM rendering helpers (`window.LlamaGui.chatRendering`)
-9. `api-tab.js` — API endpoint/snippet rendering helpers (`window.LlamaGui.apiTab`)
-10. `hf-download-ui.js` — Quick Launch Hugging Face downloader UI (`window.LlamaGui.hfDownloadUi`)
-11. `remote-tunnel-ui.js` — API tab Cloudflare tunnel UI (`window.LlamaGui.remoteTunnelUi`)
-12. `quick-launch-ui.js` — Quick Launch controls and shared-state UI sync (`window.LlamaGui.quickLaunchUi`)
-13. `chat-ui.js` — Chat tab state, streaming, history, web search, and sampler controls (`window.LlamaGui.chatUi`)
-14. `app.js` — main orchestration (wires everything together)
+8. `sampler-presets.js` — sampler preset storage, import/export, apply behavior, and Configure controls (`window.LlamaGui.samplerPresets`)
+9. `chat-rendering.js` — markdown and low-level chat DOM rendering helpers (`window.LlamaGui.chatRendering`)
+10. `api-tab.js` — API endpoint/snippet rendering helpers (`window.LlamaGui.apiTab`)
+11. `hf-download-ui.js` — Quick Launch Hugging Face downloader UI (`window.LlamaGui.hfDownloadUi`)
+12. `remote-tunnel-ui.js` — API tab Cloudflare tunnel UI (`window.LlamaGui.remoteTunnelUi`)
+13. `quick-launch-ui.js` — Quick Launch controls and shared-state UI sync (`window.LlamaGui.quickLaunchUi`)
+14. `chat-ui.js` — Chat tab state, streaming, history, web search, and sampler controls (`window.LlamaGui.chatUi`)
+15. `app.js` — main orchestration (wires everything together)
 
 **Do not change this order.** Each file depends on the ones above it. If you
 add a new module, place it after its dependencies and before its consumers.
@@ -238,8 +239,8 @@ private closure variables.
 - Polling functions (`pollStats`, `pollOutput`) may fail silently when the
   server is not ready. This is expected. Do not add user-visible errors for
   polling failures during startup.
-- `saveSamplerPresetStore()` has no error handling. If you change it, add a
-  try/catch for `QuotaExceededError`.
+- `saveSamplerPresetStore()` in `ui/js/sampler-presets.js` logs storage
+  failures with `console.warn()`. Keep custom preset save failures visible.
 - localStorage `getItem` returns `null` for missing keys. Always check
   before parsing JSON.
 
@@ -283,7 +284,8 @@ private closure variables.
 
 ### Frontend
 - **`ui/index.html`**: HTML template defining the tabbed layout and UI structure.
-- **`ui/js/app.js`**: Main UI orchestration. Manages tab switching, server launch/stop, output polling, stats polling, shared sampler/template helpers, toasts, module initialization, and cache-busting reload.
+- **`ui/js/app.js`**: Main UI orchestration. Manages tab switching, server launch/stop, output polling, stats polling, shared template helpers, toasts, module initialization, and cache-busting reload.
+- **`ui/js/sampler-presets.js`**: Sampler preset storage, normalization, apply behavior, import/export, and Configure-tab controls exposed as `window.LlamaGui.samplerPresets`; writes sampler values through injected `flagCore`.
 - **`ui/js/chat-rendering.js`**: Markdown and low-level chat DOM rendering helpers exposed as `window.LlamaGui.chatRendering`.
 - **`ui/js/chat-ui.js`**: Chat tab state, streaming/abort flow, web search settings, conversation history, sidebar controls, sampler sliders, and status badge updates exposed as `window.LlamaGui.chatUi`; reads and writes launch-relevant sampler state through injected `flagCore`.
 - **`ui/js/api-tab.js`**: API tab endpoint/snippet data, base URL helpers, and rendering exposed as `window.LlamaGui.apiTab`; reads shared state through injected `flagCore`.
@@ -678,7 +680,7 @@ Sampler presets allow saving and loading groups of sampling flags.
 
 ### Built-In Presets
 
-Defined in `BUILTIN_SAMPLER_PRESETS` in `app.js`:
+Defined in `BUILTIN_SAMPLER_PRESETS` in `ui/js/app-data.js` and managed by `ui/js/sampler-presets.js`:
 - **Neutral**: KoboldCpp-style neutral baseline with temperature=1.0, top_k=200, top_p=1.0, min_p=0, repeat_penalty=1.0, repeat_last_n=360
 - **Balanced**: KoboldCpp `Simple Balanced` style with temperature=0.75, top_k=100, top_p=0.92, min_p=0, repeat_penalty=1.05, repeat_last_n=360
 - **Creative**: KoboldCpp `Simple Creative` style with temperature=1.0, top_k=100, top_p=0.98, min_p=0, repeat_penalty=1.1, repeat_last_n=360
@@ -696,7 +698,7 @@ Defined in `BUILTIN_SAMPLER_PRESETS` in `app.js`:
 - Configure tab: Sampler Preset controls appear at the top of the Sampling accordion.
 - Quick Launch tab: Sampler Preset controls in the sampler section.
 - Quick profiles reference preset names (e.g., `samplerPresetName: "Balanced"`).
-- Loading a preset calls `applySamplerPresetValues()` which writes through `window.LlamaGui.flagCore.setMultipleFlagValues()`.
+- Loading a preset calls `window.LlamaGui.samplerPresets.applySamplerPresetValues()` which writes through `window.LlamaGui.flagCore.setMultipleFlagValues()`.
 
 ## Server Stats & Metrics
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ Storage behavior:
 - export creates portable `.json` files
 - import accepts single-preset or multi-preset JSON
 
+Quick Launch, Configure, and Chat sampler controls all use the same shared sampler state, so decimal values and preset changes stay synchronized across tabs.
+
 Note: loading a full app preset can overwrite sampler values because samplers are part of the full flag set.
 
 ## Server Stats Bar
@@ -416,6 +418,11 @@ It does not remove:
 - `backend/` - local HTTP API, route handlers, service modules, installer/update logic, process manager, HF downloads, web search, remote tunnel, and lifecycle helpers
 - `requirements.txt` - Python dependencies, including optional Chat web search support
 - `ui/` - static frontend (HTML/CSS/JS)
+  - `ui/js/app.js` - app bootstrap, tab switching, launch/stop flow, polling, toasts, and shared orchestration
+  - `ui/js/quick-launch-ui.js` - Quick Launch profiles, simplified launch controls, sampler fields, and command preview mirror
+  - `ui/js/chat-ui.js` and `ui/js/chat-rendering.js` - Chat state, streaming, conversation history, web search controls, markdown, and message rendering
+  - `ui/js/api-tab.js`, `ui/js/hf-download-ui.js`, and `ui/js/remote-tunnel-ui.js` - API snippets, Hugging Face downloads, and Cloudflare tunnel controls
+  - `ui/js/sampler-presets.js` - sampler preset storage, import/export, and Configure sampler preset controls
 - `llama/bin/` - installed `llama.cpp` executables/runtime files
 - `llama/grammars/` - grammar/schema files from release assets
 - `models/` - local model files
@@ -426,7 +433,7 @@ It does not remove:
 
 - `config.json` - installed release/backend metadata
 - `presets/` - full app presets (tool/model/flags)
-- browser `localStorage` - custom sampler presets and the Chat Web Search toggle state
+- browser `localStorage` - custom sampler presets, chat conversations, and Chat Web Search settings
 
 ## Troubleshooting
 

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -25,13 +25,14 @@
 | `backend/routes/` | 14 route handler modules grouped by feature (status, models, presets, metrics, chat, search, hf_download, file_picker, process, install, tunnel, git_update, lifecycle) |
 | `backend/services/` | 10 service modules (llama_manager, process_manager, hf_download, web_search, tunnel, git_update, lifecycle, file_picker, chat) |
 | `ui/js/app-data.js` | Shared Quick Launch profile, context preset, sampler preset, and chat sampler slider data |
+| `ui/js/sampler-presets.js` | Sampler preset storage, normalization, apply behavior, import/export, and Configure-tab controls exposed as `window.LlamaGui.samplerPresets` |
 | `ui/js/chat-rendering.js` | Markdown and low-level chat DOM rendering helpers exposed as `window.LlamaGui.chatRendering` |
 | `ui/js/chat-ui.js` | Chat tab state, streaming/abort flow, web search settings, conversation history, sidebar controls, sampler sliders, and status badge updates exposed as `window.LlamaGui.chatUi` |
 | `ui/js/api-tab.js` | API tab endpoint/snippet data, base URL helpers, and rendering exposed as `window.LlamaGui.apiTab` |
 | `ui/js/hf-download-ui.js` | Quick Launch Hugging Face downloader controls, status rendering, progress polling, cancel handling, and completion flow exposed as `window.LlamaGui.hfDownloadUi` |
 | `ui/js/remote-tunnel-ui.js` | API tab Cloudflare tunnel controls, status rendering, URL rendering, copy wiring, start/stop actions, and polling exposed as `window.LlamaGui.remoteTunnelUi` |
 | `ui/js/quick-launch-ui.js` | Quick Launch profile, context, GPU, template, sampler, metrics, command preview mirror, action buttons, and event wiring exposed as `window.LlamaGui.quickLaunchUi` |
-| `ui/js/app.js` | Main UI orchestration: tab switching, launch/stop flow, module initialization, shared sampler/template helpers, stats polling, toasts |
+| `ui/js/app.js` | Main UI orchestration: tab switching, launch/stop flow, module initialization, shared template helpers, stats polling, toasts |
 | `ui/js/flags/` | Ordered flag modules for exposed llama.cpp flag categories, option lists, chat template presets, flag definitions, and flag helpers |
 | `ui/js/flag-core.js` | Shared frontend flag state and launch-argument core (`currentTool`, selected model, `flagValues`, setters, preset apply/collect helpers, command preview generation) |
 | `ui/js/config-flags-ui.js` | Configure tab flag rendering, search/filtering, expand/collapse state, type-specific flag input builders, input restoration, and high-risk `multi_enum` warnings |
@@ -110,6 +111,7 @@ Built-in (Neutral/Balanced/Creative/Precise) + custom presets:
 - Stored in `localStorage` under `llama_gui_sampler_presets_v1`
 - Save/load/delete/export/import with deduplication
 - Shared across Configure and Quick Launch tabs
+- Preset storage, validation, and Configure controls live in `ui/js/sampler-presets.js`
 - Built-ins are tuned as KoboldCpp-style simple equivalents while preserving the existing preset names
 
 ## Server Metrics

--- a/refactor_appjs.md
+++ b/refactor_appjs.md
@@ -192,7 +192,7 @@ Remote tunnel controls are a good next extraction because they own a distinct ti
 
 Quick Launch is high-value but riskier because it touches mirrored controls, shared flag state, sampler presets, profiles, templates, command preview, and launch buttons.
 
-Status: Completed. `ui/js/quick-launch-ui.js` now owns Quick Launch local UI state, profile/context/GPU/template/sampler controls, command preview mirroring, action button sync, and event wiring through `window.LlamaGui.quickLaunchUi`. `app.js` keeps small compatibility wrappers and shared sampler/template helpers for now.
+Status: Completed. `ui/js/quick-launch-ui.js` now owns Quick Launch local UI state, profile/context/GPU/template/sampler controls, command preview mirroring, action button sync, and event wiring through `window.LlamaGui.quickLaunchUi`. `app.js` keeps small compatibility wrappers and shared template helpers; sampler preset helpers now live in `ui/js/sampler-presets.js`.
 
 ### Implementation
 
@@ -285,9 +285,11 @@ Status: Completed. `ui/js/chat-ui.js` now owns chat state, streaming/abort flow,
 - Confirm chat rendering still goes through the extracted safe rendering helpers.
 - Confirm stats interactions did not become hidden cross-module coupling.
 
-## Phase 7: Shrink `app.js` To Bootstrap And Shared App Shell
+## Phase 7: Shrink `app.js` To Bootstrap And Shared App Shell - Done
 
 After feature modules are extracted, clean up `app.js` so it is mostly startup sequencing and shared shell behavior.
+
+Status: Completed. `ui/js/sampler-presets.js` now owns sampler preset storage, normalization, apply behavior, import/export, and Configure-tab sampler preset controls. `app.js` remains the shared app shell for startup sequencing, module configuration, tab switching, launch/stop flow, polling, command preview coordination, toasts, and cross-module callbacks.
 
 ### Implementation
 

--- a/tests/frontend/flag_sync_smoke.cjs
+++ b/tests/frontend/flag_sync_smoke.cjs
@@ -268,14 +268,27 @@ async function main() {
         await page.waitForTimeout(250);
         await page.waitForFunction(() => window.LlamaGui.flagCore.getFlagValues().temperature === 0.42);
         await page.waitForFunction(() => document.querySelector("#chat-slider-temp")?.value === "0.42");
+        await page.fill("#quick-temperature", ".96");
+        await page.dispatchEvent("#quick-temperature", "input");
+        await page.fill("#quick-repeat-penalty", "1.02");
+        await page.dispatchEvent("#quick-repeat-penalty", "input");
+        await page.waitForTimeout(250);
+        await page.waitForFunction(() => window.LlamaGui.flagCore.getFlagValues().temperature === 0.96);
+        await page.waitForFunction(() => window.LlamaGui.flagCore.getFlagValues().repeat_penalty === 1.02);
+        assert.equal(await page.locator("#quick-temperature").evaluate((el) => el.validity.valid), true);
+        assert.equal(await page.locator("#quick-repeat-penalty").evaluate((el) => el.validity.valid), true);
         await selectSection(page, "configure");
         await page.fill("#config-search", "temperature");
         await page.waitForSelector("#flag-temperature", { state: "visible" });
-        await page.waitForFunction(() => document.querySelector("#flag-temperature")?.value === "0.42");
+        await page.waitForFunction(() => document.querySelector("#flag-temperature")?.value === "0.96");
+        assert.equal(await page.locator("#flag-temperature").evaluate((el) => el.step), "0.01");
+        assert.equal(await page.locator("#flag-temperature").evaluate((el) => el.validity.valid), true);
 
         const launchArgs = await page.evaluate(() => window.LlamaGui.flagCore.getLaunchArgs().args.flat());
         assert.ok(launchArgs.includes("-c") && launchArgs.includes("12345"));
         assert.ok(launchArgs.includes("-ngl") && launchArgs.includes("9"));
+        assert.ok(launchArgs.includes("--temp") && launchArgs.includes("0.96"));
+        assert.ok(launchArgs.includes("--repeat-penalty") && launchArgs.includes("1.02"));
 
         await page.fill("#custom-launch-args", "--threads 8\n--chat-template-kwargs '{\"preserve_thinking\":true}'");
         await page.dispatchEvent("#custom-launch-args", "input");

--- a/ui/index.html
+++ b/ui/index.html
@@ -365,7 +365,7 @@
                     <div class="quick-slider-grid">
                         <div class="form-group">
                             <label class="form-label" for="quick-temperature">Temperature</label>
-                            <input type="number" id="quick-temperature" min="0" max="5" step="0.05" />
+                            <input type="number" id="quick-temperature" min="0" max="5" step="0.01" />
                         </div>
                         <div class="form-group">
                             <label class="form-label" for="quick-top-k">Top-K</label>
@@ -818,6 +818,7 @@
 <script src="/js/manager.js?v=revamp-1"></script>
 <script src="/js/presets.js?v=revamp-1"></script>
 <script src="/js/app-data.js?v=revamp-1"></script>
+<script src="/js/sampler-presets.js?v=revamp-1"></script>
 <script src="/js/chat-rendering.js?v=revamp-1"></script>
 <script src="/js/api-tab.js?v=revamp-1"></script>
 <script src="/js/hf-download-ui.js?v=revamp-1"></script>

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -34,13 +34,21 @@ const initApiTab = apiTab.init;
 const updateApiEndpoints = apiTab.updateEndpoints;
 const chatUi = window.LlamaGui.chatUi;
 const { renderChatSources } = window.LlamaGui.chatRendering;
+const samplerPresets = window.LlamaGui.samplerPresets;
+const quickLaunchUi = window.LlamaGui.quickLaunchUi;
+samplerPresets.configure({
+    flagCore,
+    getFlags: () => FLAGS,
+    getDefaultFlagValues: getDefaultValues,
+    confirmAction,
+    refreshSamplerPresetSelect: () => quickLaunchUi.refreshSamplerPresetSelect(),
+});
 const remoteTunnelUi = window.LlamaGui.remoteTunnelUi;
 remoteTunnelUi.configure({
     fetchJson,
     copyText,
     getServerEndpointConfig,
 });
-const quickLaunchUi = window.LlamaGui.quickLaunchUi;
 const hfDownloadUi = window.LlamaGui.hfDownloadUi;
 hfDownloadUi.configure({
     flagCore,
@@ -65,325 +73,14 @@ quickLaunchUi.configure({
     setChatTemplateValue,
     getSelectedChatTemplateDropdownValue,
     getQuickTemplateSummaryText,
-    getAllSamplerPresets,
-    applySamplerPresetValues,
-    loadSamplerPresetStore,
-    saveSamplerPresetStore,
-    normalizeSamplerPresetValues,
-    collectSamplerValues,
+    getAllSamplerPresets: samplerPresets.getAllSamplerPresets,
+    applySamplerPresetValues: samplerPresets.applySamplerPresetValues,
+    loadSamplerPresetStore: samplerPresets.loadSamplerPresetStore,
+    saveSamplerPresetStore: samplerPresets.saveSamplerPresetStore,
+    normalizeSamplerPresetValues: samplerPresets.normalizeSamplerPresetValues,
+    collectSamplerValues: samplerPresets.collectSamplerValues,
     confirmAction,
 });
-
-function getSamplerFlags() {
-    return FLAGS.filter(f => f.category === "sampling");
-}
-
-function loadSamplerPresetStore() {
-    try {
-        const raw = localStorage.getItem(SAMPLER_PRESET_STORAGE_KEY);
-        if (!raw) return {};
-        const parsed = JSON.parse(raw);
-        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-        return parsed;
-    } catch (_) {
-        return {};
-    }
-}
-
-function saveSamplerPresetStore(store) {
-    localStorage.setItem(SAMPLER_PRESET_STORAGE_KEY, JSON.stringify(store));
-}
-
-function collectSamplerValues() {
-    const values = {};
-    const currentValues = flagCore.getFlagValues();
-    for (const f of getSamplerFlags()) {
-        const v = currentValues[f.id];
-        if (v !== undefined && v !== null && v !== "") {
-            values[f.id] = v;
-        }
-    }
-    return values;
-}
-
-function normalizeSamplerPresetValues(values) {
-    const result = {};
-    if (!values || typeof values !== "object" || Array.isArray(values)) return result;
-
-    const allowed = new Set(getSamplerFlags().map(f => f.id));
-    for (const [k, v] of Object.entries(values)) {
-        if (allowed.has(k)) {
-            result[k] = v;
-        }
-    }
-    return result;
-}
-
-function getAllSamplerPresets() {
-    const custom = loadSamplerPresetStore();
-    const entries = [];
-
-    for (const [name, values] of Object.entries(BUILTIN_SAMPLER_PRESETS)) {
-        entries.push({ name, values: normalizeSamplerPresetValues(values), source: "builtin" });
-    }
-    for (const [name, values] of Object.entries(custom)) {
-        entries.push({ name, values: normalizeSamplerPresetValues(values), source: "custom" });
-    }
-
-    return entries.sort((a, b) => a.name.localeCompare(b.name));
-}
-
-function applySamplerPresetValues(values) {
-    const defaults = getDefaultValues();
-    const patch = {};
-    for (const f of getSamplerFlags()) {
-        if (Object.prototype.hasOwnProperty.call(values, f.id)) {
-            patch[f.id] = values[f.id];
-        } else if (Object.prototype.hasOwnProperty.call(defaults, f.id)) {
-            patch[f.id] = defaults[f.id];
-        } else {
-            patch[f.id] = undefined;
-        }
-    }
-    flagCore.setMultipleFlagValues(patch);
-}
-
-function createSamplerPresetControls() {
-    const panel = document.createElement("div");
-    panel.className = "sampler-presets";
-
-    const title = document.createElement("div");
-    title.className = "sampler-presets-title";
-    title.textContent = "Sampler Presets";
-
-    const row = document.createElement("div");
-    row.className = "sampler-presets-row";
-
-    const select = document.createElement("select");
-    const nameInput = document.createElement("input");
-    nameInput.type = "text";
-    nameInput.placeholder = "Preset name...";
-
-    const loadBtn = document.createElement("button");
-    loadBtn.className = "btn btn-sm";
-    loadBtn.type = "button";
-    loadBtn.textContent = "Load";
-
-    const saveBtn = document.createElement("button");
-    saveBtn.className = "btn btn-sm";
-    saveBtn.type = "button";
-    saveBtn.textContent = "Save";
-
-    const delBtn = document.createElement("button");
-    delBtn.className = "btn btn-sm btn-danger";
-    delBtn.type = "button";
-    delBtn.textContent = "Delete";
-
-    const exportBtn = document.createElement("button");
-    exportBtn.className = "btn btn-sm";
-    exportBtn.type = "button";
-    exportBtn.textContent = "Export";
-
-    const importBtn = document.createElement("button");
-    importBtn.className = "btn btn-sm";
-    importBtn.type = "button";
-    importBtn.textContent = "Import";
-
-    const importInput = document.createElement("input");
-    importInput.type = "file";
-    importInput.accept = ".json";
-    importInput.style.display = "none";
-
-    const getSelectedPresetEntry = () => {
-        const value = select.value;
-        if (!value) return null;
-        const [source, ...nameParts] = value.split("|");
-        const name = nameParts.join("|");
-        if (!name) return null;
-        const entries = getAllSamplerPresets();
-        return entries.find(e => e.source === source && e.name === name) || null;
-    };
-
-    const buildUniqueName = (base, takenNames) => {
-        if (!takenNames.has(base)) return base;
-        let idx = 2;
-        let candidate = `${base} (${idx})`;
-        while (takenNames.has(candidate)) {
-            idx += 1;
-            candidate = `${base} (${idx})`;
-        }
-        return candidate;
-    };
-
-    const refreshOptions = () => {
-        const entries = getAllSamplerPresets();
-        const builtins = entries.filter(e => e.source === "builtin");
-        const customs = entries.filter(e => e.source === "custom");
-        select.innerHTML = "";
-
-        const placeholder = document.createElement("option");
-        placeholder.value = "";
-        placeholder.textContent = entries.length ? "-- Select Sampler Preset --" : "No sampler presets";
-        select.appendChild(placeholder);
-
-        if (builtins.length) {
-            const group = document.createElement("optgroup");
-            group.label = "Built-in";
-            for (const p of builtins) {
-                const opt = document.createElement("option");
-                opt.value = `builtin|${p.name}`;
-                opt.textContent = p.name;
-                group.appendChild(opt);
-            }
-            select.appendChild(group);
-        }
-
-        if (customs.length) {
-            const group = document.createElement("optgroup");
-            group.label = "Custom";
-            for (const p of customs) {
-                const opt = document.createElement("option");
-                opt.value = `custom|${p.name}`;
-                opt.textContent = p.name;
-                group.appendChild(opt);
-            }
-            select.appendChild(group);
-        }
-
-        if (entries.length) {
-            const first = entries[0];
-            select.value = `${first.source}|${first.name}`;
-        }
-    };
-
-    loadBtn.addEventListener("click", () => {
-        const selected = getSelectedPresetEntry();
-        if (!selected) return;
-        applySamplerPresetValues(selected.values);
-    });
-
-    saveBtn.addEventListener("click", () => {
-        const typedName = nameInput.value.trim();
-        const selected = getSelectedPresetEntry();
-        const name = typedName || (selected && selected.source === "custom" ? selected.name : "");
-        if (!name) {
-            nameInput.focus();
-            return;
-        }
-        const store = loadSamplerPresetStore();
-        store[name] = normalizeSamplerPresetValues(collectSamplerValues());
-        saveSamplerPresetStore(store);
-        refreshOptions();
-        refreshQuickSamplerPresetSelect();
-        select.value = `custom|${name}`;
-        nameInput.value = "";
-    });
-
-    delBtn.addEventListener("click", async () => {
-        const selected = getSelectedPresetEntry();
-        if (!selected) return;
-        if (selected.source !== "custom") {
-            alert("Built-in sampler presets cannot be deleted.");
-            return;
-        }
-        const ok = await confirmAction(
-            "Delete Sampler Preset",
-            `Delete sampler preset "${selected.name}"? This cannot be undone.`,
-            "Delete"
-        );
-        if (!ok) return;
-
-        const store = loadSamplerPresetStore();
-        delete store[selected.name];
-        saveSamplerPresetStore(store);
-        refreshOptions();
-        refreshQuickSamplerPresetSelect();
-    });
-
-    exportBtn.addEventListener("click", () => {
-        const selected = getSelectedPresetEntry();
-        if (!selected) return;
-
-        const payload = {
-            name: selected.name,
-            values: normalizeSamplerPresetValues(selected.values),
-        };
-        const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement("a");
-        a.href = url;
-        a.download = `${selected.name.replace(/[<>:"/\\|?*]/g, "_")}.json`;
-        a.click();
-        URL.revokeObjectURL(url);
-    });
-
-    importBtn.addEventListener("click", () => importInput.click());
-
-    importInput.addEventListener("change", async () => {
-        if (!importInput.files || importInput.files.length === 0) return;
-        const file = importInput.files[0];
-        importInput.value = "";
-
-        try {
-            const text = await file.text();
-            const parsed = JSON.parse(text);
-
-            const incoming = [];
-            if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-                if (parsed.name && parsed.values && typeof parsed.values === "object") {
-                    incoming.push({ name: String(parsed.name), values: parsed.values });
-                } else if (parsed.presets && typeof parsed.presets === "object") {
-                    for (const [name, values] of Object.entries(parsed.presets)) {
-                        incoming.push({ name, values });
-                    }
-                }
-            }
-
-            if (incoming.length === 0) {
-                alert("Invalid sampler preset JSON format.");
-                return;
-            }
-
-            const store = loadSamplerPresetStore();
-            const taken = new Set([
-                ...Object.keys(BUILTIN_SAMPLER_PRESETS),
-                ...Object.keys(store),
-            ]);
-
-            let lastImportedName = "";
-            for (const item of incoming) {
-                const baseName = String(item.name || "Imported Sampler").trim() || "Imported Sampler";
-                const uniqueName = buildUniqueName(baseName, taken);
-                taken.add(uniqueName);
-                store[uniqueName] = normalizeSamplerPresetValues(item.values);
-                lastImportedName = uniqueName;
-            }
-
-            saveSamplerPresetStore(store);
-            refreshOptions();
-            refreshQuickSamplerPresetSelect();
-            if (lastImportedName) {
-                select.value = `custom|${lastImportedName}`;
-            }
-        } catch (e) {
-            alert("Failed to import sampler preset: " + e.message);
-        }
-    });
-
-    row.appendChild(select);
-    row.appendChild(nameInput);
-    row.appendChild(loadBtn);
-    row.appendChild(saveBtn);
-    row.appendChild(delBtn);
-    row.appendChild(exportBtn);
-    row.appendChild(importBtn);
-    panel.appendChild(title);
-    panel.appendChild(row);
-    panel.appendChild(importInput);
-
-    refreshOptions();
-    return panel;
-}
 
 function syncUiAfterToolChange(nextTool) {
     const toolSel = document.getElementById("tool-select");
@@ -446,7 +143,7 @@ configFlagsUi.configure({
     getFlagsByCategory,
     getFlags: () => FLAGS,
     switchTab,
-    createSamplerPresetControls,
+    createSamplerPresetControls: samplerPresets.createSamplerPresetControls,
     refreshQuickLaunchUI,
     browseForPathFlag,
     showStatus,
@@ -745,14 +442,6 @@ function initToolSelect() {
 
 function initConfigControls() {
     return configFlagsUi.initConfigControls();
-}
-
-function flagMatchesSearch(flag, query) {
-    return configFlagsUi.flagMatchesSearch(flag, query);
-}
-
-function getFlagDescriptionParts(flag) {
-    return configFlagsUi.getFlagDescriptionParts(flag);
 }
 
 function updateServerAddressPreview() {

--- a/ui/js/flags/definitions.js
+++ b/ui/js/flags/definitions.js
@@ -120,7 +120,7 @@ const FLAGS = [
     { id: "temperature", flag: "--temp", category: "sampling", type: "float", label: "Temperature",
       short_desc: "Controls creativity: lower is focused, higher is more random.",
       beginner_tip: "Try 0.7-0.9 for general chat. Lower for factual tasks.",
-      desc: "Sampling temperature (higher = more random)", tool: "both", default: 0.8, min: 0, max: 5, step: 0.05 },
+      desc: "Sampling temperature (higher = more random)", tool: "both", default: 0.8, min: 0, max: 5, step: 0.01 },
     { id: "top_k", flag: "--top-k", category: "sampling", type: "int", label: "Top-K",
       short_desc: "Limits choices to the K most likely next tokens.",
       desc: "Limit selection to K most probable tokens (0 = disabled)", tool: "both", default: 40, min: 0, max: 1000 },

--- a/ui/js/quick-launch-ui.js
+++ b/ui/js/quick-launch-ui.js
@@ -491,8 +491,7 @@
         };
 
         for (const [elementId, flagId] of Object.entries(quickSamplerFieldMap)) {
-            on(elementId, "input", debounce((e) => {
-                const rawValue = e.target.value.trim();
+            const applyQuickSamplerValue = debounce((rawValue) => {
                 let nextValue;
                 if (rawValue === "") {
                     nextValue = undefined;
@@ -502,7 +501,10 @@
                     nextValue = parseFloat(rawValue);
                 }
                 flagCore.setFlagValue(flagId, nextValue);
-            }, 200));
+            }, 200);
+            on(elementId, "input", (e) => {
+                applyQuickSamplerValue(e.target.value.trim());
+            });
         }
 
         on("btn-copy-quick-server-url", "click", copyQuickServerUrl);

--- a/ui/js/sampler-presets.js
+++ b/ui/js/sampler-presets.js
@@ -1,0 +1,361 @@
+(function () {
+    window.LlamaGui = window.LlamaGui || {};
+
+    let dependencies = {};
+
+    function configure(options) {
+        dependencies = Object.assign({}, dependencies, options || {});
+    }
+
+    function getFlagCore() {
+        return dependencies.flagCore || window.LlamaGui.flagCore;
+    }
+
+    function getFlags() {
+        return typeof dependencies.getFlags === "function" ? dependencies.getFlags() : [];
+    }
+
+    function getDefaultFlagValues() {
+        return typeof dependencies.getDefaultFlagValues === "function" ? dependencies.getDefaultFlagValues() : {};
+    }
+
+    function getSamplerFlags() {
+        return getFlags().filter(f => f.category === "sampling");
+    }
+
+    function loadSamplerPresetStore() {
+        try {
+            const raw = localStorage.getItem(SAMPLER_PRESET_STORAGE_KEY);
+            if (!raw) return {};
+            const parsed = JSON.parse(raw);
+            if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+            return parsed;
+        } catch (_) {
+            return {};
+        }
+    }
+
+    function saveSamplerPresetStore(store) {
+        try {
+            localStorage.setItem(SAMPLER_PRESET_STORAGE_KEY, JSON.stringify(store));
+        } catch (e) {
+            console.warn("Failed to save sampler presets", e);
+        }
+    }
+
+    function collectSamplerValues() {
+        const core = getFlagCore();
+        const values = {};
+        const currentValues = core ? core.getFlagValues() : {};
+        for (const f of getSamplerFlags()) {
+            const v = currentValues[f.id];
+            if (v !== undefined && v !== null && v !== "") {
+                values[f.id] = v;
+            }
+        }
+        return values;
+    }
+
+    function normalizeSamplerPresetValues(values) {
+        const result = {};
+        if (!values || typeof values !== "object" || Array.isArray(values)) return result;
+
+        const allowed = new Set(getSamplerFlags().map(f => f.id));
+        for (const [k, v] of Object.entries(values)) {
+            if (allowed.has(k)) {
+                result[k] = v;
+            }
+        }
+        return result;
+    }
+
+    function getAllSamplerPresets() {
+        const custom = loadSamplerPresetStore();
+        const entries = [];
+
+        for (const [name, values] of Object.entries(BUILTIN_SAMPLER_PRESETS)) {
+            entries.push({ name, values: normalizeSamplerPresetValues(values), source: "builtin" });
+        }
+        for (const [name, values] of Object.entries(custom)) {
+            entries.push({ name, values: normalizeSamplerPresetValues(values), source: "custom" });
+        }
+
+        return entries.sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    function applySamplerPresetValues(values) {
+        const core = getFlagCore();
+        if (!core) return;
+
+        const defaults = getDefaultFlagValues();
+        const patch = {};
+        for (const f of getSamplerFlags()) {
+            if (Object.prototype.hasOwnProperty.call(values, f.id)) {
+                patch[f.id] = values[f.id];
+            } else if (Object.prototype.hasOwnProperty.call(defaults, f.id)) {
+                patch[f.id] = defaults[f.id];
+            } else {
+                patch[f.id] = undefined;
+            }
+        }
+        core.setMultipleFlagValues(patch);
+    }
+
+    function refreshConsumers() {
+        if (typeof dependencies.refreshSamplerPresetSelect === "function") {
+            dependencies.refreshSamplerPresetSelect();
+        }
+    }
+
+    function createSamplerPresetControls() {
+        const panel = document.createElement("div");
+        panel.className = "sampler-presets";
+
+        const title = document.createElement("div");
+        title.className = "sampler-presets-title";
+        title.textContent = "Sampler Presets";
+
+        const row = document.createElement("div");
+        row.className = "sampler-presets-row";
+
+        const select = document.createElement("select");
+        const nameInput = document.createElement("input");
+        nameInput.type = "text";
+        nameInput.placeholder = "Preset name...";
+
+        const loadBtn = document.createElement("button");
+        loadBtn.className = "btn btn-sm";
+        loadBtn.type = "button";
+        loadBtn.textContent = "Load";
+
+        const saveBtn = document.createElement("button");
+        saveBtn.className = "btn btn-sm";
+        saveBtn.type = "button";
+        saveBtn.textContent = "Save";
+
+        const delBtn = document.createElement("button");
+        delBtn.className = "btn btn-sm btn-danger";
+        delBtn.type = "button";
+        delBtn.textContent = "Delete";
+
+        const exportBtn = document.createElement("button");
+        exportBtn.className = "btn btn-sm";
+        exportBtn.type = "button";
+        exportBtn.textContent = "Export";
+
+        const importBtn = document.createElement("button");
+        importBtn.className = "btn btn-sm";
+        importBtn.type = "button";
+        importBtn.textContent = "Import";
+
+        const importInput = document.createElement("input");
+        importInput.type = "file";
+        importInput.accept = ".json";
+        importInput.style.display = "none";
+
+        const getSelectedPresetEntry = () => {
+            const value = select.value;
+            if (!value) return null;
+            const [source, ...nameParts] = value.split("|");
+            const name = nameParts.join("|");
+            if (!name) return null;
+            const entries = getAllSamplerPresets();
+            return entries.find(e => e.source === source && e.name === name) || null;
+        };
+
+        const buildUniqueName = (base, takenNames) => {
+            if (!takenNames.has(base)) return base;
+            let idx = 2;
+            let candidate = `${base} (${idx})`;
+            while (takenNames.has(candidate)) {
+                idx += 1;
+                candidate = `${base} (${idx})`;
+            }
+            return candidate;
+        };
+
+        const refreshOptions = () => {
+            const entries = getAllSamplerPresets();
+            const builtins = entries.filter(e => e.source === "builtin");
+            const customs = entries.filter(e => e.source === "custom");
+            select.innerHTML = "";
+
+            const placeholder = document.createElement("option");
+            placeholder.value = "";
+            placeholder.textContent = entries.length ? "-- Select Sampler Preset --" : "No sampler presets";
+            select.appendChild(placeholder);
+
+            if (builtins.length) {
+                const group = document.createElement("optgroup");
+                group.label = "Built-in";
+                for (const p of builtins) {
+                    const opt = document.createElement("option");
+                    opt.value = `builtin|${p.name}`;
+                    opt.textContent = p.name;
+                    group.appendChild(opt);
+                }
+                select.appendChild(group);
+            }
+
+            if (customs.length) {
+                const group = document.createElement("optgroup");
+                group.label = "Custom";
+                for (const p of customs) {
+                    const opt = document.createElement("option");
+                    opt.value = `custom|${p.name}`;
+                    opt.textContent = p.name;
+                    group.appendChild(opt);
+                }
+                select.appendChild(group);
+            }
+
+            if (entries.length) {
+                const first = entries[0];
+                select.value = `${first.source}|${first.name}`;
+            }
+        };
+
+        loadBtn.addEventListener("click", () => {
+            const selected = getSelectedPresetEntry();
+            if (!selected) return;
+            applySamplerPresetValues(selected.values);
+        });
+
+        saveBtn.addEventListener("click", () => {
+            const typedName = nameInput.value.trim();
+            const selected = getSelectedPresetEntry();
+            const name = typedName || (selected && selected.source === "custom" ? selected.name : "");
+            if (!name) {
+                nameInput.focus();
+                return;
+            }
+            const store = loadSamplerPresetStore();
+            store[name] = normalizeSamplerPresetValues(collectSamplerValues());
+            saveSamplerPresetStore(store);
+            refreshOptions();
+            refreshConsumers();
+            select.value = `custom|${name}`;
+            nameInput.value = "";
+        });
+
+        delBtn.addEventListener("click", async () => {
+            const selected = getSelectedPresetEntry();
+            if (!selected) return;
+            if (selected.source !== "custom") {
+                alert("Built-in sampler presets cannot be deleted.");
+                return;
+            }
+            const confirmAction = dependencies.confirmAction;
+            const ok = typeof confirmAction === "function"
+                ? await confirmAction(
+                    "Delete Sampler Preset",
+                    `Delete sampler preset "${selected.name}"? This cannot be undone.`,
+                    "Delete"
+                )
+                : confirm(`Delete sampler preset "${selected.name}"? This cannot be undone.`);
+            if (!ok) return;
+
+            const store = loadSamplerPresetStore();
+            delete store[selected.name];
+            saveSamplerPresetStore(store);
+            refreshOptions();
+            refreshConsumers();
+        });
+
+        exportBtn.addEventListener("click", () => {
+            const selected = getSelectedPresetEntry();
+            if (!selected) return;
+
+            const payload = {
+                name: selected.name,
+                values: normalizeSamplerPresetValues(selected.values),
+            };
+            const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `${selected.name.replace(/[<>:"/\\|?*]/g, "_")}.json`;
+            a.click();
+            URL.revokeObjectURL(url);
+        });
+
+        importBtn.addEventListener("click", () => importInput.click());
+
+        importInput.addEventListener("change", async () => {
+            if (!importInput.files || importInput.files.length === 0) return;
+            const file = importInput.files[0];
+            importInput.value = "";
+
+            try {
+                const text = await file.text();
+                const parsed = JSON.parse(text);
+
+                const incoming = [];
+                if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+                    if (parsed.name && parsed.values && typeof parsed.values === "object") {
+                        incoming.push({ name: String(parsed.name), values: parsed.values });
+                    } else if (parsed.presets && typeof parsed.presets === "object") {
+                        for (const [name, values] of Object.entries(parsed.presets)) {
+                            incoming.push({ name, values });
+                        }
+                    }
+                }
+
+                if (incoming.length === 0) {
+                    alert("Invalid sampler preset JSON format.");
+                    return;
+                }
+
+                const store = loadSamplerPresetStore();
+                const taken = new Set([
+                    ...Object.keys(BUILTIN_SAMPLER_PRESETS),
+                    ...Object.keys(store),
+                ]);
+
+                let lastImportedName = "";
+                for (const item of incoming) {
+                    const baseName = String(item.name || "Imported Sampler").trim() || "Imported Sampler";
+                    const uniqueName = buildUniqueName(baseName, taken);
+                    taken.add(uniqueName);
+                    store[uniqueName] = normalizeSamplerPresetValues(item.values);
+                    lastImportedName = uniqueName;
+                }
+
+                saveSamplerPresetStore(store);
+                refreshOptions();
+                refreshConsumers();
+                if (lastImportedName) {
+                    select.value = `custom|${lastImportedName}`;
+                }
+            } catch (e) {
+                alert("Failed to import sampler preset: " + e.message);
+            }
+        });
+
+        row.appendChild(select);
+        row.appendChild(nameInput);
+        row.appendChild(loadBtn);
+        row.appendChild(saveBtn);
+        row.appendChild(delBtn);
+        row.appendChild(exportBtn);
+        row.appendChild(importBtn);
+        panel.appendChild(title);
+        panel.appendChild(row);
+        panel.appendChild(importInput);
+
+        refreshOptions();
+        return panel;
+    }
+
+    window.LlamaGui.samplerPresets = {
+        configure,
+        getSamplerFlags,
+        loadSamplerPresetStore,
+        saveSamplerPresetStore,
+        collectSamplerValues,
+        normalizeSamplerPresetValues,
+        getAllSamplerPresets,
+        applySamplerPresetValues,
+        createSamplerPresetControls,
+    };
+})();


### PR DESCRIPTION
Move sampler preset logic out of app.js into a new ui/js/sampler-presets.js module and wire it into the app. The new module exposes window.LlamaGui.samplerPresets (load/save/normalize/collect/getAll/apply/create controls), logs storage write failures with console.warn, and refreshes dependent UI via a configurable callback. Update app.js to configure and delegate sampler-presets operations to the new module and remove the inlined sampler preset code. Update ui/index.html to include the new script and tighten temperature precision (step 0.01). Adjust flag definition for temperature (step 0.01). Modify quick-launch input handling to use a debounced apply function. Update tests and documentation to reflect the new module, changed loading/apply call sites, script load order, and shared sampler state behavior. Test expectations updated to assert sampler flag sync and launch args for temperature and repeat_penalty.