### PR TITLE
Add Linux CUDA build toolkit

### DIFF
--- a/Linux_compile_toolkit/build_llama_cpp_cuda.sh
+++ b/Linux_compile_toolkit/build_llama_cpp_cuda.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================
+# build_llama_cpp_cuda.sh
+# Fetches/updates the latest llama.cpp source and compiles a
+# portable CUDA-enabled build for Linux, then packages the
+# binaries into a tar.gz.
+#
+# Prerequisites on the build host:
+#   - git, cmake, nvcc (CUDA toolkit), nproc
+#   - strip is optional; it is used to reduce binary size when available
+#
+# The target machine must have CUDA drivers installed.
+# Shared libraries (libcudart, libcublas, etc.) are NOT bundled.
+# ============================================================
+
+REPO_URL="https://github.com/ggml-org/llama.cpp.git"
+SOURCE_DIR="llama.cpp"
+BUILD_DIR="build"
+DIST_DIR="dist"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+PACKAGE_NAME="llama-cpp-cuda-linux-${TIMESTAMP}.tar.gz"
+
+# ---- helpers ------------------------------------------------
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info()  { echo -e "${GREEN}==>${NC} $*"; }
+warn()  { echo -e "${YELLOW}!!>${NC} $*"; }
+error() { echo -e "${RED}XX>${NC} $*" >&2; }
+
+die() {
+    error "$*"
+    exit 1
+}
+
+# ---- 1. prerequisite checks ---------------------------------
+
+info "Checking prerequisites"
+
+for cmd in git cmake nvcc; do
+    if ! command -v "$cmd" &>/dev/null; then
+        die "'$cmd' is not installed or not in PATH. Please install it before running this script."
+    fi
+done
+
+if ! command -v nproc &>/dev/null; then
+    die "'nproc' is not installed or not in PATH. Please install coreutils."
+fi
+
+CMAKE_MIN_VERSION="3.20"
+CMAKE_VERSION=$(cmake --version | head -n1 | awk '{print $3}')
+info "  cmake version: $CMAKE_VERSION"
+
+# Compare versions (sort -V works on most Linux distros)
+LOWER=$(printf '%s\n%s\n' "$CMAKE_MIN_VERSION" "$CMAKE_VERSION" | sort -V | head -n1)
+if [[ "$LOWER" != "$CMAKE_MIN_VERSION" ]]; then
+    die "CMake $CMAKE_MIN_VERSION or newer is required (found $CMAKE_VERSION)"
+fi
+
+info "  git version:   $(git --version)"
+info "  nvcc version:  $(nvcc --version | tail -n1)"
+if command -v strip &>/dev/null; then
+    STRIP_BIN="$(command -v strip)"
+    info "  strip:         $STRIP_BIN"
+else
+    STRIP_BIN=""
+    warn "  strip is not installed; binaries will not be stripped."
+fi
+
+# ---- 2. source management -----------------------------------
+
+info "Managing llama.cpp source"
+
+if [[ -d "$SOURCE_DIR" ]]; then
+    if [[ -d "$SOURCE_DIR/.git" ]]; then
+        cd "$SOURCE_DIR"
+
+        # Check for dirty / modified files
+        if ! git diff --quiet || ! git diff --cached --quiet; then
+            die "Working tree in '$SOURCE_DIR' is dirty. Please stash or discard local changes and re-run."
+        fi
+
+        info "  Updating existing repo via git pull --ff-only"
+        if ! git pull --ff-only; then
+            die "git pull failed. You may need to reset or re-clone manually."
+        fi
+
+        cd ..
+    else
+        die "Directory '$SOURCE_DIR' exists but is not a git repository. Please remove it and re-run."
+    fi
+else
+    info "  Cloning $REPO_URL"
+    git clone --depth 1 "$REPO_URL" "$SOURCE_DIR"
+fi
+
+cd "$SOURCE_DIR"
+
+# ---- 3. build configuration ---------------------------------
+
+info "Configuring CMake (portable CUDA build)"
+
+cmake -B "$BUILD_DIR" \
+    -DGGML_CUDA=ON \
+    -DGGML_NATIVE=OFF \
+    -DCMAKE_BUILD_TYPE=Release
+
+# ---- 4. compilation -----------------------------------------
+
+info "Compiling (this may take several minutes)"
+
+PARALLEL_JOBS=$(nproc)
+cmake --build "$BUILD_DIR" --config Release -j "$PARALLEL_JOBS"
+
+# ---- 5. strip binaries --------------------------------------
+
+info "Stripping release binaries"
+
+BIN_DIR="$BUILD_DIR/bin"
+if [[ -n "$STRIP_BIN" && -d "$BIN_DIR" ]]; then
+    find "$BIN_DIR" -maxdepth 1 -type f -executable -print0 | while IFS= read -r -d '' binary; do
+        "$STRIP_BIN" "$binary" 2>/dev/null || true
+    done
+elif [[ -z "$STRIP_BIN" ]]; then
+    warn "Skipping strip step because 'strip' is not available."
+fi
+
+# ---- 6. verification ----------------------------------------
+
+info "Verifying build artifacts"
+
+REQUIRED_BINS=("llama-cli" "llama-server" "llama-quantize")
+MISSING=()
+
+for bin in "${REQUIRED_BINS[@]}"; do
+    if [[ ! -f "$BIN_DIR/$bin" ]]; then
+        MISSING+=("$bin")
+    fi
+done
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+    die "Build verification failed - missing binaries: ${MISSING[*]}"
+fi
+
+info "  Build successful!"
+
+# ---- 7. packaging -------------------------------------------
+
+info "Packaging binaries"
+
+mkdir -p "../$DIST_DIR"
+STAGE_DIR="../$DIST_DIR/llama-cpp-cuda-linux-${TIMESTAMP}"
+mkdir -p "$STAGE_DIR/bin"
+
+# Copy all executables from the build bin directory
+cp -a "$BIN_DIR/"* "$STAGE_DIR/bin/"
+
+# Create tarball
+cd "../$DIST_DIR"
+tar -czf "$PACKAGE_NAME" "$(basename "$STAGE_DIR")"
+
+# Clean up stage directory
+rm -rf "$(basename "$STAGE_DIR")"
+
+# ---- 8. summary ---------------------------------------------
+
+info "Done!"
+echo ""
+echo "  Package: $(pwd)/$PACKAGE_NAME"
+echo "  Size:    $(du -h "$PACKAGE_NAME" | cut -f1)"
+echo ""
+echo "  To use on a target Linux machine with CUDA drivers:"
+echo "    tar -xzf $PACKAGE_NAME"
+echo "    cd llama-cpp-cuda-linux-${TIMESTAMP}/bin"
+echo "    ./llama-cli --help"
+echo ""

