### PR TITLE
Add frontend unit tests and test docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 
 The full project reference lives in **`docs/directory.md`**. It covers architecture, directory map, backend/frontend module reference, data flow, flag system, chat template presets, Quick Launch, Chat, HF downloader, tunnel, auto-update, sampler presets, metrics, MCP, reasoning support, custom launch args, configuration search, smoke tests, and native file picker.
 
+The test reference lives in **`docs/tests.md`**. It lists the frontend/backend test commands, test file purposes, and when to use focused unit tests versus browser smoke tests.
+
 Read `docs/directory.md` before starting any task.
 
 ## UI State Sync Rule

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,87 @@
+# Tests
+
+This repo has two main test groups:
+
+- Frontend tests under `tests/frontend/`
+- Backend tests under `tests/backend/`
+
+The goal is not exhaustive coverage. Tests should make common regressions easier to diagnose, especially around shared launch state, command generation, route/service behavior, and UI helper logic.
+
+## Common Commands
+
+```powershell
+npm test
+```
+
+Runs the full frontend suite: JavaScript syntax checks, fast Node unit tests, flag compatibility checks, module loading checks, and the Playwright smoke test.
+
+```powershell
+npm run test:syntax
+```
+
+Checks every frontend JavaScript file with `node --check`.
+
+```powershell
+npm run test:frontend:modules
+```
+
+Loads scripts in the same order as `ui/index.html` inside a Node VM and verifies expected `window.LlamaGui.*` namespaces exist.
+
+```powershell
+npm run test:flags
+```
+
+Compares exposed GUI flags against installed `llama-server` and `llama-cli` help output when those binaries are available.
+
+```powershell
+npm run test:frontend
+```
+
+Runs the Playwright smoke test for browser-level shared-state sync.
+
+```powershell
+python -m unittest discover tests -v
+```
+
+Runs the backend unittest suite.
+
+## Frontend Tests
+
+Fast Node tests:
+
+- `custom_launch_args_unit.cjs`: custom launch arg tokenization, quote handling, duplicate flag warnings, and preset preservation.
+- `launch_args_unit.cjs`: launch argument generation for inert defaults and sampler-related flag behavior.
+- `benchmark_args_unit.cjs`: benchmark/perplexity argument adaptation without mutating source presets.
+- `chat_rendering_unit.cjs`: markdown escaping, fenced code safety, and safe source-link rendering.
+- `sampler_presets_unit.cjs`: sampler preset storage fallback, normalization, applying defaults, and built-in/custom preset shape.
+- `hf_download_ui_unit.cjs`: Hugging Face downloader UI helper behavior, request payloads, duplicate overwrite retry, and completion handling.
+- `api_tab_unit.cjs`: API endpoint host/port fallback, model alias selection, and API-key snippet rendering.
+- `presets_unit.cjs`: imported preset normalization and stale flag filtering.
+- `module_namespace_unit.cjs`: frontend script load order and exported namespaces.
+- `js_syntax_check.cjs`: syntax-only check for frontend JavaScript.
+
+Browser smoke test:
+
+- `flag_sync_smoke.cjs`: serves `ui/`, stubs backend APIs, and verifies shared state across Quick Launch, Configure, Chat, command preview, API snippets, remote tunnel UI, sampler presets, and custom launch args.
+
+Use fast Node tests for focused debugging. Use the Playwright smoke test when a change affects real DOM wiring, mirrored controls, tab sync, command preview rendering, or launch blocking behavior.
+
+## Backend Tests
+
+Backend tests use Python `unittest` and mostly exercise route/service logic without starting the real app server.
+
+- `test_backend_foundation.py`: config parsing, path setup, shared state containers, and context shape.
+- `test_routing.py`: router matching for exact and prefix routes.
+- `test_http_adapters.py`: request/response helpers and CORS origin handling.
+- `test_server_baseline.py`: compatibility wrapper behavior, API dispatch, CORS, static asset versioning, and baseline server helpers.
+- `test_services.py`: service-level helpers for install specs, runtime validation, downloads, file picker behavior, chat/search helpers, and HF validation.
+- `test_extracted_routes.py`: extracted route handlers and larger service flows, including presets, process launch, metrics/slots, chat web search, HF download, tunnel, app update, and lifecycle routes.
+
+Run backend tests after changes under `backend/`, route behavior changes, service helper changes, process management changes, install/update changes, or security-sensitive validation changes.
+
+## When Adding Tests
+
+- Prefer a small unit test when a helper has clear inputs and outputs.
+- Prefer Playwright only when browser DOM wiring or cross-tab shared state is the thing being protected.
+- Prefer backend unit tests with mocked services over starting real external processes.
+- Keep tests specific enough that a failure points to the broken behavior, not just "the app changed."

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "llama-gui",
   "private": true,
   "scripts": {
-    "test": "npm run test:syntax && node tests/frontend/custom_launch_args_unit.cjs && node tests/frontend/launch_args_unit.cjs && node tests/frontend/benchmark_args_unit.cjs && npm run test:frontend:modules && npm run test:flags && npm run test:frontend",
+    "test": "npm run test:syntax && node tests/frontend/custom_launch_args_unit.cjs && node tests/frontend/launch_args_unit.cjs && node tests/frontend/benchmark_args_unit.cjs && node tests/frontend/chat_rendering_unit.cjs && node tests/frontend/sampler_presets_unit.cjs && node tests/frontend/hf_download_ui_unit.cjs && node tests/frontend/api_tab_unit.cjs && npm run test:frontend:modules && npm run test:flags && npm run test:frontend",
     "test:syntax": "node tests/frontend/js_syntax_check.cjs",
     "test:frontend:modules": "node tests/frontend/module_namespace_unit.cjs",
     "test:flags": "node tests/frontend/llama_flags_supported_unit.cjs",

--- a/tests/frontend/api_tab_unit.cjs
+++ b/tests/frontend/api_tab_unit.cjs
@@ -1,0 +1,111 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const source = fs.readFileSync(path.join(ROOT, "ui", "js", "api-tab.js"), "utf8");
+
+function createElement(tagName = "div") {
+    return {
+        tagName: tagName.toUpperCase(),
+        children: [],
+        className: "",
+        textContent: "",
+        href: "",
+        addEventListener: () => {},
+        appendChild(child) {
+            this.children.push(child);
+            return child;
+        },
+        set innerHTML(_value) {
+            this.children = [];
+        },
+        get innerHTML() {
+            return "";
+        },
+        querySelectorAll(selector) {
+            const matches = [];
+            const className = selector.startsWith(".") ? selector.slice(1) : "";
+            const stack = [...this.children];
+            while (stack.length) {
+                const child = stack.shift();
+                if (className && String(child.className || "").split(/\s+/).includes(className)) {
+                    matches.push(child);
+                }
+                stack.push(...(child.children || []));
+            }
+            return matches;
+        },
+    };
+}
+
+const elements = new Map();
+const context = {
+    window: { LlamaGui: {} },
+    document: {
+        createElement,
+        getElementById: (id) => elements.get(id) || null,
+    },
+    console,
+};
+context.window.window = context.window;
+vm.createContext(context);
+vm.runInContext(source, context, { filename: "ui/js/api-tab.js" });
+
+const apiTab = context.window.LlamaGui.apiTab;
+let flagValues = {};
+let selectedModel = "";
+let currentTool = "llama-server";
+apiTab.configure({
+    flagCore: {
+        getFlagValues: () => flagValues,
+        getSelectedModel: () => selectedModel,
+        getCurrentTool: () => currentTool,
+    },
+    getLatestStatus: () => ({ running: true }),
+});
+
+flagValues = { host: "", port: "bad" };
+assert.equal(
+    JSON.stringify(apiTab.getServerEndpointConfig()),
+    JSON.stringify({ host: "127.0.0.1", port: 8080, baseUrl: "http://127.0.0.1:8080" }),
+    "API endpoint config should fall back for blank host and invalid port"
+);
+
+flagValues = { host: "0.0.0.0", port: "9099", alias: "primary-alias, backup", api_key: "secret" };
+selectedModel = "selected-model.gguf";
+currentTool = "llama-server";
+elements.set("api-base-url", createElement("a"));
+elements.set("api-endpoints-list", createElement("div"));
+elements.set("api-snippets-list", createElement("div"));
+elements.set("api-status-note", createElement("div"));
+
+apiTab.updateEndpoints();
+
+assert.equal(elements.get("api-base-url").textContent, "http://0.0.0.0:9099");
+assert.match(elements.get("api-status-note").textContent, /API key is configured/);
+
+const endpointText = elements.get("api-endpoints-list").children
+    .map((card) => JSON.stringify(card))
+    .join("\n");
+assert.match(endpointText, /http:\/\/0\.0\.0\.0:9099\/v1\/chat\/completions/);
+
+const snippetsText = elements.get("api-snippets-list").children
+    .map((card) => JSON.stringify(card))
+    .join("\n");
+assert.match(snippetsText, /primary-alias/);
+assert.match(snippetsText, /Authorization: Bearer YOUR_API_KEY/);
+assert.ok(!snippetsText.includes("selected-model.gguf"), "API snippets should prefer first alias over selected model");
+
+flagValues = { host: "localhost", port: 8081, alias: "", api_key: "" };
+selectedModel = "fallback-model.gguf";
+apiTab.updateEndpoints();
+
+const fallbackSnippetsText = elements.get("api-snippets-list").children
+    .map((card) => JSON.stringify(card))
+    .join("\n");
+assert.match(fallbackSnippetsText, /fallback-model\.gguf/);
+assert.match(fallbackSnippetsText, /no-key-needed/);
+
+console.log("api tab unit tests passed");

--- a/tests/frontend/chat_rendering_unit.cjs
+++ b/tests/frontend/chat_rendering_unit.cjs
@@ -1,0 +1,179 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const source = fs.readFileSync(path.join(ROOT, "ui", "js", "chat-rendering.js"), "utf8");
+
+function createClassList(el) {
+    return {
+        add: (...names) => {
+            for (const name of names) el._classes.add(name);
+            el.className = Array.from(el._classes).join(" ");
+        },
+        remove: (...names) => {
+            for (const name of names) el._classes.delete(name);
+            el.className = Array.from(el._classes).join(" ");
+        },
+        contains: (name) => el._classes.has(name),
+        toggle: (name, force) => {
+            const shouldAdd = force === undefined ? !el._classes.has(name) : !!force;
+            if (shouldAdd) el._classes.add(name);
+            else el._classes.delete(name);
+            el.className = Array.from(el._classes).join(" ");
+            return shouldAdd;
+        },
+    };
+}
+
+function createElement(tagName) {
+    const el = {
+        tagName: tagName.toUpperCase(),
+        children: [],
+        parentNode: null,
+        style: {},
+        dataset: {},
+        _classes: new Set(),
+        _className: "",
+        _textContent: "",
+        _innerHTML: "",
+        href: "",
+        target: "",
+        rel: "",
+        title: "",
+        appendChild(child) {
+            child.parentNode = this;
+            this.children.push(child);
+            return child;
+        },
+        remove() {
+            if (!this.parentNode) return;
+            this.parentNode.children = this.parentNode.children.filter((child) => child !== this);
+            this.parentNode = null;
+        },
+        closest(selector) {
+            if (!selector.startsWith(".")) return null;
+            const className = selector.slice(1);
+            let node = this;
+            while (node) {
+                if (node._classes && node._classes.has(className)) return node;
+                node = node.parentNode;
+            }
+            return null;
+        },
+        querySelector(selector) {
+            if (!selector.startsWith(".")) return null;
+            const className = selector.slice(1);
+            const stack = [...this.children];
+            while (stack.length) {
+                const child = stack.shift();
+                if (child._classes && child._classes.has(className)) return child;
+                stack.push(...child.children);
+            }
+            return null;
+        },
+    };
+    Object.defineProperty(el, "className", {
+        get() {
+            return this._className;
+        },
+        set(value) {
+            this._className = String(value || "");
+            this._classes = new Set(this._className.split(/\s+/).filter(Boolean));
+        },
+    });
+    Object.defineProperty(el, "textContent", {
+        get() {
+            return this._textContent;
+        },
+        set(value) {
+            this._textContent = String(value || "");
+        },
+    });
+    Object.defineProperty(el, "innerHTML", {
+        get() {
+            return this._innerHTML;
+        },
+        set(value) {
+            this._innerHTML = String(value || "");
+        },
+    });
+    el.classList = createClassList(el);
+    return el;
+}
+
+const elements = new Map();
+const context = {
+    window: { LlamaGui: {} },
+    document: {
+        createElement,
+        getElementById: (id) => elements.get(id) || null,
+    },
+    URL,
+    console,
+};
+context.window.window = context.window;
+vm.createContext(context);
+vm.runInContext(source, context, { filename: "ui/js/chat-rendering.js" });
+
+const rendering = context.window.LlamaGui.chatRendering;
+
+{
+    const html = rendering.renderMarkdown([
+        "# <img src=x onerror=alert(1)> **safe**",
+        "",
+        "- <script>alert(1)</script>",
+        "1. `</code><img src=x>`",
+        "",
+        "| <b>h</b> | value |",
+        "| --- | --- |",
+        "| <i>x</i> | ~~gone~~ |",
+        "",
+        "Plain <svg onload=alert(1)> text",
+    ].join("\n"));
+
+    assert.ok(!html.includes("<img"), "chat markdown should not emit raw image HTML");
+    assert.ok(!html.includes("<script"), "chat markdown should not emit raw script HTML");
+    assert.ok(!html.includes("<svg"), "chat markdown should not emit raw svg HTML");
+    assert.match(html, /<h1>&lt;img src=x onerror=alert\(1\)&gt; <strong>safe<\/strong><\/h1>/);
+    assert.match(html, /<li>&lt;script&gt;alert\(1\)&lt;\/script&gt;<\/li>/);
+    assert.match(html, /<code>&lt;\/code&gt;&lt;img src=x&gt;<\/code>/);
+    assert.match(html, /<th>&lt;b&gt;h&lt;\/b&gt;<\/th>/);
+    assert.match(html, /<td>&lt;i&gt;x&lt;\/i&gt;<\/td>/);
+    assert.match(html, /Plain &lt;svg onload=alert\(1\)&gt; text<\/p>/);
+}
+
+{
+    const html = rendering.renderMarkdown("```html\n<div onclick=\"bad()\">x</div>\n```");
+
+    assert.match(html, /<pre data-lang="html"><code>&lt;div onclick=&quot;bad\(\)&quot;&gt;x&lt;\/div&gt;<\/code><\/pre>/);
+    assert.ok(!html.includes("<div onclick"), "fenced code blocks should stay escaped");
+}
+
+{
+    const wrap = createElement("div");
+    wrap.className = "chat-message-content";
+    const bubble = createElement("div");
+    bubble.className = "chat-bubble";
+    wrap.appendChild(bubble);
+
+    rendering.renderChatSources(bubble, [
+        { index: 1, title: "JS URL", url: "javascript:alert(1)" },
+        { index: 2, title: "HTTP URL", url: "http://example.com/path" },
+        { index: 3, title: "HTTPS URL", url: "https://example.com/secure" },
+        { index: 4, title: "File URL", url: "file:///etc/passwd" },
+    ]);
+
+    const sources = wrap.querySelector(".chat-sources");
+    assert.ok(sources, "expected chat sources wrapper");
+    assert.equal(sources.children[0].tagName, "SPAN");
+    assert.equal(sources.children[0].href, "");
+    assert.equal(sources.children[1].tagName, "A");
+    assert.equal(sources.children[1].href, "http://example.com/path");
+    assert.equal(sources.children[2].tagName, "A");
+    assert.equal(sources.children[2].href, "https://example.com/secure");
+    assert.equal(sources.children[3].tagName, "SPAN");
+}
+
+console.log("chat rendering unit tests passed");

--- a/tests/frontend/hf_download_ui_unit.cjs
+++ b/tests/frontend/hf_download_ui_unit.cjs
@@ -1,0 +1,264 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const source = fs.readFileSync(path.join(ROOT, "ui", "js", "hf-download-ui.js"), "utf8");
+
+function createClassList(el) {
+    return {
+        add: (...names) => {
+            for (const name of names) el._classes.add(name);
+        },
+        remove: (...names) => {
+            for (const name of names) el._classes.delete(name);
+        },
+        contains: (name) => el._classes.has(name),
+        toggle: (name, force) => {
+            const shouldAdd = force === undefined ? !el._classes.has(name) : !!force;
+            if (shouldAdd) el._classes.add(name);
+            else el._classes.delete(name);
+            return shouldAdd;
+        },
+    };
+}
+
+function createElement(tagName = "div") {
+    return {
+        tagName: tagName.toUpperCase(),
+        children: [],
+        _classes: new Set(),
+        className: "",
+        textContent: "",
+        value: "",
+        disabled: false,
+        style: {},
+        addEventListener: () => {},
+        appendChild(child) {
+            this.children.push(child);
+            if (this.tagName === "SELECT" && !this.value && child.value !== undefined) {
+                this.value = child.value;
+            }
+            return child;
+        },
+        get options() {
+            return this.children;
+        },
+        set innerHTML(_value) {
+            this.children = [];
+            this.value = "";
+        },
+        get innerHTML() {
+            return "";
+        },
+    };
+}
+
+function makeContext() {
+    const elements = new Map();
+    const context = {
+        window: { LlamaGui: {} },
+        document: {
+            createElement,
+            getElementById: (id) => elements.get(id) || null,
+        },
+        console,
+        setInterval: () => 1,
+        clearInterval: () => {},
+        Date,
+    };
+    context.window.window = context.window;
+    vm.createContext(context);
+    vm.runInContext(source, context, { filename: "ui/js/hf-download-ui.js" });
+    return { context, elements, ui: context.window.LlamaGui.hfDownloadUi };
+}
+
+function addElement(elements, id, tagName = "div", value = "") {
+    const el = createElement(tagName);
+    el.id = id;
+    el.value = value;
+    el.classList = createClassList(el);
+    elements.set(id, el);
+    return el;
+}
+
+(async () => {
+{
+    const { elements, ui } = makeContext();
+    const status = addElement(elements, "hf-download-status");
+    const findBtn = addElement(elements, "btn-hf-find-files", "button");
+    const downloadBtn = addElement(elements, "btn-hf-download", "button");
+    const cancelBtn = addElement(elements, "btn-hf-cancel", "button");
+    const progress = addElement(elements, "hf-download-progress");
+    const fill = addElement(elements, "hf-progress-fill");
+    const text = addElement(elements, "hf-progress-text");
+
+    assert.equal(ui.formatHfBytes(0), "unknown size");
+    assert.equal(ui.formatHfBytes(1048576), "1.0 MB");
+    assert.equal(ui.formatHfBytes(2147483648), "2.00 GB");
+
+    ui.showStatus("success", "Ready");
+    assert.equal(status.className, "hf-download-status success");
+    assert.equal(status.textContent, "Ready");
+
+    ui.setBusy(true);
+    assert.equal(findBtn.disabled, true);
+    assert.equal(downloadBtn.disabled, true);
+    assert.equal(cancelBtn.classList.contains("hidden"), false);
+    ui.setBusy(false);
+    assert.equal(findBtn.disabled, false);
+    assert.equal(downloadBtn.disabled, false);
+    assert.equal(cancelBtn.classList.contains("hidden"), true);
+
+    ui.updateProgress({ status: "downloading", downloaded: 1048576, total: 2097152, current_file: "model.gguf" });
+    assert.equal(progress.classList.contains("hidden"), false);
+    assert.equal(fill.style.width, "50%");
+    assert.equal(text.textContent, "model.gguf 50% (1.0 MB / 2.0 MB)");
+}
+
+{
+    const { elements, ui } = makeContext();
+    addElement(elements, "hf-download-status");
+    addElement(elements, "btn-hf-find-files", "button");
+    addElement(elements, "btn-hf-download", "button");
+    addElement(elements, "btn-hf-cancel", "button");
+    const repo = addElement(elements, "hf-repo-input", "input", " owner/model ");
+    const revision = addElement(elements, "hf-revision-input", "input", " refs/pr/1 ");
+    const token = addElement(elements, "hf-token-input", "input", " hf_secret ");
+    const options = addElement(elements, "hf-file-options");
+    const modelSelect = addElement(elements, "hf-model-file-select", "select");
+    const mmprojSelect = addElement(elements, "hf-mmproj-file-select", "select");
+    const mmprojGroup = addElement(elements, "hf-mmproj-group");
+    options.classList.add("hidden");
+    mmprojGroup.classList.add("hidden");
+
+    const calls = [];
+    ui.configure({
+        fetchJson: async (url, optionsArg) => {
+            calls.push({ url, body: JSON.parse(optionsArg.body) });
+            return {
+                models: [{ name: "model.Q4.gguf", size: 1048576 }],
+                mmproj: [{ name: "mmproj.gguf", size: 524288 }],
+            };
+        },
+    });
+
+    await ui.findFiles();
+    assert.equal(calls[0].url, "/api/hf/repo-files");
+    assert.deepEqual(calls[0].body, {
+        repo_id: "owner/model",
+        revision: "refs/pr/1",
+        token: "hf_secret",
+    });
+    assert.equal(modelSelect.options.length, 2);
+    assert.equal(modelSelect.options[1].textContent, "model.Q4.gguf  (1.0 MB)");
+    assert.equal(modelSelect.value, "model.Q4.gguf");
+    assert.equal(mmprojSelect.options[1].value, "mmproj.gguf");
+    assert.equal(options.classList.contains("hidden"), false);
+    assert.equal(mmprojGroup.classList.contains("hidden"), false);
+    assert.equal(repo.value, " owner/model ");
+    assert.equal(revision.value, " refs/pr/1 ");
+    assert.equal(token.value, " hf_secret ");
+}
+
+{
+    const { elements, ui } = makeContext();
+    const status = addElement(elements, "hf-download-status");
+    addElement(elements, "btn-hf-find-files", "button");
+    addElement(elements, "btn-hf-download", "button");
+    addElement(elements, "btn-hf-cancel", "button");
+    const options = addElement(elements, "hf-file-options");
+    addElement(elements, "hf-repo-input", "input", "owner/model");
+    addElement(elements, "hf-revision-input", "input", "");
+    addElement(elements, "hf-token-input", "input", "");
+    addElement(elements, "hf-model-file-select", "select");
+    addElement(elements, "hf-mmproj-file-select", "select");
+    options.classList.remove("hidden");
+
+    ui.configure({
+        fetchJson: async () => {
+            throw new Error("network down");
+        },
+    });
+
+    await ui.findFiles();
+    assert.equal(options.classList.contains("hidden"), true);
+    assert.equal(status.className, "hf-download-status error");
+    assert.equal(status.textContent, "Hugging Face lookup failed: network down");
+}
+
+{
+    const { elements, ui } = makeContext();
+    addElement(elements, "hf-download-status");
+    addElement(elements, "btn-hf-find-files", "button");
+    addElement(elements, "btn-hf-download", "button");
+    addElement(elements, "btn-hf-cancel", "button");
+    addElement(elements, "hf-repo-input", "input", "owner/model");
+    addElement(elements, "hf-revision-input", "input", "");
+    addElement(elements, "hf-token-input", "input", "");
+    addElement(elements, "hf-model-file-select", "select", "model.gguf");
+    addElement(elements, "hf-mmproj-file-select", "select", "mmproj.gguf");
+
+    const calls = [];
+    const confirmations = [];
+    ui.configure({
+        fetchJson: async (url, optionsArg) => {
+            calls.push({ url, body: JSON.parse(optionsArg.body) });
+            if (!calls.at(-1).body.overwrite) throw new Error("Already exists: model.gguf");
+            return { status: "starting" };
+        },
+        confirmAction: async (message) => {
+            confirmations.push(message);
+            return true;
+        },
+    });
+
+    await ui.startDownload(false);
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(confirmations.length, 1);
+    assert.match(confirmations[0], /Already exists: model\.gguf/);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].body.overwrite, false);
+    assert.equal(calls[1].body.overwrite, true);
+}
+
+{
+    const { elements, ui } = makeContext();
+    const status = addElement(elements, "hf-download-status");
+    addElement(elements, "btn-hf-find-files", "button");
+    addElement(elements, "btn-hf-download", "button");
+    addElement(elements, "btn-hf-cancel", "button");
+
+    const calls = [];
+    ui.configure({
+        refreshModels: async () => calls.push("refreshModels"),
+        applyPresetModel: (name) => calls.push(["applyPresetModel", name]),
+        refreshQuickLaunchUI: () => calls.push("refreshQuickLaunchUI"),
+        flagCore: {
+            setPathFlagValue: (id, value) => calls.push(["setPathFlagValue", id, value]),
+            updateCommandPreview: () => calls.push("updateCommandPreview"),
+        },
+    });
+
+    await ui.finishDownload({
+        message: "Done",
+        model_name: "downloaded.gguf",
+        mmproj_path: "models/mmproj.gguf",
+    });
+
+    assert.equal(status.className, "hf-download-status success");
+    assert.deepEqual(calls, [
+        "refreshModels",
+        ["applyPresetModel", "downloaded.gguf"],
+        ["setPathFlagValue", "mmproj", "models/mmproj.gguf"],
+        "updateCommandPreview",
+        "refreshQuickLaunchUI",
+    ]);
+}
+
+console.log("hf download ui unit tests passed");
+})().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/tests/frontend/sampler_presets_unit.cjs
+++ b/tests/frontend/sampler_presets_unit.cjs
@@ -1,0 +1,128 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const source = fs.readFileSync(path.join(ROOT, "ui", "js", "sampler-presets.js"), "utf8");
+
+let storedValue = null;
+const debugMessages = [];
+const context = {
+    window: { LlamaGui: {} },
+    console: {
+        debug: (...args) => debugMessages.push(args),
+        warn: () => {},
+    },
+    localStorage: {
+        getItem: () => storedValue,
+        setItem: (_key, value) => {
+            storedValue = value;
+        },
+    },
+    SAMPLER_PRESET_STORAGE_KEY: "llama_gui_sampler_presets_v1",
+    BUILTIN_SAMPLER_PRESETS: {
+        Balanced: { temperature: 0.75, top_k: 100, ctx_size: 32768 },
+        Creative: { temperature: 1, top_p: 0.98 },
+    },
+    document: {
+        createElement: () => ({
+            appendChild: () => {},
+            addEventListener: () => {},
+            classList: { add: () => {}, remove: () => {}, toggle: () => {} },
+            style: {},
+        }),
+    },
+    URL: { createObjectURL: () => "", revokeObjectURL: () => {} },
+    Blob: function Blob() {},
+    alert: () => {},
+    confirm: () => true,
+};
+context.window.window = context.window;
+vm.createContext(context);
+vm.runInContext(source, context, { filename: "ui/js/sampler-presets.js" });
+
+const samplerPresets = context.window.LlamaGui.samplerPresets;
+let appliedPatch = null;
+samplerPresets.configure({
+    getFlags: () => [
+        { id: "temperature", category: "sampling" },
+        { id: "top_k", category: "sampling" },
+        { id: "top_p", category: "sampling" },
+        { id: "ctx_size", category: "context" },
+    ],
+    getDefaultFlagValues: () => ({
+        temperature: 0.8,
+        top_k: 40,
+        top_p: 0.95,
+        ctx_size: 4096,
+    }),
+    flagCore: {
+        getFlagValues: () => ({
+            temperature: 0.2,
+            top_k: 12,
+            ctx_size: 8192,
+        }),
+        setMultipleFlagValues: (patch) => {
+            appliedPatch = patch;
+        },
+    },
+});
+
+function assertJsonEqual(actual, expected, message) {
+    assert.equal(JSON.stringify(actual), JSON.stringify(expected), message);
+}
+
+storedValue = null;
+assertJsonEqual(samplerPresets.loadSamplerPresetStore(), {}, "missing sampler preset storage should load as empty object");
+
+storedValue = "not json";
+assertJsonEqual(samplerPresets.loadSamplerPresetStore(), {}, "invalid sampler preset storage should load as empty object");
+assert.ok(debugMessages.length > 0, "invalid sampler preset storage should produce a debug log");
+
+storedValue = JSON.stringify(["not", "an", "object"]);
+assertJsonEqual(samplerPresets.loadSamplerPresetStore(), {}, "array sampler preset storage should load as empty object");
+
+assertJsonEqual(
+    samplerPresets.normalizeSamplerPresetValues({
+        temperature: 0.61,
+        top_k: 77,
+        ctx_size: 12345,
+        unknown: true,
+    }),
+    { temperature: 0.61, top_k: 77 },
+    "sampler preset normalization should keep only sampling flags"
+);
+
+assertJsonEqual(
+    samplerPresets.collectSamplerValues(),
+    { temperature: 0.2, top_k: 12 },
+    "sampler value collection should ignore non-sampling current flags"
+);
+
+samplerPresets.applySamplerPresetValues({ temperature: 0.42 });
+assertJsonEqual(
+    appliedPatch,
+    { temperature: 0.42, top_k: 40, top_p: 0.95 },
+    "applying a sampler preset should reset missing sampler values to defaults only"
+);
+assert.equal(
+    Object.prototype.hasOwnProperty.call(appliedPatch, "ctx_size"),
+    false,
+    "applying a sampler preset should not patch unrelated flags"
+);
+
+storedValue = JSON.stringify({
+    "My Sampler": { temperature: 0.33, ctx_size: 9999, top_p: 0.7 },
+});
+assertJsonEqual(
+    samplerPresets.getAllSamplerPresets(),
+    [
+        { name: "Balanced", values: { temperature: 0.75, top_k: 100 }, source: "builtin" },
+        { name: "Creative", values: { temperature: 1, top_p: 0.98 }, source: "builtin" },
+        { name: "My Sampler", values: { temperature: 0.33, top_p: 0.7 }, source: "custom" },
+    ],
+    "all sampler presets should expose a stable normalized shape for consumers"
+);
+
+console.log("sampler presets unit tests passed");


### PR DESCRIPTION
Add fast Node frontend unit tests and documentation. Introduces new unit tests for api tab, chat rendering, HF download UI, and sampler presets (tests/frontend/*.cjs), adds docs/tests.md with test commands and guidance, and updates AGENTS.md to reference the new test docs. Also updates package.json test script to run the new unit tests as part of the frontend test suite to improve regression coverage and make focused debugging easier.