### PR TITLE
Use LlamaGui.chatRendering.renderChatSources

### DIFF
--- a/tests/frontend/flag_sync_smoke.cjs
+++ b/tests/frontend/flag_sync_smoke.cjs
@@ -190,7 +190,7 @@ async function main() {
             bubble.className = "chat-bubble";
             wrap.appendChild(bubble);
             document.body.appendChild(wrap);
-            renderChatSources(bubble, [
+            window.LlamaGui.chatRendering.renderChatSources(bubble, [
                 { index: 1, title: "Unsafe", url: "javascript:alert(1)" },
                 { index: 2, title: "Safe", url: "https://example.com/path" },
             ]);

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -33,7 +33,6 @@ const {
 const initApiTab = apiTab.init;
 const updateApiEndpoints = apiTab.updateEndpoints;
 const chatUi = window.LlamaGui.chatUi;
-const { renderChatSources } = window.LlamaGui.chatRendering;
 const samplerPresets = window.LlamaGui.samplerPresets;
 const quickLaunchUi = window.LlamaGui.quickLaunchUi;
 samplerPresets.configure({


### PR DESCRIPTION
Call renderChatSources via window.LlamaGui.chatRendering.renderChatSources in the smoke test and remove the local destructure in ui/js/app.js. This ensures the helper is referenced from the global LlamaGui.chatRendering namespace and removes an unused local binding.