### PR TITLE
Chat fixes

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -8,7 +8,6 @@ import sys
 import urllib.request
 import urllib.parse
 import urllib.error
-import ipaddress
 
 from backend.config import (
     APP_LOGO_FILE,
@@ -444,31 +443,11 @@ def get_local_chat_api_url(body):
 
 
 def get_local_interface_addresses():
-    addresses = {LLAMA_HOST, "::1"}
-    hostnames = {socket.gethostname(), socket.getfqdn()}
-    for name in hostnames:
-        try:
-            for info in socket.getaddrinfo(name, None):
-                addresses.add(info[4][0])
-        except OSError:
-            pass
-    return addresses
+    return chat_service.get_local_interface_addresses()
 
 
 def get_metrics_host(host):
-    value = str(host or LLAMA_HOST).strip() or LLAMA_HOST
-    if value.lower() == "localhost" or value in {"0.0.0.0", "::", "*"}:
-        return LLAMA_HOST, ""
-    try:
-        infos = socket.getaddrinfo(value, None, type=socket.SOCK_STREAM)
-    except OSError as exc:
-        return "", f"Invalid llama-server metrics host: {exc}"
-    local_addresses = get_local_interface_addresses()
-    for info in infos:
-        ip = ipaddress.ip_address(info[4][0])
-        if ip.is_loopback or info[4][0] in local_addresses:
-            return value, ""
-    return "", "Blocked: metrics proxy can only target this machine."
+    return chat_service.get_local_proxy_host(host)
 
 
 def get_local_llama_metrics(host, port):

--- a/backend/services/web_search.py
+++ b/backend/services/web_search.py
@@ -4,6 +4,7 @@ import html
 import ipaddress
 import re
 import socket
+import sys
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -89,7 +90,8 @@ def html_to_readable_text(raw_html: str) -> str:
         parser.feed(raw_html)
         parser.close()
         return parser.text()
-    except Exception:
+    except Exception as exc:
+        print(f"[web_search] HTML parser failed, using regex fallback: {exc}", file=sys.stderr)
         text = re.sub(r"(?is)<(script|style|noscript|svg).*?</\1>", " ", raw_html)
         text = re.sub(r"(?s)<[^>]+>", " ", text)
         text = html.unescape(text)

--- a/chat_review.md
+++ b/chat_review.md
@@ -1,0 +1,249 @@
+# Chat Components Code Review
+
+## Files Reviewed
+
+| File | Size | Role |
+|------|------|------|
+| `ui/js/chat-ui.js` | 681 lines | Main chat tab logic |
+| `ui/js/chat-rendering.js` | 295 lines | Markdown rendering, DOM helpers |
+| `ui/js/sampler-presets.js` | 361 lines | Sampler preset CRUD |
+| `ui/js/app.js` (chat-related) | ~160 lines | Stats polling, tool lifecycle, chat init |
+| `ui/js/flag-core.js` (chat-related) | ~10 lines | Chat template filtering in launch args |
+| `ui/js/config-flags-ui.js` (chat-related) | ~20 lines | Chat template flag rendering |
+| `ui/js/api-tab.js` (chat-related) | ~6 lines | API endpoint/snippet rendering |
+| `ui/js/quick-launch-ui.js` (chat-related) | ~3 lines | Chat template sync |
+| `ui/js/app-data.js` (chat-related) | ~8 lines | Chat sampler slider map |
+| `backend/routes/chat.py` | 136 lines | Chat completions route |
+| `backend/services/chat.py` | 99 lines | Chat proxy helpers |
+| `backend/services/web_search.py` | 214 lines | Web search service |
+
+---
+
+## Issues Found
+
+### 1. `chat-rendering.js` — `renderMarkdown` uses `innerHTML` for model output (Medium risk)
+
+**File:** `ui/js/chat-rendering.js`, lines 173-175 and 277
+
+```js
+bubble.innerHTML = renderMarkdown(content);
+```
+
+The AGENTS.md explicitly says: *"Never use `innerHTML` with user/model content. Use `textContent` for user-facing text. The `renderMarkdown()` function is the one exception for model output."*
+
+This is a documented exception, but it means **any model output can inject arbitrary HTML**. If a model is compromised or the template is mishandled, this is a stored XSS vector. The `rawText` is preserved in `dataset.rawText` for copy purposes, but the rendered HTML is what the user sees.
+
+**Recommendation:** Consider a safer markdown parser (like `DOMPurify` + `showdown` or a custom sanitizer) to strip dangerous attributes/protocols while preserving formatting.
+
+---
+
+### 2. `chat-rendering.js` — `appendChatStreamToken` re-renders the entire bubble on every token (Performance)
+
+**File:** `ui/js/chat-rendering.js`, lines 275-280
+
+```js
+function appendChatStreamToken(bubble, token) {
+    bubble.dataset.rawText = (bubble.dataset.rawText || "") + token;
+    bubble.innerHTML = renderMarkdown(bubble.dataset.rawText);
+    // ...
+}
+```
+
+Every streamed token triggers a full markdown re-parse and DOM re-render of the entire message. For long responses (1000+ tokens), this compounds: each render processes progressively more text.
+
+**Recommendation:** Incremental rendering — append raw text, then only re-render the new portion. Or debounce slightly. This is a low-priority optimization unless users report lag on long responses.
+
+---
+
+### 3. `chat-ui.js` — Conversation history can silently overflow localStorage (Medium risk)
+
+**File:** `ui/js/chat-ui.js`, lines 327-341
+
+```js
+function saveConversationsToStorage(list) {
+    try {
+        localStorage.setItem(CHAT_CONVERSATIONS_STORAGE_KEY, JSON.stringify(list));
+    } catch (e) {
+        console.warn("Failed to save conversations to localStorage:", e);
+    }
+}
+```
+
+There's no size check or rotation. If a user has many long conversations, localStorage (typically 5-10 MB) can fill up. The `console.warn` is logged but the user gets no feedback.
+
+**Recommendation:** Add a max-conversation limit (e.g., 50) and delete oldest conversations when exceeded. Or add a size check with user notification.
+
+---
+
+### 4. `backend/services/chat.py` — `build_search_context` truncates at 3500 chars (Design note)
+
+**File:** `backend/services/chat.py`, lines 41-42
+
+```python
+if len(text) > 3500:
+    text = text[:3500].rstrip() + "\n... (source excerpt truncated)"
+```
+
+This is a reasonable limit, but 3500 chars per source may be tight for 10 sources (35,000 chars total context). Combined with the system prompt and conversation history, this could exceed the model's context window.
+
+**Recommendation:** No code change needed, but document this limit in the UI or allow users to adjust it.
+
+---
+
+### 5. `backend/services/chat.py` — `get_local_proxy_host` duplicate logic (Code smell)
+
+**File:** `backend/services/chat.py`, lines 72-85 and lines 59-69
+
+The `get_local_interface_addresses` function is called by `get_local_proxy_host`, and the same logic is duplicated in `backend/app.py` (lines 446-455).
+
+**Recommendation:** Extract this into a shared utility and import it from both places.
+
+---
+
+### 6. `backend/services/web_search.py` — `fetch_page_text` silent HTMLParser fallback (Low risk)
+
+**File:** `backend/services/web_search.py`, lines 86-96
+
+```python
+def html_to_readable_text(raw_html: str) -> str:
+    parser = ReadableHTMLParser()
+    try:
+        parser.feed(raw_html)
+        parser.close()
+        return parser.text()
+    except Exception:
+        text = re.sub(r"(?is)<(script|style|noscript|svg).*?</\1>", " ", raw_html)
+        # ...
+```
+
+The `except Exception` silently falls back to regex-based extraction. If the parser fails for a specific page, the fallback may produce different quality output without warning.
+
+**Recommendation:** Log parser failures to stderr so quality issues can be diagnosed.
+
+---
+
+### 7. `app.js` — Stats polling has no error recovery for permanent failures (Medium risk)
+
+**File:** `ui/js/app.js`, lines 676-726
+
+```js
+async function pollStats() {
+    if (pollStatsActive) return;
+    pollStatsActive = true;
+    try {
+        // ... fetch metrics ...
+    } catch (e) {
+        // server not ready yet or metrics unavailable
+    } finally {
+        pollStatsActive = false;
+    }
+}
+```
+
+The catch block silently swallows errors (empty catch body). Unlike the output polling which has a retry counter (`pollOutputFailCount`), stats polling never reports failure to the user or attempts recovery.
+
+**AGENTS.md says:** *"Never use empty `catch` without re-raising or logging. Use `console.debug()` for expected optional failures."*
+
+**Recommendation:** Add `console.debug()` in the catch block per AGENTS.md guidelines.
+
+---
+
+### 8. `backend/routes/chat.py` — `web_sources` sent before content is fully streamed (Minor logic note)
+
+**File:** `backend/routes/chat.py`, lines 68-69
+
+```python
+writer.write({"type": "web_sources", "sources": sources})
+writer.write({"type": "web_status", "content": "Answering..."})
+```
+
+The sources are written to the SSE stream **before** the model actually starts generating. The frontend receives them and renders them, but the assistant's response text hasn't started flowing yet. This means sources appear below the empty bubble before any text.
+
+**Recommendation:** This is arguably fine UX (sources appear while waiting for the model to start). Not a bug.
+
+---
+
+### 9. `backend/app.py` — Chat route is registered without CORS-specific handling (Security note)
+
+**File:** `backend/app.py`, line 843
+
+```python
+.add("POST", "/api/chat/completions", chat_routes.completions)
+```
+
+The chat route inherits the general CORS handling. It sends the raw llama-server response to the frontend (including SSE), which means any llama-server response headers (including potentially sensitive ones) are forwarded.
+
+**Recommendation:** This is acceptable for a local-first app. No change needed.
+
+---
+
+### 10. `chat-ui.js` — `undoMessage` doesn't handle system prompt separation (Minor logic note)
+
+**File:** `ui/js/chat-ui.js`, lines 285-304
+
+The system prompt is stored separately (in the DOM textarea) and prepended to the messages list at send time (line 157-158), but it's not part of the `chatMessages` array. Undo correctly pops from `chatMessages` only. This is correct behavior, but the system prompt is not part of the conversation history storage either — it's re-read from the DOM on each save.
+
+**Recommendation:** This is correct as-is. The system prompt is a per-conversation setting stored alongside messages, so it's fine.
+
+---
+
+### 11. `app.js` — `restoreRunningState` only restores tool/API host, not full flag state (Minor)
+
+**File:** `ui/js/app.js`, lines 511-548
+
+When the page reloads and finds a running server, it only restores the tool and API host/port from the status. It doesn't restore other flag values from the server's actual configuration.
+
+**Recommendation:** This is out of scope for a code review — it's a design decision for the app's "restore running state" feature.
+
+---
+
+### 12. `chat-ui.js` — `sendMessage` has no rate limiting (Minor note)
+
+**File:** `ui/js/chat-ui.js`, lines 141-142
+
+```js
+async function sendMessage(userText) {
+    if (chatStreaming || !userText.trim()) return;
+```
+
+The `chatStreaming` guard prevents concurrent requests, but there's no debounce on the input field. Users can rapidly press Enter multiple times before the first request completes (the guard works, but the input field autosize happens immediately).
+
+**Recommendation:** The existing guard is actually sufficient. This is a minor note, not a bug.
+
+---
+
+### 13. `backend/routes/chat.py` — Generic `except Exception` with tunnel-aware sanitization (Low risk, acceptable)
+
+**File:** `backend/routes/chat.py`, lines 131-134
+
+```python
+except Exception as exc:
+    tunnel_active = bool(ctx.state.remote_tunnel.snapshot().get("url"))
+    writer.write({"error": {"message": sanitize_sse_error(exc, tunnel_active)}})
+    writer.write("[DONE]")
+```
+
+This catches all exceptions in the chat proxy. The `sanitize_sse_error` function is used for tunnel security, but this means any unexpected error in the chat flow (e.g., malformed response from llama-server, network issues) is silently sanitized for the client while the real error goes to stderr.
+
+**Recommendation:** This is acceptable per AGENTS.md guidelines. The error is logged to stderr. No change needed.
+
+---
+
+## Summary
+
+| Severity | Count | Details |
+|-----------|-------|---------|
+| Security | 1 | XSS via `innerHTML` with model output (documented exception, but worth noting) |
+| Performance | 1 | Full re-render of markdown on every streamed token |
+| Reliability | 3 | localStorage overflow, silent stats errors, parser fallback |
+| Code quality | 1 | Duplicate host validation logic |
+| Design | 2 | 3500-char truncation, partial state restoration |
+| Minor/Notes | 3 | Rate limiting (guard sufficient), web_sources timing, undo/system prompt |
+| Acceptable | 1 | Generic exception handling (per AGENTS.md) |
+
+## Actionable Items
+
+1. **Add `console.debug()` to the stats polling catch block** (line 721-722 in `app.js`)
+2. **Consider localStorage rotation for conversation history** to prevent silent failures on large histories
+3. **Consider incremental markdown rendering** for performance on long responses
+4. **Extract duplicate host validation logic** into a shared utility

--- a/docs/mockups/configure-tab-redesign.html
+++ b/docs/mockups/configure-tab-redesign.html
@@ -1,0 +1,771 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Llama GUI Configure Redesign Mockup</title>
+  <style>
+    :root {
+      --bg: #090d14;
+      --panel: #101722;
+      --panel-2: #151e2b;
+      --panel-3: #1b2635;
+      --ink: #eef4ff;
+      --muted: #9aa8be;
+      --faint: #69758a;
+      --line: rgba(226, 238, 255, 0.1);
+      --line-strong: rgba(226, 238, 255, 0.18);
+      --blue: #63a7ff;
+      --blue-2: #8fd4ff;
+      --green: #70e39a;
+      --yellow: #f2ca66;
+      --red: #ff6f91;
+      --violet: #bfa5ff;
+      --shadow: 0 20px 70px rgba(0, 0, 0, 0.42);
+      --mono: "JetBrains Mono", "Cascadia Code", Consolas, monospace;
+      --font: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at 12% 0%, rgba(99, 167, 255, 0.16), transparent 30%),
+        radial-gradient(circle at 88% 14%, rgba(112, 227, 154, 0.12), transparent 28%),
+        linear-gradient(145deg, #070a10 0%, var(--bg) 48%, #0d1118 100%);
+      color: var(--ink);
+      font-family: var(--font);
+      font-size: 14px;
+      letter-spacing: 0;
+    }
+
+    button, input, select, textarea { font: inherit; }
+    button { cursor: pointer; }
+
+    .shell {
+      display: grid;
+      grid-template-columns: 248px minmax(0, 1fr);
+      min-height: 100vh;
+    }
+
+    .sidebar {
+      border-right: 1px solid var(--line);
+      background: rgba(12, 17, 25, 0.86);
+      backdrop-filter: blur(22px);
+      padding: 20px 14px;
+      position: sticky;
+      top: 0;
+      height: 100vh;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 8px 10px 22px;
+      border-bottom: 1px solid var(--line);
+      margin-bottom: 16px;
+    }
+
+    .mark {
+      width: 38px;
+      height: 38px;
+      border-radius: 10px;
+      background: linear-gradient(135deg, var(--blue), var(--green));
+      box-shadow: 0 12px 30px rgba(99, 167, 255, 0.25);
+      display: grid;
+      place-items: center;
+      color: #061019;
+      font-weight: 900;
+    }
+
+    .brand strong { display: block; font-size: 15px; }
+    .brand span { color: var(--muted); font-size: 11px; }
+
+    .nav {
+      display: grid;
+      gap: 4px;
+    }
+
+    .nav button {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      width: 100%;
+      padding: 10px 12px;
+      color: var(--muted);
+      background: transparent;
+      border: 1px solid transparent;
+      border-radius: 8px;
+      text-align: left;
+    }
+
+    .nav button.active {
+      color: var(--ink);
+      background: rgba(99, 167, 255, 0.12);
+      border-color: rgba(99, 167, 255, 0.22);
+      box-shadow: inset 3px 0 0 var(--blue);
+    }
+
+    .main {
+      padding: 24px;
+      min-width: 0;
+    }
+
+    .hero {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background:
+        linear-gradient(135deg, rgba(99, 167, 255, 0.16), transparent 34%),
+        linear-gradient(180deg, rgba(21, 30, 43, 0.96), rgba(15, 22, 33, 0.96));
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .topbar {
+      display: grid;
+      grid-template-columns: minmax(260px, 1.4fr) minmax(420px, 2fr);
+      gap: 22px;
+      padding: 22px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .title-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 8px;
+    }
+
+    .eyebrow {
+      color: var(--blue-2);
+      text-transform: uppercase;
+      font-size: 11px;
+      font-weight: 750;
+      letter-spacing: 0.08em;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 28px;
+      line-height: 1.1;
+      letter-spacing: 0;
+    }
+
+    .subtitle {
+      color: var(--muted);
+      max-width: 620px;
+      margin: 10px 0 0;
+      line-height: 1.55;
+    }
+
+    .status-strip {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 16px;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      height: 28px;
+      padding: 0 10px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      color: var(--muted);
+      background: rgba(255, 255, 255, 0.035);
+      font-size: 12px;
+      white-space: nowrap;
+    }
+
+    .dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: var(--green);
+      box-shadow: 0 0 18px rgba(112, 227, 154, 0.8);
+    }
+
+    .control-board {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 10px;
+      align-items: end;
+    }
+
+    .field {
+      display: grid;
+      gap: 6px;
+      min-width: 0;
+    }
+
+    label {
+      color: var(--muted);
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    select, input, textarea {
+      width: 100%;
+      color: var(--ink);
+      background: rgba(7, 10, 16, 0.7);
+      border: 1px solid var(--line-strong);
+      border-radius: 7px;
+      outline: none;
+    }
+
+    select, input { height: 40px; padding: 0 11px; }
+    textarea { min-height: 94px; padding: 12px; resize: vertical; }
+
+    .btn {
+      height: 40px;
+      border: 1px solid var(--line-strong);
+      border-radius: 7px;
+      background: rgba(255, 255, 255, 0.04);
+      color: var(--ink);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      padding: 0 12px;
+      white-space: nowrap;
+    }
+
+    .btn.primary {
+      border-color: rgba(112, 227, 154, 0.45);
+      background: linear-gradient(135deg, var(--green), #52c7ff);
+      color: #061019;
+      font-weight: 800;
+      box-shadow: 0 14px 34px rgba(82, 199, 255, 0.22);
+    }
+
+    .btn.ghost { color: var(--muted); }
+    .btn.icon { width: 40px; padding: 0; }
+
+    .content {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 360px;
+      gap: 18px;
+      padding: 18px;
+    }
+
+    .workbench {
+      display: grid;
+      gap: 14px;
+      min-width: 0;
+    }
+
+    .searchbar {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto auto auto;
+      gap: 8px;
+      align-items: center;
+      padding: 10px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: rgba(9, 13, 20, 0.55);
+    }
+
+    .searchbar input {
+      border: 0;
+      background: transparent;
+      height: 34px;
+      padding-left: 4px;
+    }
+
+    .category-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .category {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: rgba(16, 23, 34, 0.86);
+      padding: 14px;
+      min-height: 112px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .category.active {
+      border-color: rgba(99, 167, 255, 0.45);
+      background: linear-gradient(180deg, rgba(99, 167, 255, 0.16), rgba(16, 23, 34, 0.86));
+    }
+
+    .category h3 {
+      margin: 0 0 8px;
+      font-size: 14px;
+    }
+
+    .category p {
+      margin: 0;
+      color: var(--muted);
+      line-height: 1.45;
+      font-size: 12px;
+    }
+
+    .category .count {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+      color: var(--faint);
+      font-size: 11px;
+      font-family: var(--mono);
+    }
+
+    .flag-panel {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+      background: rgba(11, 16, 24, 0.78);
+    }
+
+    .flag-panel-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 14px 16px;
+      border-bottom: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.03);
+    }
+
+    .flag-panel-header h2 {
+      margin: 0;
+      font-size: 16px;
+    }
+
+    .flag-table {
+      display: grid;
+    }
+
+    .flag-row {
+      display: grid;
+      grid-template-columns: minmax(180px, 0.9fr) minmax(260px, 1.2fr) minmax(210px, 0.75fr);
+      gap: 18px;
+      align-items: center;
+      padding: 14px 16px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .flag-row:last-child { border-bottom: 0; }
+
+    .flag-name strong {
+      display: block;
+      margin-bottom: 3px;
+      font-size: 13px;
+    }
+
+    .flag-name code {
+      color: var(--blue-2);
+      font-family: var(--mono);
+      font-size: 11px;
+    }
+
+    .flag-desc {
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    .segmented {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      border: 1px solid var(--line-strong);
+      border-radius: 7px;
+      overflow: hidden;
+      background: rgba(6, 9, 14, 0.62);
+    }
+
+    .segmented button {
+      height: 36px;
+      border: 0;
+      border-right: 1px solid var(--line);
+      background: transparent;
+      color: var(--muted);
+    }
+
+    .segmented button:last-child { border-right: 0; }
+    .segmented .selected { background: rgba(99, 167, 255, 0.18); color: var(--ink); }
+
+    .range {
+      display: grid;
+      grid-template-columns: 1fr 54px;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .slider {
+      height: 6px;
+      border-radius: 999px;
+      background: linear-gradient(90deg, var(--blue) 0 62%, rgba(255, 255, 255, 0.12) 62%);
+    }
+
+    .value {
+      font-family: var(--mono);
+      color: var(--ink);
+      font-size: 12px;
+      text-align: right;
+    }
+
+    .switch {
+      width: 48px;
+      height: 26px;
+      border-radius: 999px;
+      border: 1px solid rgba(112, 227, 154, 0.4);
+      background: rgba(112, 227, 154, 0.16);
+      padding: 3px;
+      justify-self: start;
+    }
+
+    .knob {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background: var(--green);
+      margin-left: 20px;
+      box-shadow: 0 0 18px rgba(112, 227, 154, 0.7);
+    }
+
+    .side {
+      display: grid;
+      gap: 14px;
+      align-content: start;
+    }
+
+    .card {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: rgba(16, 23, 34, 0.82);
+      overflow: hidden;
+    }
+
+    .card-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 13px 14px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .card-head h3 {
+      margin: 0;
+      font-size: 13px;
+    }
+
+    .card-body {
+      padding: 14px;
+      display: grid;
+      gap: 12px;
+    }
+
+    .score {
+      display: grid;
+      grid-template-columns: 68px 1fr;
+      gap: 12px;
+      align-items: center;
+    }
+
+    .ring {
+      width: 68px;
+      height: 68px;
+      border-radius: 50%;
+      background:
+        radial-gradient(circle at center, #101722 0 56%, transparent 57%),
+        conic-gradient(var(--green) 0 78%, rgba(255, 255, 255, 0.12) 78% 100%);
+      display: grid;
+      place-items: center;
+      font-weight: 850;
+      color: var(--green);
+    }
+
+    .mini-list {
+      display: grid;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 12px;
+    }
+
+    .mini-row {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 8px;
+    }
+
+    .mini-row:last-child {
+      border-bottom: 0;
+      padding-bottom: 0;
+    }
+
+    .mini-row strong { color: var(--ink); font-weight: 700; }
+
+    .command {
+      font-family: var(--mono);
+      color: var(--green);
+      font-size: 12px;
+      line-height: 1.65;
+      background: rgba(3, 6, 10, 0.66);
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      padding: 12px;
+      word-break: break-word;
+    }
+
+    .args textarea {
+      font-family: var(--mono);
+      color: var(--blue-2);
+      font-size: 12px;
+    }
+
+    .footer-launch {
+      position: sticky;
+      bottom: 0;
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto auto;
+      gap: 10px;
+      align-items: center;
+      margin-top: 18px;
+      padding: 12px;
+      border: 1px solid var(--line-strong);
+      border-radius: 8px;
+      background: rgba(9, 13, 20, 0.88);
+      backdrop-filter: blur(22px);
+      box-shadow: 0 -18px 60px rgba(0, 0, 0, 0.25);
+    }
+
+    .launch-copy {
+      min-width: 0;
+      color: var(--muted);
+      font-size: 12px;
+    }
+
+    .launch-copy strong {
+      display: block;
+      color: var(--ink);
+      font-size: 13px;
+    }
+
+    svg { width: 16px; height: 16px; stroke: currentColor; stroke-width: 2; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+
+    @media (max-width: 1120px) {
+      .shell { grid-template-columns: 1fr; }
+      .sidebar { display: none; }
+      .topbar, .content { grid-template-columns: 1fr; }
+      .control-board, .category-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .side { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+
+    @media (max-width: 760px) {
+      .main { padding: 12px; }
+      .control-board, .category-grid, .side, .searchbar, .flag-row, .footer-launch { grid-template-columns: 1fr; }
+      .hero { border-radius: 7px; }
+      h1 { font-size: 24px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <aside class="sidebar">
+      <div class="brand">
+        <div class="mark">L</div>
+        <div>
+          <strong>Llama GUI</strong>
+          <span>Local inference studio</span>
+        </div>
+      </div>
+      <nav class="nav" aria-label="Primary">
+        <button><svg viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg> Install</button>
+        <button><svg viewBox="0 0 24 24"><polygon points="5 3 19 12 5 21 5 3"/></svg> Quick Launch</button>
+        <button class="active"><svg viewBox="0 0 24 24"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg> Configure</button>
+        <button><svg viewBox="0 0 24 24"><path d="M21 15a4 4 0 0 1-4 4H7l-4 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z"/></svg> Chat</button>
+        <button><svg viewBox="0 0 24 24"><path d="M4 17h16"/><path d="M4 12h16"/><path d="M4 7h16"/></svg> API</button>
+        <button><svg viewBox="0 0 24 24"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/></svg> Presets</button>
+      </nav>
+    </aside>
+
+    <main class="main">
+      <section class="hero" aria-label="Configure tab redesign mockup">
+        <div class="topbar">
+          <div>
+            <div class="title-row">
+              <span class="eyebrow">Configure</span>
+              <span class="pill"><span class="dot"></span> Ready</span>
+            </div>
+            <h1>Build a launch profile with confidence.</h1>
+            <p class="subtitle">A redesigned control surface that turns hundreds of llama.cpp flags into clear groups, visible impact, and a launch command you can trust.</p>
+            <div class="status-strip">
+              <span class="pill">llama-server</span>
+              <span class="pill">Qwen3-32B-Q4_K_M.gguf</span>
+              <span class="pill">CUDA 12.4</span>
+              <span class="pill">32K context</span>
+            </div>
+          </div>
+
+          <div class="control-board">
+            <div class="field">
+              <label for="tool">Tool</label>
+              <select id="tool"><option>llama-server HTTP API</option><option>llama-cli Interactive Chat</option></select>
+            </div>
+            <div class="field">
+              <label for="model">Model</label>
+              <select id="model"><option>Qwen3-32B-Q4_K_M.gguf</option><option>Meta-Llama-3.1-8B-Instruct.gguf</option></select>
+            </div>
+            <button class="btn icon" aria-label="Refresh models"><svg viewBox="0 0 24 24"><path d="M21 12a9 9 0 1 1-2.64-6.36"/><path d="M21 3v6h-6"/></svg></button>
+            <button class="btn"><svg viewBox="0 0 24 24"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg> Download</button>
+          </div>
+        </div>
+
+        <div class="content">
+          <div class="workbench">
+            <div class="searchbar">
+              <input aria-label="Search flags" value="sampling, gpu, context..." />
+              <button class="btn ghost">Clear</button>
+              <button class="btn ghost">Expand</button>
+              <button class="btn ghost">Collapse</button>
+            </div>
+
+            <div class="category-grid">
+              <article class="category active">
+                <span class="count">12</span>
+                <h3>Performance</h3>
+                <p>GPU layers, batch sizing, memory mapping, and throughput controls.</p>
+              </article>
+              <article class="category">
+                <span class="count">18</span>
+                <h3>Sampling</h3>
+                <p>Temperature, top-p, min-p, penalties, and repeat behavior.</p>
+              </article>
+              <article class="category">
+                <span class="count">9</span>
+                <h3>Context</h3>
+                <p>Prompt budget, KV cache, RoPE scaling, and sequence settings.</p>
+              </article>
+              <article class="category">
+                <span class="count">7</span>
+                <h3>API Server</h3>
+                <p>Host, port, metrics, CORS, slots, and endpoint behavior.</p>
+              </article>
+              <article class="category">
+                <span class="count">14</span>
+                <h3>Templates</h3>
+                <p>Chat formats, bundled presets, and custom Jinja paths.</p>
+              </article>
+              <article class="category">
+                <span class="count">21</span>
+                <h3>Advanced</h3>
+                <p>Expert flags separated from everyday launch decisions.</p>
+              </article>
+            </div>
+
+            <section class="flag-panel">
+              <div class="flag-panel-header">
+                <h2>Performance</h2>
+                <span class="pill">6 modified</span>
+              </div>
+              <div class="flag-table">
+                <div class="flag-row">
+                  <div class="flag-name"><strong>GPU Layers</strong><code>--n-gpu-layers</code></div>
+                  <div class="flag-desc">Offload model layers to the active GPU backend. Use Auto for the best default fit.</div>
+                  <div class="segmented"><button>0</button><button class="selected">Auto</button><button>All</button></div>
+                </div>
+                <div class="flag-row">
+                  <div class="flag-name"><strong>Context Size</strong><code>--ctx-size</code></div>
+                  <div class="flag-desc">Maximum prompt and generation context. Linked to the fit planner by default.</div>
+                  <div class="range"><div class="slider"></div><div class="value">32768</div></div>
+                </div>
+                <div class="flag-row">
+                  <div class="flag-name"><strong>Flash Attention</strong><code>--flash-attn</code></div>
+                  <div class="flag-desc">Enable optimized attention kernels when supported by the selected build.</div>
+                  <div class="switch" aria-label="Flash attention enabled"><div class="knob"></div></div>
+                </div>
+                <div class="flag-row">
+                  <div class="flag-name"><strong>Batch Size</strong><code>--batch-size</code></div>
+                  <div class="flag-desc">Controls prompt processing batch size. Higher values can improve throughput.</div>
+                  <div class="range"><div class="slider" style="background:linear-gradient(90deg,var(--violet) 0 44%,rgba(255,255,255,.12) 44%)"></div><div class="value">1024</div></div>
+                </div>
+              </div>
+            </section>
+
+            <section class="card args">
+              <div class="card-head">
+                <h3>Custom Launch Args</h3>
+                <span class="pill">Advanced</span>
+              </div>
+              <div class="card-body">
+                <textarea spellcheck="false">--threads 12
+--cache-type-k q8_0
+--chat-template-kwargs '{"preserve_thinking":true}'</textarea>
+              </div>
+            </section>
+          </div>
+
+          <aside class="side">
+            <section class="card">
+              <div class="card-head">
+                <h3>Launch Health</h3>
+                <span class="pill"><span class="dot"></span> Good</span>
+              </div>
+              <div class="card-body">
+                <div class="score">
+                  <div class="ring">78</div>
+                  <div>
+                    <strong>Balanced profile</strong>
+                    <p class="subtitle" style="margin:4px 0 0">Estimated to fit VRAM with room for a 32K prompt window.</p>
+                  </div>
+                </div>
+                <div class="mini-list">
+                  <div class="mini-row"><span>VRAM estimate</span><strong>18.4 / 24 GB</strong></div>
+                  <div class="mini-row"><span>Template</span><strong>ChatML</strong></div>
+                  <div class="mini-row"><span>Metrics</span><strong>Enabled</strong></div>
+                </div>
+              </div>
+            </section>
+
+            <section class="card">
+              <div class="card-head">
+                <h3>Command Preview</h3>
+                <button class="btn ghost" style="height:30px">Copy</button>
+              </div>
+              <div class="card-body">
+                <div class="command">llama-server --model models/Qwen3-32B-Q4_K_M.gguf --ctx-size 32768 --n-gpu-layers 999 --flash-attn --metrics --chat-template chatml --threads 12</div>
+              </div>
+            </section>
+
+            <section class="card">
+              <div class="card-head">
+                <h3>Changed Flags</h3>
+                <span class="pill">6</span>
+              </div>
+              <div class="card-body mini-list">
+                <div class="mini-row"><span>Context Size</span><strong>32768</strong></div>
+                <div class="mini-row"><span>GPU Layers</span><strong>Auto</strong></div>
+                <div class="mini-row"><span>Flash Attention</span><strong>On</strong></div>
+                <div class="mini-row"><span>Metrics</span><strong>On</strong></div>
+              </div>
+            </section>
+          </aside>
+        </div>
+      </section>
+
+      <div class="footer-launch">
+        <button class="btn primary"><svg viewBox="0 0 24 24"><polygon points="5 3 19 12 5 21 5 3"/></svg> Launch Server</button>
+        <div class="launch-copy">
+          <strong>Ready to start on 127.0.0.1:8080</strong>
+          Last validation passed. Custom args will be appended after UI-managed flags.
+        </div>
+        <button class="btn">Save Preset</button>
+        <button class="btn ghost">Open Quick Launch</button>
+      </div>
+    </main>
+  </div>
+</body>
+</html>

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -719,7 +719,7 @@ async function pollStats() {
             document.getElementById("stats-kv-usage").textContent = (kvUsage * 100).toFixed(0) + "%";
         }
     } catch (e) {
-        // server not ready yet or metrics unavailable
+        console.debug("Failed to fetch llama-server metrics", e);
     } finally {
         pollStatsActive = false;
     }

--- a/ui/js/chat-rendering.js
+++ b/ui/js/chat-rendering.js
@@ -274,7 +274,21 @@
 
     function appendChatStreamToken(bubble, token) {
         bubble.dataset.rawText = (bubble.dataset.rawText || "") + token;
-        bubble.innerHTML = renderMarkdown(bubble.dataset.rawText);
+        if (!bubble.dataset.streamingTextInitialized) {
+            bubble.textContent = bubble.dataset.rawText;
+            bubble.dataset.streamingTextInitialized = "1";
+        } else {
+            bubble.textContent += token;
+        }
+        const container = document.getElementById("chat-messages");
+        container.scrollTop = container.scrollHeight;
+    }
+
+    function finalizeChatStreamMarkdown(bubble) {
+        if (!bubble) return;
+        const rawText = bubble.dataset.rawText || "";
+        bubble.innerHTML = renderMarkdown(rawText);
+        delete bubble.dataset.streamingTextInitialized;
         const container = document.getElementById("chat-messages");
         container.scrollTop = container.scrollHeight;
     }
@@ -291,5 +305,6 @@
         renderChatTypingIndicator,
         removeChatTypingIndicator,
         appendChatStreamToken,
+        finalizeChatStreamMarkdown,
     };
 })();

--- a/ui/js/chat-ui.js
+++ b/ui/js/chat-ui.js
@@ -18,6 +18,7 @@
     const CHAT_WEB_SEARCH_DEFAULT_MAX_RESULTS = 5;
     const CHAT_WEB_SEARCH_MIN_RESULTS = 1;
     const CHAT_WEB_SEARCH_MAX_RESULTS = 10;
+    const CHAT_MAX_STORED_CONVERSATIONS = 50;
 
     const chatRendering = window.LlamaGui.chatRendering;
     const {
@@ -27,6 +28,7 @@
         renderChatTypingIndicator,
         removeChatTypingIndicator,
         appendChatStreamToken,
+        finalizeChatStreamMarkdown,
     } = chatRendering;
 
     function configure(options) {
@@ -258,6 +260,7 @@
             }
             setChatWebStatus(bubble, "");
             if (fullContent) {
+                finalizeChatStreamMarkdown(bubble);
                 chatMessages.push({ role: "assistant", content: fullContent, sources: responseSources });
                 saveCurrentConversation();
             }
@@ -333,10 +336,14 @@
     }
 
     function saveConversationsToStorage(list) {
+        const pruned = Array.isArray(list) ? list.slice(0, CHAT_MAX_STORED_CONVERSATIONS) : [];
         try {
-            localStorage.setItem(CHAT_CONVERSATIONS_STORAGE_KEY, JSON.stringify(list));
+            localStorage.setItem(CHAT_CONVERSATIONS_STORAGE_KEY, JSON.stringify(pruned));
         } catch (e) {
             console.warn("Failed to save conversations to localStorage:", e);
+            if (typeof window.showToast === "function") {
+                window.showToast("Conversation history is full. Recent chat is still active, but history was not saved.", "warning");
+            }
         }
     }
 


### PR DESCRIPTION
ui/js/chat-rendering.js: streaming now appends plain text during generation and renders markdown once at completion.
ui/js/chat-ui.js: conversation history is capped at 50 saved chats, with a user toast plus console warning if storage fails.
ui/js/app.js: stats polling now logs expected failures with console.debug().
backend/services/web_search.py: HTML parser fallback now logs to stderr.
backend/app.py: local host validation now reuses the shared chat service helper.