### PR TITLE
Add online installers and one-command install

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ Supported prebuilt backends vary by platform:
 
 ## Quick Start
 
+### One-command install
+
+macOS/Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/thomas9120/LLama-GUI/main/online_installers/install-online.sh | sh
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/thomas9120/LLama-GUI/main/online_installers/install-online.ps1 | iex
+```
+
+The online installer clones Llama GUI into `~/LLama-GUI` on macOS/Linux or `%USERPROFILE%\LLama-GUI` on Windows, installs the Python dependencies, and starts the app. To install somewhere else, set `LLAMA_GUI_INSTALL_DIR` before running the command. To install without starting the app, set `LLAMA_GUI_NO_START=1`.
+
+### Manual install
+
 1. Clone this repository:
 
 ```bash

--- a/online_installers/install-online.ps1
+++ b/online_installers/install-online.ps1
@@ -1,0 +1,83 @@
+$ErrorActionPreference = "Stop"
+
+$repoUrl = if ($env:LLAMA_GUI_REPO_URL) { $env:LLAMA_GUI_REPO_URL } else { "https://github.com/thomas9120/LLama-GUI.git" }
+$repoBranch = if ($env:LLAMA_GUI_BRANCH) { $env:LLAMA_GUI_BRANCH } else { "main" }
+$installDir = if ($env:LLAMA_GUI_INSTALL_DIR) { $env:LLAMA_GUI_INSTALL_DIR } else { Join-Path $HOME "LLama-GUI" }
+
+function Test-Command {
+    param([Parameter(Mandatory = $true)][string]$Name)
+    return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [string[]]$Arguments = @()
+    )
+
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$FilePath exited with code $LASTEXITCODE"
+    }
+}
+
+function Get-PythonCommand {
+    if (Test-Command "py") {
+        return @{ File = "py"; Args = @("-3") }
+    }
+    if (Test-Command "python") {
+        return @{ File = "python"; Args = @() }
+    }
+    return $null
+}
+
+if (-not (Test-Command "git")) {
+    throw "Required command not found: git. Install Git for Windows and rerun this installer."
+}
+
+$python = Get-PythonCommand
+if ($null -eq $python) {
+    throw "Python 3 was not found. Install Python 3.9+ from https://www.python.org/downloads/ and ensure it is available in PATH."
+}
+
+if (Test-Path $installDir) {
+    $gitDir = Join-Path $installDir ".git"
+    if (-not (Test-Path $gitDir)) {
+        throw "Install path already exists but is not a git checkout: $installDir. Set LLAMA_GUI_INSTALL_DIR to a different folder and rerun this installer."
+    }
+
+    Write-Host "Updating existing Llama GUI checkout at $installDir..."
+    Invoke-Native "git" @("-C", $installDir, "pull", "--ff-only")
+} else {
+    Write-Host "Cloning Llama GUI into $installDir..."
+    Invoke-Native "git" @("clone", "--branch", $repoBranch, $repoUrl, $installDir)
+}
+
+Set-Location $installDir
+
+if (-not (Test-Path ".venv")) {
+    Write-Host "Creating local virtual environment..."
+    Invoke-Native $python.File ($python.Args + @("-m", "venv", ".venv"))
+}
+
+$venvPython = Join-Path $installDir ".venv\Scripts\python.exe"
+if (-not (Test-Path $venvPython)) {
+    throw "Virtual environment is missing its Python executable. Delete .venv and rerun this installer."
+}
+
+Write-Host "Upgrading pip..."
+Invoke-Native $venvPython @("-m", "pip", "install", "--upgrade", "pip")
+
+Write-Host "Installing Python dependencies from requirements.txt..."
+Invoke-Native $venvPython @("-m", "pip", "install", "-r", "requirements.txt")
+
+if ($env:LLAMA_GUI_NO_START -eq "1") {
+    Write-Host ""
+    Write-Host "Install complete. Start Llama GUI later with:"
+    Write-Host "  cd `"$installDir`"; .\windows_start.bat"
+    exit 0
+}
+
+Write-Host ""
+Write-Host "Starting Llama GUI..."
+Invoke-Native "cmd.exe" @("/c", "windows_start.bat")

--- a/online_installers/install-online.sh
+++ b/online_installers/install-online.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO_URL="${LLAMA_GUI_REPO_URL:-https://github.com/thomas9120/LLama-GUI.git}"
+REPO_BRANCH="${LLAMA_GUI_BRANCH:-main}"
+INSTALL_DIR="${LLAMA_GUI_INSTALL_DIR:-$HOME/LLama-GUI}"
+
+need_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "[ERROR] Required command not found: $1"
+        exit 1
+    fi
+}
+
+find_python() {
+    if command -v python3 >/dev/null 2>&1; then
+        echo "python3"
+    elif command -v python >/dev/null 2>&1; then
+        echo "python"
+    else
+        echo ""
+    fi
+}
+
+need_cmd git
+
+PY_CMD=$(find_python)
+if [ -z "$PY_CMD" ]; then
+    echo "[ERROR] Python 3 was not found on this system."
+    echo "Install Python 3.9+ and ensure it is available in PATH."
+    exit 1
+fi
+
+if [ -e "$INSTALL_DIR" ]; then
+    if [ ! -d "$INSTALL_DIR/.git" ]; then
+        echo "[ERROR] Install path already exists but is not a git checkout:"
+        echo "        $INSTALL_DIR"
+        echo "Set LLAMA_GUI_INSTALL_DIR to a different folder and rerun this installer."
+        exit 1
+    fi
+    echo "Updating existing Llama GUI checkout at $INSTALL_DIR..."
+    git -C "$INSTALL_DIR" pull --ff-only
+else
+    echo "Cloning Llama GUI into $INSTALL_DIR..."
+    git clone --branch "$REPO_BRANCH" "$REPO_URL" "$INSTALL_DIR"
+fi
+
+cd "$INSTALL_DIR"
+chmod +x install.sh mac_linux_start.sh mac_linux_silent_start.sh 2>/dev/null || true
+
+echo "Installing Python dependencies..."
+./install.sh
+
+if [ "${LLAMA_GUI_NO_START:-0}" = "1" ]; then
+    echo
+    echo "Install complete. Start Llama GUI later with:"
+    echo "  cd \"$INSTALL_DIR\" && ./mac_linux_start.sh"
+    exit 0
+fi
+
+echo
+echo "Starting Llama GUI..."
+exec ./mac_linux_start.sh


### PR DESCRIPTION
Introduce online installers for quick setup: add install-online.sh and install-online.ps1 and document a one-command install in README. The scripts clone or update the repo (defaults to ~/LLama-GUI or %USERPROFILE%\LLama-GUI), create a venv, install Python dependencies, and start the app; they accept environment variables (LLAMA_GUI_INSTALL_DIR, LLAMA_GUI_NO_START, LLAMA_GUI_REPO_URL, LLAMA_GUI_BRANCH) to customize behavior. README updated with curl/PowerShell examples and notes about skipping auto-start or changing the install location.