### PR TITLE
Replaced CUDA 13 with 13.3

### DIFF
--- a/backend/services/llama_manager.py
+++ b/backend/services/llama_manager.py
@@ -40,10 +40,10 @@ def build_backend_specs(current_platform: str, current_arch: str) -> dict[str, A
                 "asset": "llama-{tag}-bin-win-cuda-12.4-x64.zip",
                 "extra_assets": ["cudart-llama-bin-win-cuda-12.4-x64.zip"],
             },
-            "cuda-13.1": {
-                "label": "CUDA 13.1 (NVIDIA)",
-                "asset": "llama-{tag}-bin-win-cuda-13.1-x64.zip",
-                "extra_assets": ["cudart-llama-bin-win-cuda-13.1-x64.zip"],
+            "cuda-13.3": {
+                "label": "CUDA 13.3 (NVIDIA)",
+                "asset": "llama-{tag}-bin-win-cuda-13.3-x64.zip",
+                "extra_assets": ["cudart-llama-bin-win-cuda-13.3-x64.zip"],
             },
             "vulkan": {
                 "label": "Vulkan",

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -77,7 +77,8 @@ class BuildBackendSpecsTests(unittest.TestCase):
 
         self.assertIn("cpu", specs)
         self.assertIn("cuda-12.4", specs)
-        self.assertIn("cuda-13.1", specs)
+        self.assertIn("cuda-13.3", specs)
+        self.assertNotIn("cuda-13.1", specs)
         self.assertIn("vulkan", specs)
         self.assertIn("sycl", specs)
         self.assertIn("hip", specs)
@@ -152,8 +153,11 @@ class BuildBackendSpecsTests(unittest.TestCase):
         specs = llama_manager.build_backend_specs("win32", "x64")
 
         self.assertIn("extra_assets", specs["cuda-12.4"])
-        self.assertIn("extra_assets", specs["cuda-13.1"])
+        self.assertIn("extra_assets", specs["cuda-13.3"])
         self.assertEqual(len(specs["cuda-12.4"]["extra_assets"]), 1)
+        self.assertEqual(len(specs["cuda-13.3"]["extra_assets"]), 1)
+        self.assertIn("cuda-13.3", specs["cuda-13.3"]["asset"])
+        self.assertIn("cuda-13.3", specs["cuda-13.3"]["extra_assets"][0])
 
 
 class NormalizeArchTests(unittest.TestCase):


### PR DESCRIPTION
The Windows x64 backend specs now replace cuda-13.1 with cuda-13.3 in backend/services/llama_manager.py (line 40), including the new llama.cpp binary and CUDA DLL asset names.