### PR TITLE
Add Lemonade llamacpp-rocm optional ROCm backend

### DIFF
--- a/backend/routes/install.py
+++ b/backend/routes/install.py
@@ -1,6 +1,7 @@
 """Routes for llama.cpp install/update management."""
 
 import threading
+import urllib.parse
 
 from ..http import sanitize_error
 from ..services import llama_manager
@@ -12,7 +13,14 @@ RELEASE_RESPONSE_LIMIT = 30
 
 def get_releases(request, response, ctx):
     try:
-        releases = llama_manager.get_releases(ctx)
+        repo_api = None
+        query = urllib.parse.parse_qs(request.query or "")
+        backend = (query.get("backend") or [""])[0].strip()
+        if backend:
+            spec = ctx.services.backend_specs.get(backend)
+            if spec is not None:
+                repo_api = llama_manager.resolve_repo_api(spec, ctx)
+        releases = llama_manager.get_releases(ctx, repo_api)
         result = []
         for r in releases[:RELEASE_RESPONSE_LIMIT]:
             result.append(
@@ -81,7 +89,9 @@ def start_update(request, response, ctx):
             return
         ctx.state.install_in_progress = True
     try:
-        releases = llama_manager.get_releases(ctx)
+        backend_spec = ctx.services.backend_specs[backend]
+        repo_api = llama_manager.resolve_repo_api(backend_spec, ctx)
+        releases = llama_manager.get_releases(ctx, repo_api)
         latest = releases[0]["tag_name"] if releases else None
         if latest and latest != tag:
 

--- a/backend/services/llama_manager.py
+++ b/backend/services/llama_manager.py
@@ -450,6 +450,9 @@ def extract_archive_preserve_paths(
                 target.parent.mkdir(parents=True, exist_ok=True)
                 with zf.open(info, "r") as src, open(target, "wb") as dst:
                     shutil.copyfileobj(src, dst)
+                mode = (info.external_attr >> 16) & 0o777
+                if mode:
+                    os.chmod(target, mode)
         return
 
     if lower_name.endswith((".tar.gz", ".tgz")):

--- a/backend/services/llama_manager.py
+++ b/backend/services/llama_manager.py
@@ -19,6 +19,51 @@ from ..context import AppContext
 
 RPATH_LIBRARY_RE = re.compile(r"^\s*@rpath/([^\s(]+)")
 
+# Optional llamacpp-rocm backend (https://github.com/lemonade-sdk/llamacpp-rocm).
+# Publishes nightly ROCm 7 llama.cpp archives for Windows and Ubuntu, one asset
+# per AMD GPU target. Users must choose the target matching their GPU arch.
+LEMONADE_ROCM_REPO_API = (
+    "https://api.github.com/repos/lemonade-sdk/llamacpp-rocm/releases"
+)
+
+# (gpu_target, family label) for every target upstream publishes.
+LEMONADE_ROCM_TARGETS = [
+    ("gfx103X", "AMD RDNA2"),
+    ("gfx110X", "AMD RDNA3"),
+    ("gfx1150", "Ryzen AI 300"),
+    ("gfx1151", "Ryzen AI"),
+    ("gfx120X", "AMD RDNA4"),
+    ("gfx90a", "AMD CDNA2"),
+    ("gfx908", "AMD CDNA1"),
+]
+
+
+def _lemonade_rocm_backend(platform_token: str, gpu_target: str, family: str) -> dict[str, Any]:
+    return {
+        "label": f"ROCm 7 {gpu_target} ({family}, Lemonade)",
+        "asset": f"llama-{{tag}}-{platform_token}-rocm-{gpu_target}-x64.zip",
+        "provider": "lemonade-rocm",
+        "repo_api": LEMONADE_ROCM_REPO_API,
+        "preserve_paths": True,
+        "gpu_target": gpu_target,
+    }
+
+
+def _lemonade_rocm_specs(platform_token: str) -> dict[str, dict[str, Any]]:
+    return {
+        f"lemonade-rocm-{gpu_target}": _lemonade_rocm_backend(platform_token, gpu_target, family)
+        for gpu_target, family in LEMONADE_ROCM_TARGETS
+    }
+
+
+def resolve_repo_api(spec: Mapping[str, Any], ctx: AppContext) -> str:
+    """Return the GitHub releases API for a backend spec.
+
+    Lemonade ROCm specs carry their own ``repo_api``. Official llama.cpp specs
+    omit it and fall back to the configured official API.
+    """
+    return spec.get("repo_api") or ctx.config.github_api
+
 
 def build_backend_specs(current_platform: str, current_arch: str) -> dict[str, Any]:
     if current_platform == "win32":
@@ -33,7 +78,7 @@ def build_backend_specs(current_platform: str, current_arch: str) -> dict[str, A
                     "asset": "llama-{tag}-bin-win-opencl-adreno-arm64.zip",
                 },
             }
-        return {
+        specs = {
             "cpu": {"label": "CPU", "asset": "llama-{tag}-bin-win-cpu-x64.zip"},
             "cuda-12.4": {
                 "label": "CUDA 12.4 (NVIDIA)",
@@ -58,6 +103,8 @@ def build_backend_specs(current_platform: str, current_arch: str) -> dict[str, A
                 "asset": "llama-{tag}-bin-win-hip-radeon-x64.zip",
             },
         }
+        specs.update(_lemonade_rocm_specs("windows"))
+        return specs
 
     if current_platform == "darwin":
         if current_arch == "arm64":
@@ -78,7 +125,7 @@ def build_backend_specs(current_platform: str, current_arch: str) -> dict[str, A
 
     if current_platform.startswith("linux"):
         if current_arch == "x64":
-            return {
+            specs = {
                 "cpu": {"label": "CPU", "asset": "llama-{tag}-bin-ubuntu-x64.tar.gz"},
                 "vulkan": {
                     "label": "Vulkan",
@@ -93,6 +140,8 @@ def build_backend_specs(current_platform: str, current_arch: str) -> dict[str, A
                     "asset": "llama-{tag}-bin-ubuntu-openvino-2026.2-x64.tar.gz",
                 },
             }
+            specs.update(_lemonade_rocm_specs("ubuntu"))
+            return specs
         if current_arch == "arm64":
             return {
                 "cpu": {
@@ -114,18 +163,22 @@ def build_backend_specs(current_platform: str, current_arch: str) -> dict[str, A
     return {}
 
 
-def get_releases(ctx: AppContext) -> list[dict[str, Any]]:
+def get_releases(ctx: AppContext, repo_api: Optional[str] = None) -> list[dict[str, Any]]:
+    api_url = repo_api or ctx.config.github_api
     req = urllib.request.Request(
-        ctx.config.github_api,
+        api_url,
         headers={"Accept": "application/vnd.github+json"},
     )
     with ctx.services.urlopen_with_ssl(req, timeout=30) as resp:
         return json.loads(resp.read())
 
 
-def get_release_by_tag(ctx: AppContext, tag: str) -> dict[str, Any]:
+def get_release_by_tag(
+    ctx: AppContext, tag: str, repo_api: Optional[str] = None
+) -> dict[str, Any]:
+    api_url = repo_api or ctx.config.github_api
     req = urllib.request.Request(
-        f"{ctx.config.github_api}/tags/{tag}",
+        f"{api_url}/tags/{tag}",
         headers={"Accept": "application/vnd.github+json"},
     )
     with ctx.services.urlopen_with_ssl(req, timeout=30) as resp:
@@ -357,6 +410,71 @@ def extract_archive_flat(
     raise ValueError(f"Unsupported archive format: {archive_path.name}")
 
 
+def _safe_preserve_target(dest_root: pathlib.Path, member_name: str) -> Optional[pathlib.Path]:
+    """Resolve an archive member to a path under dest_root, or None if unsafe.
+
+    Rejects absolute paths and ``..`` traversal so a malicious/crafted archive
+    cannot escape the destination directory. Member names use POSIX
+    separators; backslashes are normalized defensively.
+    """
+    raw = (member_name or "").replace("\\", "/")
+    rel = pathlib.PurePosixPath(raw)
+    parts = [p for p in rel.parts if p not in (".", "")]
+    if not parts:
+        return None
+    if rel.is_absolute() or ".." in parts:
+        return None
+    return dest_root.joinpath(*parts)
+
+
+def extract_archive_preserve_paths(
+    archive_path: pathlib.Path,
+    dest_root: pathlib.Path,
+) -> None:
+    """Extract an archive preserving its nested directory layout under dest_root.
+
+    Used for Lemonade ROCm packages, which bundle ROCm runtime data in nested
+    directories (e.g. ``hipblaslt/``, ``rocblas/``) that the flat extractor
+    would destroy. Absolute and path-traversal entries are skipped. Archive
+    links are skipped for safety.
+    """
+    lower_name = archive_path.name.lower()
+    if lower_name.endswith(".zip"):
+        with zipfile.ZipFile(archive_path, "r") as zf:
+            for info in zf.infolist():
+                if info.is_dir():
+                    continue
+                target = _safe_preserve_target(dest_root, info.filename)
+                if target is None:
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(info, "r") as src, open(target, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+        return
+
+    if lower_name.endswith((".tar.gz", ".tgz")):
+        with tarfile.open(archive_path, "r:gz") as tf:
+            for member in tf.getmembers():
+                if member.issym() or member.islnk():
+                    continue
+                if not member.isfile():
+                    continue
+                target = _safe_preserve_target(dest_root, member.name)
+                if target is None:
+                    continue
+                src = tf.extractfile(member)
+                if src is None:
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with src, open(target, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+                if member.mode:
+                    os.chmod(target, member.mode)
+        return
+
+    raise ValueError(f"Unsupported archive format: {archive_path.name}")
+
+
 def install_release(
     ctx: AppContext,
     tag: str,
@@ -367,10 +485,13 @@ def install_release(
         ctx, status="downloading", message=f"Fetching release {tag}..."
     )
 
+    backend_spec = backend_specs[backend]
+    repo_api = resolve_repo_api(backend_spec, ctx)
+
     try:
-        release = get_release_by_tag(ctx, tag)
+        release = get_release_by_tag(ctx, tag, repo_api)
     except Exception:
-        releases = get_releases(ctx)
+        releases = get_releases(ctx, repo_api)
         release = next((r for r in releases if r["tag_name"] == tag), None)
         if not release:
             set_download_progress(
@@ -383,7 +504,6 @@ def install_release(
     def progress_cb(downloaded: int, total: int) -> None:
         set_download_progress(ctx, downloaded=downloaded, total=total)
 
-    backend_spec = backend_specs[backend]
     bin_filename = backend_spec["asset"].format(tag=tag)
     if bin_filename not in asset_map:
         set_download_progress(
@@ -436,11 +556,17 @@ def install_release(
                 shutil.rmtree(d)
             d.mkdir(parents=True, exist_ok=True)
 
-        extract_archive_flat(bin_archive, ctx.paths.llama_bin, ctx.paths.llama_grammars)
-        for extra_archive in extra_archives:
-            extract_archive_flat(
-                extra_archive, ctx.paths.llama_bin, ctx.paths.llama_grammars
-            )
+        preserve_paths = bool(backend_spec.get("preserve_paths"))
+        if preserve_paths:
+            extract_archive_preserve_paths(bin_archive, ctx.paths.llama_bin)
+            for extra_archive in extra_archives:
+                extract_archive_preserve_paths(extra_archive, ctx.paths.llama_bin)
+        else:
+            extract_archive_flat(bin_archive, ctx.paths.llama_bin, ctx.paths.llama_grammars)
+            for extra_archive in extra_archives:
+                extract_archive_flat(
+                    extra_archive, ctx.paths.llama_bin, ctx.paths.llama_grammars
+                )
 
         ctx.services.save_config(
             {"version": release.get("name", tag), "backend": backend, "tag": tag}

--- a/docs/llamacpp-rocm-integration-plan.md
+++ b/docs/llamacpp-rocm-integration-plan.md
@@ -1,0 +1,172 @@
+# llamacpp-rocm Optional Backend Integration Plan
+
+## Goal
+
+Add [`lemonade-sdk/llamacpp-rocm`](https://github.com/lemonade-sdk/llamacpp-rocm) as an optional installable backend alongside official `ggml-org/llama.cpp` releases, reusing Llama GUI's existing Install tab, download progress, config, and process launch flow.
+
+## Current Llama GUI Shape
+
+- Official `llama.cpp` releases are fetched from `https://api.github.com/repos/ggml-org/llama.cpp/releases`.
+- Backend options come from `build_backend_specs()` in `backend/services/llama_manager.py`.
+- `/api/releases` currently returns releases for the single configured GitHub API.
+- `/api/install` receives `{ tag, backend }`, downloads the matching asset, extracts it into `llama/bin` and `llama/grammars`, then saves `config.json` with `{ version, backend, tag }`.
+- Launching is generic: `process_manager` runs `llama-server`, `llama-cli`, and other tools from `llama/bin`. A correctly installed `llamacpp-rocm` package should not need a separate launcher.
+
+## Upstream Findings
+
+- Repo: `https://github.com/lemonade-sdk/llamacpp-rocm`
+- Publishes nightly/prebuilt ROCm 7 `llama.cpp` archives for Windows and Ubuntu.
+- Latest checked release during investigation: `b1294`.
+- Asset names follow patterns like:
+  - `llama-b1294-windows-rocm-gfx103X-x64.zip`
+  - `llama-b1294-windows-rocm-gfx110X-x64.zip`
+  - `llama-b1294-windows-rocm-gfx1150-x64.zip`
+  - `llama-b1294-windows-rocm-gfx1151-x64.zip`
+  - `llama-b1294-windows-rocm-gfx120X-x64.zip`
+  - `llama-b1294-windows-rocm-gfx908-x64.zip`
+  - `llama-b1294-windows-rocm-gfx90a-x64.zip`
+  - Equivalent `ubuntu-rocm` variants.
+- Users must choose a GPU target, not just "ROCm".
+- Supported targets listed upstream include `gfx1151`, `gfx1150`, `gfx120X`, `gfx110X`, `gfx103X`, `gfx90a`, and `gfx908`.
+- Archives include normal `llama.cpp` executables plus bundled ROCm runtime files.
+- Important: archives include nested runtime directories such as `hipblaslt/` and `rocblas/`. Llama GUI's current flat extraction would break these packages.
+
+## Recommended Design
+
+### 1. Extend Backend Specs With Provider Metadata
+
+Add fields to backend specs such as:
+
+- `label`
+- `provider` or `source`, for example `official` or `lemonade-rocm`
+- `repo_api`, for example `https://api.github.com/repos/lemonade-sdk/llamacpp-rocm/releases`
+- `asset` pattern
+- `preserve_paths` boolean
+- Optional `gpu_target` metadata
+
+Example backend IDs:
+
+- `lemonade-rocm-gfx103X`
+- `lemonade-rocm-gfx110X`
+- `lemonade-rocm-gfx1150`
+- `lemonade-rocm-gfx1151`
+- `lemonade-rocm-gfx120X`
+- `lemonade-rocm-gfx90a`
+- `lemonade-rocm-gfx908`
+
+Labels should be user-facing, for example:
+
+- `ROCm 7 gfx110X (AMD RDNA3, Lemonade)`
+- `ROCm 7 gfx103X (AMD RDNA2, Lemonade)`
+- `ROCm 7 gfx1150 (Ryzen AI 300, Lemonade)`
+
+### 2. Make Release Fetching Backend-Aware
+
+Change release fetching so `/api/releases` can accept a `backend` query parameter or a `provider` query parameter.
+
+The backend route should resolve the selected backend spec, then use that spec's `repo_api`. Keep default behavior unchanged for official backends.
+
+`ui/js/manager.js` should refetch release options when backend selection changes, because official `llama.cpp` tags and Lemonade tags are independent.
+
+### 3. Make Install And Update Provider-Aware
+
+Install should still accept `{ tag, backend }`, but `llama_manager.install_release()` should fetch release data from the selected backend spec's `repo_api` instead of using `ctx.config.github_api` unconditionally.
+
+Update should use the installed backend's provider. Backward-compatible config should keep `{ version, backend, tag }` and may add provider/source metadata.
+
+### 4. Add Safe Path-Preserving Extraction
+
+Keep the current flat extraction mode for official `llama.cpp` releases.
+
+Add a `preserve_paths` mode for Lemonade ROCm archives:
+
+- Preserve nested directories under `llama/bin`.
+- Reject absolute paths and path traversal entries.
+- Route `.gbnf` grammar files to `llama/grammars` only when they are known grammar assets.
+- Leave provider archive layout intact when uncertain.
+- Do not flatten `hipblaslt/` or `rocblas/`; those layouts are runtime data.
+
+### 5. Launch Environment
+
+The existing `process_manager._build_process_env()` already prepends `llama/bin` to `PATH` and `LD_LIBRARY_PATH` on Linux. Keep that behavior.
+
+Consider provider-specific runtime environment handling only if smoke tests prove it is needed. Potential additions:
+
+- `ROCBLAS_TENSILE_LIBPATH` pointing at `llama/bin/rocblas/library`
+- `HIPBLASLT_TENSILE_LIBPATH` or equivalent only if upstream runtime requires it
+
+Do not guess too much here. First preserve archive paths and test with:
+
+- `llama-cli --version`
+- `llama-cli --help`
+- `llama-cli --list-devices`
+
+### 6. UI Behavior
+
+Keep this in the existing Install tab.
+
+- Backend dropdown lists official and Lemonade ROCm options available for the host platform/arch.
+- Add a short hint near the dropdown: ROCm builds require choosing the target matching your AMD GPU architecture.
+- When a Lemonade backend is selected, the release dropdown should show Lemonade release tags.
+- Status display can continue showing backend ID initially, but nicer labels would be better.
+
+## Tests
+
+### Backend Tests
+
+- `build_backend_specs()` includes Lemonade ROCm choices on `win32` x64 and Linux x64 only.
+- Release fetch uses the selected backend `repo_api`.
+- Install uses the selected backend `repo_api`.
+- Preserve-path extraction keeps nested `hipblaslt/` and `rocblas/` files.
+- Preserve-path extraction blocks traversal entries.
+- Official extraction still uses flat mode.
+- Update uses the installed backend provider.
+
+### Frontend Tests
+
+- Backend selection rerenders the release list or triggers release refetch.
+- Backend options include readable Lemonade ROCm labels from `/api/status`.
+- Install payload remains `{ tag, backend }`.
+
+### Manual Smoke Tests
+
+- Install a Lemonade Windows ROCm target archive, ideally the user's actual GPU target.
+- Confirm `llama/bin` contains:
+  - `llama-server.exe`
+  - `llama-cli.exe`
+  - `hipblaslt/`
+  - `rocblas/`
+- Run `llama-cli.exe --version`.
+- Run `llama-cli.exe --help`.
+- Run `llama-cli.exe --list-devices` if supported.
+- Launch `llama-server` from Llama GUI with `-ngl 99` and a known GGUF model.
+- Verify `/metrics`, `/slots`, and the Chat tab still work.
+
+## Potential Pitfalls
+
+- Flat extraction will break Lemonade packages by destroying nested ROCm runtime directory layout.
+- Official `llama.cpp` and Lemonade release tags are independent; one global release dropdown is misleading unless it refetches by backend/provider.
+- Asset names use GPU target names, so users may choose the wrong target. The UI needs labels/help text.
+- Upstream README badges currently mention `aigdat/llamacpp-rocm` in places, while the requested repo is `lemonade-sdk/llamacpp-rocm`. Use the requested repo API unless intentionally changed.
+- Lemonade builds are nightly/cutting-edge, so flags may drift from the official `llama.cpp` release expected by Llama GUI.
+- SHA256 metadata may be absent from GitHub API asset objects. The existing installer warns and skips verification when absent, but this should be explicitly accepted or improved.
+- Downloads are large. Ubuntu archives can be hundreds of MB, up to around 800 MB in the checked release. Progress and cancellation should remain responsive.
+- Runtime may require environment variables beyond `PATH` and `LD_LIBRARY_PATH`. Preserve paths first, then add env vars based on observed failures.
+- Windows AMD driver/runtime behavior may vary. The package bundles ROCm runtime, but GPU driver compatibility still matters.
+- Status currently validates Windows/Linux installs mostly by executable presence. That may say installed even if the wrong GPU target was selected.
+- Update/repair must preserve provider metadata, or Repair Install may try to fetch a Lemonade backend from official `llama.cpp` releases and fail.
+- Config migration must tolerate old `config.json` files without provider/source.
+- Avoid adding per-tab state for backend/release selection; keep Install tab state routed through existing manager/status APIs.
+
+## Suggested Implementation Order
+
+1. Add provider-aware backend spec schema and Lemonade ROCm specs.
+2. Add backend/provider-aware release fetch helpers with tests.
+3. Add preserve-path extraction helper with traversal tests.
+4. Wire install/update to use backend spec `repo_api` and extraction mode.
+5. Update status payload labels if needed.
+6. Update `manager.js` to refetch releases when backend changes.
+7. Run backend unit tests and frontend smoke tests.
+8. Do a manual install/probe of one Lemonade ROCm archive.
+
+Keep changes focused. Do not add a separate launch path unless testing proves the normal `llama/bin` process launch cannot support the ROCm package.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "llama-gui",
   "private": true,
   "scripts": {
-    "test": "npm run test:syntax && node tests/frontend/custom_launch_args_unit.cjs && node tests/frontend/launch_args_unit.cjs && node tests/frontend/benchmark_args_unit.cjs && node tests/frontend/chat_rendering_unit.cjs && node tests/frontend/sampler_presets_unit.cjs && node tests/frontend/hf_download_ui_unit.cjs && node tests/frontend/api_tab_unit.cjs && npm run test:frontend:modules && npm run test:flags && npm run test:frontend",
+    "test": "npm run test:syntax && node tests/frontend/custom_launch_args_unit.cjs && node tests/frontend/launch_args_unit.cjs && node tests/frontend/benchmark_args_unit.cjs && node tests/frontend/chat_rendering_unit.cjs && node tests/frontend/sampler_presets_unit.cjs && node tests/frontend/hf_download_ui_unit.cjs && node tests/frontend/api_tab_unit.cjs && node tests/frontend/manager_releases_unit.cjs && npm run test:frontend:modules && npm run test:flags && npm run test:frontend",
     "test:syntax": "node tests/frontend/js_syntax_check.cjs",
     "test:frontend:modules": "node tests/frontend/module_namespace_unit.cjs",
     "test:flags": "node tests/frontend/llama_flags_supported_unit.cjs",

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -1500,6 +1500,74 @@ class InstallRouteTests(unittest.TestCase):
             self.ctx, "b2", "cpu", self.ctx.services.backend_specs
         )
 
+    def test_get_releases_uses_backend_repo_api_for_lemonade(self):
+        self.ctx.services.backend_specs["lemonade-rocm-gfx110X"] = {
+            "label": "ROCm 7 gfx110X (Lemonade)",
+            "repo_api": llama_manager.LEMONADE_ROCM_REPO_API,
+        }
+        response = DummyResponse()
+        with mock.patch.object(llama_manager, "get_releases", return_value=[]) as gr:
+            install.get_releases(
+                Request("GET", "/api/releases", "backend=lemonade-rocm-gfx110X", {}),
+                response,
+                self.ctx,
+            )
+        self.assertEqual(response.status, 200)
+        gr.assert_called_once_with(self.ctx, llama_manager.LEMONADE_ROCM_REPO_API)
+
+    def test_get_releases_without_backend_param_uses_default(self):
+        response = DummyResponse()
+        with mock.patch.object(llama_manager, "get_releases", return_value=[]) as gr:
+            install.get_releases(
+                Request("GET", "/api/releases", "", {}),
+                response,
+                self.ctx,
+            )
+        gr.assert_called_once_with(self.ctx, None)
+
+    def test_get_releases_ignores_unknown_backend(self):
+        response = DummyResponse()
+        with mock.patch.object(llama_manager, "get_releases", return_value=[]) as gr:
+            install.get_releases(
+                Request("GET", "/api/releases", "backend=does-not-exist", {}),
+                response,
+                self.ctx,
+            )
+        gr.assert_called_once_with(self.ctx, None)
+
+    def test_update_uses_installed_backend_repo_api_for_lemonade(self):
+        self.ctx.services.backend_specs["lemonade-rocm-gfx110X"] = {
+            "label": "ROCm 7 gfx110X (Lemonade)",
+            "repo_api": llama_manager.LEMONADE_ROCM_REPO_API,
+        }
+        self.ctx.services.load_config = lambda: {
+            "tag": "b1294",
+            "backend": "lemonade-rocm-gfx110X",
+        }
+        fake_releases = [
+            {
+                "tag_name": "b1295",
+                "name": "b1295",
+                "published_at": "2024-03-01T00:00:00Z",
+                "assets": [],
+            }
+        ]
+        response = DummyResponse()
+        immediate_thread = self.run_route_threads_immediately()
+        with (
+            mock.patch.object(install.threading, "Thread", immediate_thread),
+            mock.patch.object(llama_manager, "get_releases", return_value=fake_releases) as gr,
+            mock.patch.object(llama_manager, "install_release", return_value=True),
+        ):
+            install.start_update(
+                Request("POST", "/api/update", "", {}, body={}),
+                response,
+                self.ctx,
+            )
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.payload["status"], "started")
+        gr.assert_called_once_with(self.ctx, llama_manager.LEMONADE_ROCM_REPO_API)
+
 
 class TunnelRouteTests(unittest.TestCase):
     def setUp(self):

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -1,5 +1,6 @@
 import hashlib
 import io
+import json
 import pathlib
 import tarfile
 import tempfile
@@ -159,6 +160,89 @@ class BuildBackendSpecsTests(unittest.TestCase):
         self.assertEqual(len(specs["cuda-13.3"]["extra_assets"]), 1)
         self.assertIn("cuda-13.3", specs["cuda-13.3"]["asset"])
         self.assertIn("cuda-13.3", specs["cuda-13.3"]["extra_assets"][0])
+
+    def test_win32_x64_includes_all_lemonade_rocm_targets(self):
+        specs = llama_manager.build_backend_specs("win32", "x64")
+
+        for gpu in ["gfx103X", "gfx110X", "gfx1150", "gfx1151", "gfx120X", "gfx90a", "gfx908"]:
+            with self.subTest(gpu=gpu):
+                self.assertIn(f"lemonade-rocm-{gpu}", specs)
+
+    def test_linux_x64_includes_all_lemonade_rocm_targets(self):
+        specs = llama_manager.build_backend_specs("linux", "x64")
+
+        for gpu in ["gfx103X", "gfx110X", "gfx1150", "gfx1151", "gfx120X", "gfx90a", "gfx908"]:
+            with self.subTest(gpu=gpu):
+                self.assertIn(f"lemonade-rocm-{gpu}", specs)
+
+    def test_lemonade_rocm_absent_on_unsupported_platforms(self):
+        for platform_name, arch in [
+            ("win32", "arm64"),
+            ("darwin", "arm64"),
+            ("darwin", "x64"),
+            ("linux", "arm64"),
+            ("linux", "s390x"),
+        ]:
+            with self.subTest(platform=platform_name, arch=arch):
+                specs = llama_manager.build_backend_specs(platform_name, arch)
+                self.assertFalse(
+                    any(key.startswith("lemonade-rocm-") for key in specs),
+                    f"unexpected lemonade backend on {platform_name}/{arch}",
+                )
+
+    def test_lemonade_specs_carry_provider_repo_api_preserve_paths_and_gpu_target(self):
+        specs = llama_manager.build_backend_specs("win32", "x64")
+
+        spec = specs["lemonade-rocm-gfx110X"]
+        self.assertEqual(spec["provider"], "lemonade-rocm")
+        self.assertEqual(spec["repo_api"], llama_manager.LEMONADE_ROCM_REPO_API)
+        self.assertIs(spec["preserve_paths"], True)
+        self.assertEqual(spec["gpu_target"], "gfx110X")
+        self.assertIn("{tag}", spec["asset"])
+
+    def test_lemonade_windows_and_linux_asset_patterns_match_upstream(self):
+        win = llama_manager.build_backend_specs("win32", "x64")
+        lin = llama_manager.build_backend_specs("linux", "x64")
+
+        self.assertEqual(
+            win["lemonade-rocm-gfx110X"]["asset"],
+            "llama-{tag}-windows-rocm-gfx110X-x64.zip",
+        )
+        self.assertEqual(
+            lin["lemonade-rocm-gfx110X"]["asset"],
+            "llama-{tag}-ubuntu-rocm-gfx110X-x64.zip",
+        )
+        self.assertEqual(
+            win["lemonade-rocm-gfx110X"]["asset"].format(tag="b1294"),
+            "llama-b1294-windows-rocm-gfx110X-x64.zip",
+        )
+
+    def test_official_specs_do_not_carry_repo_api_or_preserve_paths(self):
+        specs = llama_manager.build_backend_specs("win32", "x64")
+
+        self.assertNotIn("repo_api", specs["cpu"])
+        self.assertNotIn("preserve_paths", specs["cpu"])
+
+
+class ResolveRepoApiTests(unittest.TestCase):
+    def test_returns_spec_repo_api_for_lemonade(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            spec = {"repo_api": llama_manager.LEMONADE_ROCM_REPO_API}
+
+            self.assertEqual(
+                llama_manager.resolve_repo_api(spec, ctx),
+                llama_manager.LEMONADE_ROCM_REPO_API,
+            )
+
+    def test_falls_back_to_config_github_api_for_official(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            spec = {"label": "CPU"}
+
+            self.assertEqual(
+                llama_manager.resolve_repo_api(spec, ctx), ctx.config.github_api
+            )
 
 
 class NormalizeArchTests(unittest.TestCase):
@@ -501,6 +585,212 @@ class LlamaManagerDownloadTests(unittest.TestCase):
             self.assertIn("SHA256 mismatch", ctx.state.download_progress.snapshot()["message"])
             ctx.services.save_config.assert_not_called()
             self.assertFalse(tmpdir.exists())
+
+    def test_get_releases_uses_repo_api_when_provided(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            payload = json.dumps([{"tag_name": "b1294", "assets": []}]).encode()
+            ctx.services.urlopen_with_ssl = mock.Mock(
+                return_value=FakeDownloadResponse([payload], content_length=len(payload))
+            )
+
+            result = llama_manager.get_releases(
+                ctx, llama_manager.LEMONADE_ROCM_REPO_API
+            )
+
+            request = ctx.services.urlopen_with_ssl.call_args.args[0]
+            self.assertEqual(
+                request.full_url, llama_manager.LEMONADE_ROCM_REPO_API
+            )
+            self.assertEqual(result[0]["tag_name"], "b1294")
+
+    def test_get_releases_defaults_to_config_github_api(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            payload = json.dumps([]).encode()
+            ctx.services.urlopen_with_ssl = mock.Mock(
+                return_value=FakeDownloadResponse([payload])
+            )
+
+            llama_manager.get_releases(ctx)
+
+            request = ctx.services.urlopen_with_ssl.call_args.args[0]
+            self.assertEqual(request.full_url, ctx.config.github_api)
+
+    def test_get_release_by_tag_uses_repo_api_tags_endpoint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            payload = json.dumps({"tag_name": "b1294", "assets": []}).encode()
+            ctx.services.urlopen_with_ssl = mock.Mock(
+                return_value=FakeDownloadResponse([payload])
+            )
+
+            llama_manager.get_release_by_tag(
+                ctx, "b1294", llama_manager.LEMONADE_ROCM_REPO_API
+            )
+
+            request = ctx.services.urlopen_with_ssl.call_args.args[0]
+            self.assertEqual(
+                request.full_url,
+                f"{llama_manager.LEMONADE_ROCM_REPO_API}/tags/b1294",
+            )
+
+    def test_extract_archive_preserve_paths_keeps_nested_directories(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            archive = root / "release.zip"
+            dest = root / "bin"
+            dest.mkdir()
+
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("llama-server.exe", "exe")
+                zf.writestr("rocblas/library/tensile.dat", "data")
+                zf.writestr("hipblaslt/kernel.dll", "dll")
+
+            llama_manager.extract_archive_preserve_paths(archive, dest)
+
+            self.assertEqual((dest / "llama-server.exe").read_text(), "exe")
+            self.assertEqual(
+                (dest / "rocblas" / "library" / "tensile.dat").read_text(), "data"
+            )
+            self.assertEqual((dest / "hipblaslt" / "kernel.dll").read_text(), "dll")
+
+    def test_extract_archive_preserve_paths_blocks_traversal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            archive = root / "release.zip"
+            dest = root / "bin"
+            dest.mkdir()
+
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("../escape.exe", "evil")
+                zf.writestr("sub/../../escape2.exe", "evil2")
+                zf.writestr("ok/keep.exe", "ok")
+
+            llama_manager.extract_archive_preserve_paths(archive, dest)
+
+            self.assertEqual((dest / "ok" / "keep.exe").read_text(), "ok")
+            self.assertFalse((root / "escape.exe").exists())
+            self.assertFalse((root / "escape2.exe").exists())
+
+    def test_extract_archive_preserve_paths_blocks_absolute_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            archive = root / "release.zip"
+            dest = root / "bin"
+            dest.mkdir()
+
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("/evil.exe", "evil")
+                zf.writestr("keep.exe", "ok")
+
+            llama_manager.extract_archive_preserve_paths(archive, dest)
+
+            self.assertEqual((dest / "keep.exe").read_text(), "ok")
+            self.assertFalse((root / "evil.exe").exists())
+            self.assertFalse((dest / "evil.exe").exists())
+
+    def test_extract_tar_preserve_paths_keeps_nested_directories(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            archive = root / "release.tar.gz"
+            dest = root / "bin"
+            dest.mkdir()
+
+            with tarfile.open(archive, "w:gz") as tf:
+                payload = b"server"
+                info = tarfile.TarInfo("bin/llama-server")
+                info.size = len(payload)
+                tf.addfile(info, io.BytesIO(payload))
+
+                nested = b"data"
+                nested_info = tarfile.TarInfo("rocblas/library/tensile.dat")
+                nested_info.size = len(nested)
+                tf.addfile(nested_info, io.BytesIO(nested))
+
+            llama_manager.extract_archive_preserve_paths(archive, dest)
+
+            self.assertEqual((dest / "bin" / "llama-server").read_bytes(), b"server")
+            self.assertEqual(
+                (dest / "rocblas" / "library" / "tensile.dat").read_bytes(), b"data"
+            )
+
+    def test_install_release_preserve_paths_keeps_nested_rocm_layout_and_threads_repo_api(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            saved_configs = []
+            ctx.services.save_config = lambda cfg: saved_configs.append(dict(cfg))
+            asset_name = "llama-b1294-windows-rocm-gfx110X-x64.zip"
+            release = {
+                "tag_name": "b1294",
+                "name": "b1294",
+                "assets": [
+                    {
+                        "name": asset_name,
+                        "browser_download_url": "https://example.test/pkg.zip",
+                    }
+                ],
+            }
+            backend_specs = {
+                "lemonade-rocm-gfx110X": {
+                    "label": "ROCm 7 gfx110X (AMD RDNA3, Lemonade)",
+                    "asset": "llama-{tag}-windows-rocm-gfx110X-x64.zip",
+                    "provider": "lemonade-rocm",
+                    "repo_api": llama_manager.LEMONADE_ROCM_REPO_API,
+                    "preserve_paths": True,
+                    "gpu_target": "gfx110X",
+                }
+            }
+            captured = {}
+
+            def fake_get_release_by_tag(_ctx, tag, repo_api=None):
+                captured["repo_api"] = repo_api
+                return release
+
+            def fake_download(_ctx, _url, dest, progress_cb=None):
+                with zipfile.ZipFile(dest, "w") as zf:
+                    zf.writestr("llama-server.exe", "server")
+                    zf.writestr("rocblas/library/tensile.dat", "data")
+                    zf.writestr("hipblaslt/kernel.dll", "dll")
+                if progress_cb:
+                    progress_cb(10, 10)
+                return 10
+
+            def fake_mkdtemp(prefix):
+                path = pathlib.Path(tmp) / f"{prefix}abc"
+                path.mkdir()
+                return str(path)
+
+            stderr = io.StringIO()
+            with mock.patch.object(
+                llama_manager, "get_release_by_tag", side_effect=fake_get_release_by_tag
+            ), mock.patch.object(
+                llama_manager, "download_file", side_effect=fake_download
+            ), mock.patch.object(
+                llama_manager.tempfile, "mkdtemp", side_effect=fake_mkdtemp
+            ), mock.patch("sys.stderr", stderr):
+                ok = llama_manager.install_release(
+                    ctx, "b1294", "lemonade-rocm-gfx110X", backend_specs
+                )
+
+            self.assertTrue(ok)
+            self.assertEqual(captured["repo_api"], llama_manager.LEMONADE_ROCM_REPO_API)
+            self.assertEqual(
+                (ctx.paths.llama_bin / "llama-server.exe").read_text(), "server"
+            )
+            self.assertEqual(
+                (ctx.paths.llama_bin / "rocblas" / "library" / "tensile.dat").read_text(),
+                "data",
+            )
+            self.assertEqual(
+                (ctx.paths.llama_bin / "hipblaslt" / "kernel.dll").read_text(), "dll"
+            )
+            self.assertEqual(
+                saved_configs,
+                [{"version": "b1294", "backend": "lemonade-rocm-gfx110X", "tag": "b1294"}],
+            )
+            self.assertEqual(ctx.state.download_progress.snapshot()["status"], "done")
+            self.assertIn("No SHA256 metadata", stderr.getvalue())
 
 
 class FilePickerServiceTests(unittest.TestCase):

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -655,6 +655,24 @@ class LlamaManagerDownloadTests(unittest.TestCase):
             )
             self.assertEqual((dest / "hipblaslt" / "kernel.dll").read_text(), "dll")
 
+    def test_extract_archive_preserve_paths_restores_zip_file_mode(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            archive = root / "release.zip"
+            dest = root / "bin"
+            dest.mkdir()
+            info = zipfile.ZipInfo("llama-server")
+            info.external_attr = 0o755 << 16
+
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr(info, "exe")
+
+            with mock.patch.object(llama_manager.os, "chmod") as chmod:
+                llama_manager.extract_archive_preserve_paths(archive, dest)
+
+            chmod.assert_called_once_with(dest / "llama-server", 0o755)
+            self.assertEqual((dest / "llama-server").read_text(), "exe")
+
     def test_extract_archive_preserve_paths_blocks_traversal(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = pathlib.Path(tmp)

--- a/tests/frontend/manager_releases_unit.cjs
+++ b/tests/frontend/manager_releases_unit.cjs
@@ -1,0 +1,95 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const source = fs.readFileSync(path.join(ROOT, "ui", "js", "manager.js"), "utf8");
+
+function makeElement() {
+    const el = {
+        children: [],
+        value: "",
+        textContent: "",
+        className: "",
+        innerHTML: "",
+        style: {},
+        disabled: false,
+        appendChild(child) {
+            this.children.push(child);
+            return child;
+        },
+        addEventListener() {},
+        removeEventListener() {},
+        querySelectorAll() {
+            return [];
+        },
+    };
+    Object.defineProperty(el, "options", {
+        get() {
+            return this.children;
+        },
+        configurable: true,
+    });
+    return el;
+}
+
+const elements = new Map();
+["release-select", "backend-select"].forEach((id) => elements.set(id, makeElement()));
+
+const fetchCalls = [];
+const fetchPayload = [{ tag: "b1294", published: "2024-01-01T00:00:00Z", assets: [] }];
+
+const context = {
+    window: { addEventListener() {}, LlamaGui: {} },
+    document: {
+        createElement: () => makeElement(),
+        getElementById: (id) => elements.get(id) || null,
+    },
+    console,
+    fetch: async (url) => {
+        fetchCalls.push(url);
+        return { ok: true, json: async () => fetchPayload };
+    },
+};
+context.window.window = context.window;
+vm.createContext(context);
+vm.runInContext(source, context, { filename: "ui/js/manager.js" });
+
+(async () => {
+    const backendSelect = elements.get("backend-select");
+    backendSelect.value = "lemonade-rocm-gfx110X";
+
+    assert.equal(
+        context.selectedBackendId(),
+        "lemonade-rocm-gfx110X",
+        "selectedBackendId should read backend-select value"
+    );
+
+    await context.fetchReleases("lemonade-rocm-gfx110X");
+    assert.equal(
+        fetchCalls[fetchCalls.length - 1],
+        "/api/releases?backend=lemonade-rocm-gfx110X",
+        "fetchReleases(backend) should hit backend-aware releases URL"
+    );
+
+    await context.fetchReleases();
+    assert.equal(
+        fetchCalls[fetchCalls.length - 1],
+        "/api/releases",
+        "fetchReleases() without backend should hit default releases URL"
+    );
+
+    backendSelect.value = "cpu";
+    await context.onBackendChange();
+    assert.equal(
+        fetchCalls[fetchCalls.length - 1],
+        "/api/releases?backend=cpu",
+        "onBackendChange should refetch releases for the selected backend"
+    );
+
+    console.log("manager releases unit tests passed");
+})().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/tests/frontend/manager_releases_unit.cjs
+++ b/tests/frontend/manager_releases_unit.cjs
@@ -7,12 +7,12 @@ const ROOT = path.resolve(__dirname, "..", "..");
 const source = fs.readFileSync(path.join(ROOT, "ui", "js", "manager.js"), "utf8");
 
 function makeElement() {
+    let html = "";
     const el = {
         children: [],
         value: "",
         textContent: "",
         className: "",
-        innerHTML: "",
         style: {},
         disabled: false,
         appendChild(child) {
@@ -28,6 +28,17 @@ function makeElement() {
     Object.defineProperty(el, "options", {
         get() {
             return this.children;
+        },
+        configurable: true,
+    });
+    Object.defineProperty(el, "innerHTML", {
+        get() {
+            return html;
+        },
+        set(value) {
+            html = String(value || "");
+            this.children = [];
+            this.value = "";
         },
         configurable: true,
     });
@@ -86,6 +97,34 @@ vm.runInContext(source, context, { filename: "ui/js/manager.js" });
         fetchCalls[fetchCalls.length - 1],
         "/api/releases?backend=cpu",
         "onBackendChange should refetch releases for the selected backend"
+    );
+
+    const pending = new Map();
+    context.fetch = async (url) => {
+        fetchCalls.push(url);
+        return new Promise((resolve) => {
+            pending.set(url, (payload) => resolve({ ok: true, json: async () => payload }));
+        });
+    };
+
+    const first = context.fetchReleases("cpu");
+    const second = context.fetchReleases("lemonade-rocm-gfx110X");
+    pending.get("/api/releases?backend=lemonade-rocm-gfx110X")([
+        { tag: "b1294", published: "2024-01-01T00:00:00Z", assets: [] },
+    ]);
+    await second;
+    const releaseSelect = elements.get("release-select");
+    assert.equal(releaseSelect.options.length, 1);
+    assert.equal(releaseSelect.options[0].value, "b1294");
+
+    pending.get("/api/releases?backend=cpu")([
+        { tag: "b9999", published: "2024-01-02T00:00:00Z", assets: [] },
+    ]);
+    await first;
+    assert.equal(
+        releaseSelect.options[0].value,
+        "b1294",
+        "stale release responses should not overwrite the latest backend releases"
     );
 
     console.log("manager releases unit tests passed");

--- a/ui/index.html
+++ b/ui/index.html
@@ -139,6 +139,7 @@
                     <select id="backend-select">
                         <option value="">Loading available backends...</option>
                     </select>
+                    <div style="font-size:12px;color:var(--fg-muted);margin-top:var(--space-1);line-height:1.45;">ROCm (Lemonade) builds target a specific AMD GPU architecture &mdash; choose the gfx target matching your GPU (e.g. gfx110X = RDNA3, gfx103X = RDNA2, gfx1150/gfx1151 = Ryzen AI).</div>
                 </div>
 
                 <div class="form-row">

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -515,7 +515,8 @@ function initInstallButtons() {
     document.getElementById("btn-remove-llama").addEventListener("click", removeLlamaFiles);
     document.getElementById("btn-stop-app").addEventListener("click", stopPythonServer);
     document.getElementById("btn-restart-app").addEventListener("click", restartPythonServer);
-    document.getElementById("refresh-releases").addEventListener("click", fetchReleases);
+    document.getElementById("refresh-releases").addEventListener("click", () => fetchReleases(selectedBackendId()));
+    document.getElementById("backend-select").addEventListener("change", onBackendChange);
     document.getElementById("btn-open-models").addEventListener("click", () => openFolder("models"));
     document.getElementById("btn-open-llama").addEventListener("click", () => openFolder("llama"));
     document.getElementById("btn-check-app-update").addEventListener("click", checkAppUpdateStatus);

--- a/ui/js/manager.js
+++ b/ui/js/manager.js
@@ -1,4 +1,5 @@
 let cachedReleases = null;
+let releasesBackend = null;
 let installPollTimer = null;
 let installPollStartTime = null;
 let installPollFailCount = 0;
@@ -61,12 +62,26 @@ async function fetchJson(url, options) {
     return data;
 }
 
-async function fetchReleases() {
+function selectedBackendId() {
+    const sel = document.getElementById("backend-select");
+    return sel ? String(sel.value || "") : "";
+}
+
+function onBackendChange() {
+    fetchReleases(selectedBackendId());
+}
+
+async function fetchReleases(backend) {
     const sel = document.getElementById("release-select");
     if (!sel) return;
+    const backendParam = typeof backend === "string" ? backend.trim() : "";
+    const url = backendParam
+        ? `/api/releases?backend=${encodeURIComponent(backendParam)}`
+        : "/api/releases";
     sel.innerHTML = '<option value="">Loading...</option>';
     try {
-        cachedReleases = await fetchJson("/api/releases");
+        cachedReleases = await fetchJson(url);
+        releasesBackend = backendParam;
         sel.innerHTML = "";
         for (const r of cachedReleases) {
             const opt = document.createElement("option");
@@ -121,6 +136,13 @@ function updateStatusUI(status) {
         const hasBackendOption = Array.from(backendSelect.options).some((opt) => opt.value === status.backend);
         if (hasBackendOption) {
             backendSelect.value = status.backend;
+        }
+    }
+
+    if (backendSelect) {
+        const targetBackend = backendSelect.value || "";
+        if (targetBackend !== releasesBackend) {
+            fetchReleases(targetBackend);
         }
     }
 

--- a/ui/js/manager.js
+++ b/ui/js/manager.js
@@ -1,5 +1,7 @@
 let cachedReleases = null;
 let releasesBackend = null;
+let releasesBackendInFlight = null;
+let releaseFetchRequestId = 0;
 let installPollTimer = null;
 let installPollStartTime = null;
 let installPollFailCount = 0;
@@ -78,10 +80,15 @@ async function fetchReleases(backend) {
     const url = backendParam
         ? `/api/releases?backend=${encodeURIComponent(backendParam)}`
         : "/api/releases";
+    const requestId = ++releaseFetchRequestId;
+    releasesBackendInFlight = backendParam;
     sel.innerHTML = '<option value="">Loading...</option>';
     try {
-        cachedReleases = await fetchJson(url);
+        const releases = await fetchJson(url);
+        if (requestId !== releaseFetchRequestId) return;
+        cachedReleases = releases;
         releasesBackend = backendParam;
+        releasesBackendInFlight = null;
         sel.innerHTML = "";
         for (const r of cachedReleases) {
             const opt = document.createElement("option");
@@ -101,6 +108,8 @@ async function fetchReleases(backend) {
             sel.value = cachedReleases[0].tag;
         }
     } catch (e) {
+        if (requestId !== releaseFetchRequestId) return;
+        releasesBackendInFlight = null;
         sel.innerHTML = '<option value="">Failed to load</option>';
         showStatus("error", "Failed to fetch releases: " + e.message);
     }
@@ -141,7 +150,7 @@ function updateStatusUI(status) {
 
     if (backendSelect) {
         const targetBackend = backendSelect.value || "";
-        if (targetBackend !== releasesBackend) {
+        if (targetBackend !== releasesBackend && targetBackend !== releasesBackendInFlight) {
             fetchReleases(targetBackend);
         }
     }


### PR DESCRIPTION
Adds lemonade-sdk/llamacpp-rocm as an optional installable backend alongside the official llama.cpp releases.

Backend (llama_manager.py, routes/install.py):
- build_backend_specs() emits lemonade-rocm-{gfx103X,gfx110X,gfx1150,gfx1151,gfx120X,gfx90a,gfx908} for win32-x64 and linux-x64, each with provider/repo_api/preserve_paths/gpu_target.
- resolve_repo_api() derives the release API from the backend spec (Lemonade -> own API; official -> ctx.config.github_api), so no provider field is persisted in config.json.
- get_releases()/get_release_by_tag() accept an optional repo_api.
- extract_archive_preserve_paths() keeps the nested hipblaslt/rocblas layout while rejecting absolute and .. traversal entries (zip + tar.gz).
- install_release() resolves the spec repo_api and selects extraction mode by preserve_paths.
- start_update() resolves the installed backend's repo_api before fetching latest.
- Releases route honors ?backend= query param.

Frontend (manager.js, app.js, index.html):
- fetchReleases(backend) builds /api/releases?backend=; backend-select change listener and updateStatusUI refetch the release list when the active backend changes.
- Added GPU-target hint near the backend dropdown.

Tests: backend spec/resolve/extract/install/route coverage in test_services.py and test_extracted_routes.py; new manager_releases_unit.cjs vm test wired into npm test.