### PR TITLE
Add perplexity options to benchmark UI and adapter

### DIFF
--- a/tests/frontend/benchmark_args_unit.cjs
+++ b/tests/frontend/benchmark_args_unit.cjs
@@ -113,22 +113,50 @@ function flat(result) {
     const result = adapter.buildBenchmarkArgs({
         benchmarkType: "perplexity",
         flags,
-        source: { model: "", flags: { hf_repo: "owner/model-GGUF:Q4_K_M", mmap: false } },
+        source: { model: "ppl-model.gguf", flags: { hf_repo: "owner/model-GGUF:Q4_K_M", mmap: false, ctx_size: 100000 } },
         promptFile: "eval.txt",
-        chunks: 2,
+        pplContextSize: 4096,
+        pplBatchSize: 2048,
+        pplUbatchSize: 512,
+        pplThreads: -1,
+        pplGpuLayers: "auto",
+        pplFlashAttention: "auto",
+        pplCacheTypeK: "f16",
+        pplCacheTypeV: "f16",
+        chunks: 5,
         pplStride: 64,
         warmup: false,
     });
 
     assert.equal(result.error, null);
     assert.deepEqual(flat(result), [
-        "--no-mmap",
-        "-hf", "owner/model-GGUF:Q4_K_M",
+        "-m", "models/ppl-model.gguf",
+        "-c", "4096",
+        "-b", "2048",
+        "-ub", "512",
+        "-t", "-1",
+        "-ngl", "auto",
+        "-fa", "auto",
+        "-ctk", "f16",
+        "-ctv", "f16",
         "-f", "eval.txt",
-        "--chunks", "2",
+        "--chunks", "5",
         "--ppl-stride", "64",
         "--no-warmup",
     ]);
+    assert.ok(result.excluded.some((item) => item.label === "Configure/Preset Flags"));
+    assert.ok(!flat(result).includes("--no-mmap"));
+    assert.ok(!flat(result).includes("-hf"));
+}
+
+{
+    const result = adapter.buildBenchmarkArgs({
+        benchmarkType: "perplexity",
+        flags,
+        source: { model: "ppl-model.gguf", flags: {} },
+    });
+
+    assert.match(result.error, /prompt\/data file/);
 }
 
 console.log("benchmark adapter tests passed");

--- a/ui/index.html
+++ b/ui/index.html
@@ -888,9 +888,65 @@
                             </div>
                             <div class="benchmark-controls-grid">
                                 <div class="form-group">
+                                    <label class="form-label" for="benchmark-ppl-ctx">Context Size</label>
+                                    <input id="benchmark-ppl-ctx" type="number" min="128" max="262144" step="128" value="4096">
+                                    <p class="help-text">Scoring window size. Smaller values are faster and avoid long-context setup issues.</p>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label" for="benchmark-ppl-batch">Batch Size</label>
+                                    <input id="benchmark-ppl-batch" type="number" min="1" max="131072" step="1" value="2048">
+                                    <p class="help-text">How many tokens llama.cpp processes per batch during evaluation.</p>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label" for="benchmark-ppl-ubatch">Micro Batch Size</label>
+                                    <input id="benchmark-ppl-ubatch" type="number" min="1" max="131072" step="1" value="512">
+                                    <p class="help-text">Smaller micro batches can reduce memory pressure on large models.</p>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label" for="benchmark-ppl-threads">Threads</label>
+                                    <input id="benchmark-ppl-threads" type="number" min="-1" max="256" step="1" value="-1">
+                                    <p class="help-text">CPU worker threads. Leave -1 to let llama.cpp choose.</p>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label" for="benchmark-ppl-gpu-layers">GPU Layers</label>
+                                    <input id="benchmark-ppl-gpu-layers" type="text" value="auto">
+                                    <p class="help-text">Use auto for llama.cpp's default GPU offload choice, or enter a layer count.</p>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label" for="benchmark-ppl-flash-attn">Flash Attention</label>
+                                    <select id="benchmark-ppl-flash-attn">
+                                        <option value="auto">Auto</option>
+                                        <option value="on">On</option>
+                                        <option value="off">Off</option>
+                                    </select>
+                                    <p class="help-text">Auto lets llama.cpp choose whether flash attention is supported.</p>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label" for="benchmark-ppl-cache-k">K Cache Type</label>
+                                    <select id="benchmark-ppl-cache-k">
+                                        <option value="f16">f16</option>
+                                        <option value="bf16">bf16</option>
+                                        <option value="q8_0">q8_0</option>
+                                        <option value="q4_0">q4_0</option>
+                                        <option value="q4_1">q4_1</option>
+                                    </select>
+                                    <p class="help-text">Lower precision can reduce memory use, but may affect scores.</p>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label" for="benchmark-ppl-cache-v">V Cache Type</label>
+                                    <select id="benchmark-ppl-cache-v">
+                                        <option value="f16">f16</option>
+                                        <option value="bf16">bf16</option>
+                                        <option value="q8_0">q8_0</option>
+                                        <option value="q4_0">q4_0</option>
+                                        <option value="q4_1">q4_1</option>
+                                    </select>
+                                    <p class="help-text">Usually match K cache unless you are comparing memory tradeoffs.</p>
+                                </div>
+                                <div class="form-group">
                                     <label class="form-label" for="benchmark-chunks">Chunks</label>