--- a/Linux_compile_toolkit/description.md
+++ b/Linux_compile_toolkit/description.md
@@ -1,0 +1,70 @@
+# build_llama_cpp_cuda.sh
+
+## Purpose
+
+This script automates fetching the latest `llama.cpp` source code and compiling a **portable, CUDA-enabled build for Linux**. The resulting binaries are packaged into a versioned `.tar.gz` archive, ready to be distributed to other Linux machines that have compatible NVIDIA drivers and CUDA runtime libraries available.
+
+## Behavior
+
+### 1. Prerequisites Check
+The script verifies that the following tools are installed and available in `PATH`:
+- `git`
+- `cmake` (version 3.20 or newer)
+- `nvcc` (NVIDIA CUDA compiler)
+- `nproc` (for parallel compilation)
+- `strip` (optional; used to reduce binary size when available)
+
+If required tools are missing, the script aborts with a clear error message. If `strip` is missing, the build continues and prints a warning.
+
+### 2. Source Management
+- **First run:** Clones the latest `llama.cpp` source from `https://github.com/ggml-org/llama.cpp.git` using a shallow clone (`--depth 1`).
+- **Subsequent runs:** If the `llama.cpp/` directory already exists and is a clean Git repository, the script updates it with `git pull --ff-only`.
+- **Safety:** If the working tree is dirty (has uncommitted changes) or if `llama.cpp/` exists but is not a Git repository, the script aborts rather than risk overwriting data.
+
+### 3. Build Configuration
+CMake is configured for a **portable release build** with these flags:
+- `-DGGML_CUDA=ON` - Enables the CUDA backend.
+- `-DGGML_NATIVE=OFF` - Disables CPU-specific optimizations for the build host, improving CPU portability across Linux machines.
+- `-DCMAKE_BUILD_TYPE=Release` - Produces optimized binaries.
+
+### 4. Compilation
+The project is compiled in parallel using all available CPU cores (`nproc`). This step may take several minutes depending on hardware.
+
+### 5. Stripping
+After a successful build, debug symbols are stripped from all executables in the `build/bin/` directory to reduce file size when `strip` is available.
+
+### 6. Verification
+The script checks that the following key binaries were produced:
+- `llama-cli`
+- `llama-server`
+- `llama-quantize`
+
+If any are missing, the script aborts.
+
+### 7. Packaging
+Binaries are copied into a staging directory and compressed into a timestamped tarball:
+```text
+dist/llama-cpp-cuda-linux-<timestamp>.tar.gz
+```
+
+The staging directory is cleaned up afterward.
+
+### 8. Summary
+Finally, the script prints:
+- The full path to the generated tarball.
+- The tarball's size.
+- Quick usage instructions for the target machine.
+
+## Important Notes
+
+- **Target Machine Requirements:** The destination Linux system must have compatible NVIDIA drivers and runtime libraries available. The script does **not** bundle shared libraries such as `libcudart.so` or `libcublas.so`, so CUDA compatibility still depends on the build host CUDA toolkit and the target machine's driver/runtime combination.
+- **Branch:** The script always builds from the latest `master` branch. It does not currently support checking out specific tags or branches.
+- **Dirty Trees:** Local modifications inside the `llama.cpp/` directory will cause the script to abort. You must stash or discard changes before re-running.
+
+## Usage
+
+```bash
+./build_llama_cpp_cuda.sh
+```
+
+The final tarball will be located in the `dist/` directory.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ chmod +x install.sh mac_linux_start.sh mac_linux_silent_start.sh
 
 Note: some Linux accelerator backends may also require vendor drivers or runtime packages outside of Llama GUI itself.
 
+For users who want to compile `llama.cpp` with CUDA on Linux, the standalone `Linux_compile_toolkit/` folder includes a helper script that fetches upstream `llama.cpp`, builds a CUDA-enabled release, and packages the binaries into a `.tar.gz`.
+
 ### Headless or LAN Access
 
 By default, Llama GUI only listens on `127.0.0.1:5240`. On a trusted LAN or VPN, you can opt in to remote browser access with environment variables:


### PR DESCRIPTION
Add a Linux_compile_toolkit containing build_llama_cpp_cuda.sh (automates cloning/updating ggml-org/llama.cpp, configuring CMake with CUDA, building a portable Release, stripping binaries, verifying artifacts, and packaging them into a timestamped tarball) and a description.md documenting usage and prerequisites. Also update README.md to reference the new toolkit for users who want to compile llama.cpp with CUDA on Linux.