### PR TITLE
Add /api/llama/slots and KV usage fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,7 +318,7 @@ private closure variables.
 - Custom launch args are parsed and appended only by `flagCore.getLaunchArgs()`, after UI-managed flags and before the selected model arg.
 - Server output is polled via HTTP endpoint and streamed to the terminal panel.
 - Chat completions are streamed via SSE from `/api/chat/completions` (backend proxies to `llama-server`).
-- Stats are polled from `llama-server`'s Prometheus `/metrics` endpoint.
+- Stats are polled from `llama-server`'s Prometheus `/metrics` endpoint, with KV/context usage falling back through the local `/slots` proxy when `llamacpp:kv_cache_usage_ratio` is unavailable.
 - Remote tunnel status is polled from `/api/remote-tunnel/status`.
 - Model download progress is polled from `/api/hf/download-status`.
 - After app update, the page reloads with a cache-busting `appReload` timestamp parameter.

--- a/README.md
+++ b/README.md
@@ -381,9 +381,9 @@ When `llama-server` is running, a live stats bar appears at the bottom of the sc
 - **tok/s prompt** - prompt processing throughput
 - **gen tokens** - total tokens generated
 - **tok/s gen** - generation throughput
-- **KV %** - KV cache utilization
+- **KV %** - KV cache utilization, or active slot/context occupancy when the running `llama-server` build does not expose a direct KV metric
 
-The bar polls the `/metrics` endpoint every 3 seconds and updates automatically. It disappears when the server stops.
+The bar polls the `/metrics` endpoint every 3 seconds and can fall back to `/slots` for KV/context usage when needed. It disappears when the server stops.
 
 The `--metrics` flag is enabled by default. You can toggle it from:
 - **Quick Launch** - "Show server stats bar" checkbox in the Launch Preview card

--- a/backend/app.py
+++ b/backend/app.py
@@ -206,6 +206,7 @@ def configure_services(ctx=APP_CONTEXT):
     ctx.services.get_llama_api_target = get_llama_api_target
     ctx.services.set_llama_api_target = set_llama_api_target
     ctx.services.get_local_llama_metrics = get_local_llama_metrics
+    ctx.services.get_local_llama_slots = get_local_llama_slots
     ctx.services.validate_runtime_dependencies = validate_runtime_dependencies
 
 
@@ -493,6 +494,31 @@ def get_local_llama_metrics(host, port):
         return None, f"llama-server metrics returned HTTP {exc.code}."
     except Exception as exc:
         return None, f"Failed to fetch llama-server metrics: {exc}"
+
+
+def get_local_llama_slots(host, port):
+    try:
+        parsed_port = int(port or LLAMA_PORT)
+    except (TypeError, ValueError):
+        return None, "Invalid llama-server slots port."
+    if parsed_port < 1 or parsed_port > 65535:
+        return None, "Invalid llama-server slots port."
+
+    metrics_host, host_error = get_metrics_host(host)
+    if not metrics_host:
+        return None, host_error
+
+    url = f"http://{metrics_host}:{parsed_port}/slots"
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            raw = resp.read(WEB_SEARCH_FETCH_BYTES)
+            charset = resp.headers.get_content_charset() or "utf-8"
+            return raw.decode(charset, errors="replace"), ""
+    except urllib.error.HTTPError as exc:
+        return None, f"llama-server slots returned HTTP {exc.code}."
+    except Exception as exc:
+        return None, f"Failed to fetch llama-server slots: {exc}"
 
 
 def write_sse(wfile, data):