-                                    <input id="benchmark-chunks" type="number" min="-1" step="1" value="-1">
-                                    <p class="help-text">Limits how much of the file to evaluate. Use -1 to process all chunks.</p>
+                                    <input id="benchmark-chunks" type="number" min="-1" step="1" value="5">
+                                    <p class="help-text">Limits how much of the file to evaluate. Start small, then increase for steadier scores.</p>
                                 </div>
                                 <div class="form-group">
                                     <label class="form-label" for="benchmark-ppl-stride">PPL Stride</label>

--- a/ui/js/benchmark-ui.js
+++ b/ui/js/benchmark-ui.js
@@ -199,37 +199,40 @@
             applied.push({ label: "Model", value: model });
         }
 
-        for (const flag of allFlags) {
-            if (!flag || !flag.id || !flag.flag) continue;
-            const value = flags[flag.id];
-            if (isEmptyFlagValue(value)) continue;
-
-            if (!BENCH_COMPATIBLE_IDS.has(flag.id)) {
-                if (!Object.prototype.hasOwnProperty.call(defaultFlags, flag.id) || !valuesEqual(value, defaultFlags[flag.id])) {
-                    excluded.push({ label: getFlagLabel(flag), reason: "Not used by benchmark tools" });
-                }
-                continue;
-            }
-
-            if (tool === "llama-bench" && flag.id === "threads_batch") {
-                if (!Object.prototype.hasOwnProperty.call(defaultFlags, flag.id) || !valuesEqual(value, defaultFlags[flag.id])) {
-                    excluded.push({ label: getFlagLabel(flag), reason: "llama-bench uses one thread setting" });
-                }
-                continue;
-            }
-
-            const before = args.length;
-            const didApply = pushFlagArg(args, tool, flag, value);
-            if (didApply && args.length > before) {
-                applied.push({ label: getFlagLabel(flag), value: Array.isArray(value) ? value.join(",") : String(value) });
-            } else {
-                if (!Object.prototype.hasOwnProperty.call(defaultFlags, flag.id) || !valuesEqual(value, defaultFlags[flag.id])) {
-                    excluded.push({ label: getFlagLabel(flag), reason: "Not supported for this benchmark" });
-                }
-            }
+        if (benchmarkType === "perplexity" && !hasSelectedModelArg(args)) {
+            return { tool, args, applied, excluded, error: "Select a manual model before running perplexity." };
         }
 
         if (benchmarkType === "bench") {
+            for (const flag of allFlags) {
+                if (!flag || !flag.id || !flag.flag) continue;
+                const value = flags[flag.id];
+                if (isEmptyFlagValue(value)) continue;
+
+                if (!BENCH_COMPATIBLE_IDS.has(flag.id)) {
+                    if (!Object.prototype.hasOwnProperty.call(defaultFlags, flag.id) || !valuesEqual(value, defaultFlags[flag.id])) {
+                        excluded.push({ label: getFlagLabel(flag), reason: "Not used by benchmark tools" });
+                    }
+                    continue;
+                }
+
+                if (flag.id === "threads_batch") {
+                    if (!Object.prototype.hasOwnProperty.call(defaultFlags, flag.id) || !valuesEqual(value, defaultFlags[flag.id])) {
+                        excluded.push({ label: getFlagLabel(flag), reason: "llama-bench uses one thread setting" });
+                    }
+                    continue;
+                }
+
+                const before = args.length;
+                const didApply = pushFlagArg(args, tool, flag, value);
+                if (didApply && args.length > before) {
+                    applied.push({ label: getFlagLabel(flag), value: Array.isArray(value) ? value.join(",") : String(value) });
+                } else {
+                    if (!Object.prototype.hasOwnProperty.call(defaultFlags, flag.id) || !valuesEqual(value, defaultFlags[flag.id])) {
+                        excluded.push({ label: getFlagLabel(flag), reason: "Not supported for this benchmark" });
+                    }
+                }
+            }
             const repetitions = options.repetitions || 5;
             const nPrompt = options.nPrompt || 512;
             const nGen = options.nGen || 128;
@@ -243,14 +246,45 @@
             applied.push({ label: "Generation Tokens", value: String(nGen) });
             applied.push({ label: "Output Format", value: outputFormat });
         } else {
-            if (options.promptFile) args.push(["-f", String(options.promptFile)]);
+            const contextSize = options.pplContextSize || 4096;
+            const batchSize = options.pplBatchSize || 2048;
+            const ubatchSize = options.pplUbatchSize || 512;
+            const threads = options.pplThreads ?? -1;
+            const gpuLayers = String(options.pplGpuLayers || "auto").trim();
+            const flashAttention = options.pplFlashAttention || "auto";
+            const cacheTypeK = options.pplCacheTypeK || "f16";
+            const cacheTypeV = options.pplCacheTypeV || "f16";
+            args.push(["-c", String(contextSize)]);
+            args.push(["-b", String(batchSize)]);
+            args.push(["-ub", String(ubatchSize)]);
+            args.push(["-t", String(threads)]);
+            if (gpuLayers) args.push(["-ngl", gpuLayers]);
+            if (flashAttention) args.push(["-fa", flashAttention]);
+            if (cacheTypeK) args.push(["-ctk", cacheTypeK]);
+            if (cacheTypeV) args.push(["-ctv", cacheTypeV]);
+            if (options.promptFile) {
+                args.push(["-f", String(options.promptFile)]);
+            } else {
+                return { tool, args, applied, excluded, error: "Choose a prompt/data file before running perplexity." };
+            }
             if (options.chunks !== undefined && options.chunks !== "") args.push(["--chunks", String(options.chunks)]);
             if (options.pplStride !== undefined && options.pplStride !== "") args.push(["--ppl-stride", String(options.pplStride)]);
             args.push([options.warmup === false ? "--no-warmup" : "--warmup"]);
+            applied.push({ label: "Context Size", value: String(contextSize) });
+            applied.push({ label: "Batch Size", value: String(batchSize) });
+            applied.push({ label: "Micro Batch Size", value: String(ubatchSize) });
+            applied.push({ label: "Threads", value: String(threads) });
+            if (gpuLayers) applied.push({ label: "GPU Layers", value: gpuLayers });
+            if (flashAttention) applied.push({ label: "Flash Attention", value: flashAttention });
+            if (cacheTypeK) applied.push({ label: "K Cache Type", value: cacheTypeK });
+            if (cacheTypeV) applied.push({ label: "V Cache Type", value: cacheTypeV });
             if (options.promptFile) applied.push({ label: "Prompt/Data File", value: String(options.promptFile) });
             applied.push({ label: "Chunks", value: options.chunks === undefined || options.chunks === "" ? "-1" : String(options.chunks) });
             applied.push({ label: "PPL Stride", value: options.pplStride === undefined || options.pplStride === "" ? "0" : String(options.pplStride) });
             applied.push({ label: "Warmup", value: options.warmup === false ? "Off" : "On" });
+            if (Object.keys(flags).length > 0) {
+                excluded.push({ label: "Configure/Preset Flags", reason: "Perplexity uses only the settings shown here" });
+            }
         }
 
         if (!hasSelectedModelArg(args)) {
@@ -306,6 +340,14 @@
 
     function getSourceSnapshot() {
         const sourceType = getSelectedSourceType();
+        if (getSelectedBenchmarkType() === "perplexity") {
+            return {
+                sourceType: "manual",
+                label: "Manual Model",
+                model: byId("benchmark-manual-model")?.value || "",
+                flags: {},
+            };
+        }
         if (sourceType === "preset") {
             const preset = cachedPresets.find((entry) => entry.name === selectedPresetName);
             const data = normalizePresetData(preset && preset.data);
@@ -338,6 +380,14 @@
             nGen: getNumberValue("benchmark-n-gen", 128),
             outputFormat: byId("benchmark-output-format")?.value || "md",
             promptFile: byId("benchmark-prompt-file")?.value || "",
+            pplContextSize: getNumberValue("benchmark-ppl-ctx", 4096),
+            pplBatchSize: getNumberValue("benchmark-ppl-batch", 2048),
+            pplUbatchSize: getNumberValue("benchmark-ppl-ubatch", 512),
+            pplThreads: getNumberValue("benchmark-ppl-threads", -1),
+            pplGpuLayers: byId("benchmark-ppl-gpu-layers")?.value || "auto",
+            pplFlashAttention: byId("benchmark-ppl-flash-attn")?.value || "auto",
+            pplCacheTypeK: byId("benchmark-ppl-cache-k")?.value || "f16",
+            pplCacheTypeV: byId("benchmark-ppl-cache-v")?.value || "f16",
             chunks: byId("benchmark-chunks")?.value || "-1",
             pplStride: byId("benchmark-ppl-stride")?.value || "0",
             warmup: Boolean(byId("benchmark-warmup")?.checked),
@@ -352,7 +402,11 @@
         const sourceLabel = byId("benchmark-source-summary");
         if (sourceLabel) {
             const source = getSourceSnapshot();
-            sourceLabel.textContent = `${BENCHMARK_SOURCE_LABELS[source.sourceType]} -> ${source.model || source.flags.hf_repo || "No model selected"}`;
+            if (getSelectedBenchmarkType() === "perplexity") {
+                sourceLabel.textContent = `Perplexity uses the manual model and settings below -> ${source.model || "No model selected"}`;
+            } else {
+                sourceLabel.textContent = `${BENCHMARK_SOURCE_LABELS[source.sourceType]} -> ${source.model || source.flags.hf_repo || "No model selected"}`;
+            }
         }
         if (command) {
             command.textContent = result.error ? `Cannot run: ${result.error}` : result.command;
@@ -402,15 +456,19 @@
 
     function syncModePanels() {
         const type = getSelectedBenchmarkType();
+        const source = byId("benchmark-source");
+        if (source) source.disabled = type === "perplexity";
         byId("benchmark-bench-controls")?.classList.toggle("hidden", type !== "bench");
         byId("benchmark-ppl-controls")?.classList.toggle("hidden", type !== "perplexity");
+        syncSourcePanels();
         renderCommand();
     }
 
     function syncSourcePanels() {
         const source = getSelectedSourceType();
-        byId("benchmark-preset-row")?.classList.toggle("hidden", source !== "preset");
-        byId("benchmark-manual-row")?.classList.toggle("hidden", source !== "manual");
+        const isPerplexity = getSelectedBenchmarkType() === "perplexity";
+        byId("benchmark-preset-row")?.classList.toggle("hidden", isPerplexity || source !== "preset");
+        byId("benchmark-manual-row")?.classList.toggle("hidden", !isPerplexity && source !== "manual");
         renderCommand();
     }
 
@@ -615,6 +673,14 @@
             "benchmark-n-gen",
             "benchmark-output-format",
             "benchmark-prompt-file",
+            "benchmark-ppl-ctx",
+            "benchmark-ppl-batch",
+            "benchmark-ppl-ubatch",
+            "benchmark-ppl-threads",
+            "benchmark-ppl-gpu-layers",
+            "benchmark-ppl-flash-attn",
+            "benchmark-ppl-cache-k",
+            "benchmark-ppl-cache-v",
             "benchmark-chunks",
             "benchmark-ppl-stride",
             "benchmark-warmup",


### PR DESCRIPTION
Expose llama.cpp perplexity options in the benchmark UI (context, batch, micro-batch, threads, GPU layers, flash attention, K/V cache types) and change default chunks/help text. Update benchmark adapter to emit corresponding ppl args (-c, -b, -ub, -t, -ngl, -fa, -ctk, -ctv), require a manual model for perplexity, return an error if no prompt/data file is chosen, and exclude preset/configure flags from perplexity runs. Adjust source selection behavior (disable preset source for perplexity) and add applied/excluded metadata. Tests updated to cover the new args, exclusion behavior, and missing prompt-file error.