### PR TITLE
Make installers branch-aware and update remote

### DIFF
--- a/online_installers/install-online.ps1
+++ b/online_installers/install-online.ps1
@@ -47,7 +47,16 @@ if (Test-Path $installDir) {
     }
 
     Write-Host "Updating existing Llama GUI checkout at $installDir..."
-    Invoke-Native "git" @("-C", $installDir, "pull", "--ff-only")
+    Invoke-Native "git" @("-C", $installDir, "remote", "set-url", "origin", $repoUrl)
+    Invoke-Native "git" @("-C", $installDir, "fetch", "origin", $repoBranch)
+    & git -C $installDir show-ref --verify --quiet "refs/heads/$repoBranch"
+    $branchExists = $LASTEXITCODE -eq 0
+    if ($branchExists) {
+        Invoke-Native "git" @("-C", $installDir, "checkout", $repoBranch)
+        Invoke-Native "git" @("-C", $installDir, "merge", "--ff-only", "origin/$repoBranch")
+    } else {
+        Invoke-Native "git" @("-C", $installDir, "checkout", "-b", $repoBranch, "origin/$repoBranch")
+    }
 } else {
     Write-Host "Cloning Llama GUI into $installDir..."
     Invoke-Native "git" @("clone", "--branch", $repoBranch, $repoUrl, $installDir)

--- a/online_installers/install-online.sh
+++ b/online_installers/install-online.sh
@@ -39,7 +39,14 @@ if [ -e "$INSTALL_DIR" ]; then
         exit 1
     fi
     echo "Updating existing Llama GUI checkout at $INSTALL_DIR..."
-    git -C "$INSTALL_DIR" pull --ff-only
+    git -C "$INSTALL_DIR" remote set-url origin "$REPO_URL"
+    git -C "$INSTALL_DIR" fetch origin "$REPO_BRANCH"
+    if git -C "$INSTALL_DIR" show-ref --verify --quiet "refs/heads/$REPO_BRANCH"; then
+        git -C "$INSTALL_DIR" checkout "$REPO_BRANCH"
+        git -C "$INSTALL_DIR" merge --ff-only "origin/$REPO_BRANCH"
+    else
+        git -C "$INSTALL_DIR" checkout -b "$REPO_BRANCH" "origin/$REPO_BRANCH"
+    fi
 else
     echo "Cloning Llama GUI into $INSTALL_DIR..."
     git clone --branch "$REPO_BRANCH" "$REPO_URL" "$INSTALL_DIR"


### PR DESCRIPTION
Replace simple `git pull` with explicit `remote set-url` and `fetch` for the target branch, then verify whether the local branch exists. If it does, checkout and fast-forward merge from `origin/<branch>`; if not, create a new local branch tracking `origin/<branch>`. Changes applied to both PowerShell and shell online installer scripts to ensure correct remote/branch handling during updates.