@@ -809,6 +835,7 @@ API_ROUTER = (
     .add("GET", "/api/hf/download-status", hf_download_routes.get_download_status)
     .add("GET", "/api/remote-tunnel/status", tunnel_routes.get_status)
     .add("GET", "/api/llama/metrics", metrics_routes.get_metrics)
+    .add("GET", "/api/llama/slots", metrics_routes.get_slots)
     .add("GET", "/api/models", models_routes.list_models)
     .add("GET", "/api/app-update-status", git_update_routes.get_status)
     .add("GET", "/api/presets", presets_routes.list_presets)

--- a/backend/context.py
+++ b/backend/context.py
@@ -54,6 +54,7 @@ class BackendServices:
     current_platform: str = "unknown"
     find_tool_executable: Callable[[str], Path] = _missing_service
     get_local_llama_metrics: Callable[[str, str], Tuple[Optional[str], str]] = _missing_service
+    get_local_llama_slots: Callable[[str, str], Tuple[Optional[str], str]] = _missing_service
     get_platform_label: Callable[[], str] = _missing_service
     get_runtime_files: Callable[[], Sequence[Path]] = _missing_service
     get_tool_filename: Callable[[str], str] = _missing_service

--- a/backend/routes/metrics.py
+++ b/backend/routes/metrics.py
@@ -13,3 +13,15 @@ def get_metrics(request, response, ctx):
         response.error(error, 502)
         return
     response.text(metrics_text)
+
+
+def get_slots(request, response, ctx):
+    query = urllib.parse.parse_qs(request.query)
+    slots_text, error = ctx.services.get_local_llama_slots(
+        (query.get("host") or [ctx.config.llama_host])[0],
+        (query.get("port") or [str(ctx.config.llama_port)])[0],
+    )
+    if slots_text is None:
+        response.error(error, 502)
+        return
+    response.text(slots_text, content_type="application/json; charset=utf-8")

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -118,6 +118,7 @@ Built-in (Neutral/Balanced/Creative/Precise) + custom presets:
 
 Live Prometheus stats polled from `llama-server`:
 - Prompt/gen token counts and speeds, KV cache usage
+- KV usage falls back to proxied `/slots` data when the active `llama-server` build does not expose `llamacpp:kv_cache_usage_ratio`
 - Polling starts ~2s after launch, every 3s
 
 ## Frontend Smoke Tests

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -204,6 +204,46 @@ class ExtractedRouteTests(unittest.TestCase):
             self.assertEqual(calls, [("localhost", "9090")])
             self.assertEqual(response.text_payload, "llama metrics")
 
+    def test_slots_route_uses_context_service(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            calls = []
+
+            def get_local_llama_slots(host, port):
+                calls.append((host, port))
+                return '[{"id":0,"n_ctx":4096}]', ""
+
+            ctx.services.get_local_llama_slots = get_local_llama_slots
+            response = DummyResponse()
+
+            metrics.get_slots(
+                Request("GET", "/api/llama/slots", "host=localhost&port=9090", {}),
+                response,
+                ctx,
+            )
+
+            self.assertEqual(calls, [("localhost", "9090")])
+            self.assertEqual(response.text_payload, '[{"id":0,"n_ctx":4096}]')
+
+    def test_slots_route_returns_proxy_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+
+            def get_local_llama_slots(host, port):
+                return None, "llama-server slots returned HTTP 404."
+
+            ctx.services.get_local_llama_slots = get_local_llama_slots
+            response = DummyResponse()
+
+            metrics.get_slots(
+                Request("GET", "/api/llama/slots", "host=localhost&port=9090", {}),
+                response,
+                ctx,
+            )
+
+            self.assertEqual(response.status, 502)
+            self.assertEqual(response.payload["error"], "llama-server slots returned HTTP 404.")
+
     def test_status_route_uses_context_services(self):
         with tempfile.TemporaryDirectory() as tmp:
             ctx = make_context(tmp)

--- a/tests/frontend/flag_sync_smoke.cjs
+++ b/tests/frontend/flag_sync_smoke.cjs
@@ -159,8 +159,24 @@ async function main() {
                     "llamacpp:prompt_tokens_seconds 0",
                     "llamacpp:tokens_predicted_total 0",
                     "llamacpp:predicted_tokens_seconds 0",
-                    "llamacpp:kv_cache_usage_ratio 0",
                 ].join("\n"),
+            });
+        });
+
+        await page.route("**/api/llama/slots**", async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: "application/json",
+                body: JSON.stringify([
+                    { id: 0, n_ctx: 1000, speculative: false, is_processing: false },
+                    {
+                        id: 1,
+                        n_ctx: 1000,
+                        speculative: false,
+                        is_processing: false,
+                        next_token: [{ n_decoded: 125, n_remain: 875 }],
+                    },
+                ]),
             });
         });
 
@@ -239,6 +255,9 @@ async function main() {
         await page.waitForFunction(() => document.querySelector("#quick-metrics-toggle")?.checked === false);
         await page.click("#flag-metrics");
         await page.waitForFunction(() => document.querySelector("#quick-metrics-toggle")?.checked === true);
+        await page.evaluate(() => startStatsPolling());
+        await page.waitForFunction(() => document.querySelector("#stats-kv-usage")?.textContent === "13%");
+        await page.evaluate(() => stopStatsPolling());
 
         await selectSection(page, "chat");
         await page.evaluate(() => {

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -692,7 +692,10 @@ async function pollStats() {
         const promptSpeed = metrics["llamacpp:prompt_tokens_seconds"];
         const genTokens = metrics["llamacpp:tokens_predicted_total"];
         const genSpeed = metrics["llamacpp:predicted_tokens_seconds"];
-        const kvUsage = metrics["llamacpp:kv_cache_usage_ratio"];
+        let kvUsage = metrics["llamacpp:kv_cache_usage_ratio"];
+        if (kvUsage === undefined) {
+            kvUsage = await fetchSlotKvUsage(host, port);
+        }
         if (promptTokens !== undefined) chatStatsRaw.promptTokens = promptTokens;
         if (genTokens !== undefined) chatStatsRaw.genTokens = genTokens;
         const deltaPrompt = promptTokens !== undefined ? Math.max(0, promptTokens - chatStatsBaseline.promptTokens) : null;
@@ -720,6 +723,34 @@ async function pollStats() {
     } finally {
         pollStatsActive = false;
     }
+}
+
+async function fetchSlotKvUsage(host, port) {
+    try {
+        const params = new URLSearchParams({ host, port: String(port) });
+        const resp = await fetch(`/api/llama/slots?${params.toString()}`);
+        if (!resp.ok) return undefined;
+        const slots = await resp.json();
+        return getSlotKvUsage(slots);
+    } catch (e) {
+        console.debug("Failed to fetch llama-server slots for KV usage", e);
+        return undefined;
+    }
+}
+
+function getSlotKvUsage(slots) {
+    if (!Array.isArray(slots)) return undefined;
+    let maxUsage;
+    for (const slot of slots) {
+        const nCtx = Number(slot?.n_ctx);
+        if (!Number.isFinite(nCtx) || nCtx <= 0) continue;
+        const tokenState = Array.isArray(slot.next_token) ? slot.next_token[0] : null;
+        const nDecoded = Number(tokenState?.n_decoded);
+        if (!Number.isFinite(nDecoded) || nDecoded < 0) continue;
+        const usage = Math.max(0, Math.min(1, nDecoded / nCtx));
+        maxUsage = maxUsage === undefined ? usage : Math.max(maxUsage, usage);
+    }
+    return maxUsage;
 }
 
 async function pollOutput() {


### PR DESCRIPTION
Provide a fallback for KV/context usage when llama-server does not expose the `llamacpp:kv_cache_usage_ratio` metric. Adds a new backend service (get_local_llama_slots), registers the GET /api/llama/slots route, and implements proxy logic to fetch /slots from a local llama-server instance. The frontend now falls back to calling /api/llama/slots and computes slot-based KV usage when the direct metric is absent. Tests and smoke tests were added/updated to cover the new route and the frontend behavior; documentation and README/AGENTS entries were updated to mention the fallback.