### PR TITLE
Add custom backend support with separate install target UI

### DIFF
--- a/tests/frontend/manager_releases_unit.cjs
+++ b/tests/frontend/manager_releases_unit.cjs
@@ -8,6 +8,7 @@ const source = fs.readFileSync(path.join(ROOT, "ui", "js", "manager.js"), "utf8"
 
 function makeElement() {
     let html = "";
+    const classNames = new Set();
     const el = {
         children: [],
         value: "",
@@ -15,6 +16,29 @@ function makeElement() {
         className: "",
         style: {},
         disabled: false,
+        classList: {
+            add(...names) {
+                names.forEach((name) => classNames.add(name));
+                el.className = Array.from(classNames).join(" ");
+            },
+            remove(...names) {
+                names.forEach((name) => classNames.delete(name));
+                el.className = Array.from(classNames).join(" ");
+            },
+            toggle(name, force) {
+                const shouldAdd = force === undefined ? !classNames.has(name) : Boolean(force);
+                if (shouldAdd) {
+                    classNames.add(name);
+                } else {
+                    classNames.delete(name);
+                }
+                el.className = Array.from(classNames).join(" ");
+                return shouldAdd;
+            },
+            contains(name) {
+                return classNames.has(name);
+            },
+        },
         appendChild(child) {
             this.children.push(child);
             return child;
@@ -46,7 +70,20 @@ function makeElement() {
 }
 
 const elements = new Map();
-["release-select", "backend-select"].forEach((id) => elements.set(id, makeElement()));
+[
+    "release-select",
+    "backend-select",
+    "installed-backend-summary",
+    "version-badge",
+    "sidebar-status",
+    "sidebar-status-text",
+    "installed-info",
+    "btn-repair",
+    "btn-install",
+    "btn-update",
+    "release-group",
+    "custom-backend-info",
+].forEach((id) => elements.set(id, makeElement()));
 
 const fetchCalls = [];
 const fetchPayload = [{ tag: "b1294", published: "2024-01-01T00:00:00Z", assets: [] }];
@@ -55,6 +92,7 @@ const context = {
     window: { addEventListener() {}, LlamaGui: {} },
     document: {
         createElement: () => makeElement(),
+        createTextNode: (text) => ({ textContent: String(text || "") }),
         getElementById: (id) => elements.get(id) || null,
     },
     console,
@@ -103,6 +141,89 @@ vm.runInContext(source, context, { filename: "ui/js/manager.js" });
         "/api/releases?backend=cpu",
         "onBackendChange should refetch releases for the selected backend"
     );
+
+    const availableBackends = [
+        { id: "cpu", label: "CPU" },
+        { id: "vulkan", label: "Vulkan" },
+        { id: "custom", label: "Custom (User-Provided)" },
+    ];
+    const cpuStatus = {
+        installed: true,
+        config_stale: false,
+        version: "smoke",
+        backend: "cpu",
+        tag: "smoke",
+        running: false,
+        available_backends: availableBackends,
+        executables: {
+            "llama-cli": true,
+            "llama-server": true,
+        },
+    };
+    context.updateStatusUI(cpuStatus);
+    assert.equal(elements.get("btn-update").disabled, false);
+
+    backendSelect.value = "custom";
+    context.onBackendChange();
+    context.updateStatusUI(cpuStatus);
+    assert.equal(backendSelect.value, "custom");
+    assert.equal(elements.get("btn-update").disabled, true);
+    assert.equal(elements.get("btn-repair").disabled, true);
+    assert.equal(
+        elements.get("btn-repair").classList.contains("hidden"),
+        false,
+        "repair button should be visible but disabled when custom is selected as install target"
+    );
+
+    backendSelect.value = "cpu";
+    context.onBackendChange();
+    context.updateStatusUI(cpuStatus);
+    assert.equal(elements.get("btn-update").disabled, false);
+    assert.equal(elements.get("btn-repair").classList.contains("hidden"), true);
+
+    const customStatus = {
+        installed: true,
+        config_stale: false,
+        version: "custom",
+        backend: "custom",
+        tag: "custom",
+        running: false,
+        available_backends: availableBackends,
+        executables: {
+            "llama-cli": true,
+            "llama-server": true,
+        },
+    };
+    context.updateStatusUI(customStatus);
+    assert.equal(backendSelect.value, "custom");
+    assert.match(
+        elements.get("installed-backend-summary").textContent,
+        /Installed backend: Custom/,
+        "installed backend summary should render as read-only status"
+    );
+
+    backendSelect.value = "vulkan";
+    context.onBackendChange();
+    context.updateStatusUI(customStatus);
+    assert.equal(
+        backendSelect.value,
+        "vulkan",
+        "pending install backend should survive status refresh while installed backend is still custom"
+    );
+    assert.equal(elements.get("btn-install").textContent, "Install");
+    assert.equal(
+        elements.get("btn-update").disabled,
+        true,
+        "custom installed backend should not become auto-updatable because a default backend is selected as install target"
+    );
+
+    context.updateStatusUI({ ...customStatus, version: "smoke", backend: "vulkan", tag: "smoke" });
+    assert.equal(
+        backendSelect.value,
+        "vulkan",
+        "install target should remain on the newly installed backend once status catches up"
+    );
+    assert.equal(elements.get("btn-update").disabled, false);
 
     const pending = new Map();
     context.fetch = async (url, options) => {

--- a/ui/css/style.css
+++ b/ui/css/style.css
@@ -1337,6 +1337,24 @@ textarea { width: 100%; min-height: 60px; resize: vertical; }
 .status-box.info { display: block; background: var(--accent-subtle); border: 1px solid var(--accent-border); color: var(--accent); }
 .status-box.warning { display: block; background: var(--yellow-subtle); border: 1px solid var(--yellow-border); color: var(--yellow); }
 
+.installed-backend-summary {
+    display: flex;
+    align-items: center;
+    min-height: 34px;
+    margin-bottom: var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    background: var(--bg-raised);
+    color: var(--fg);
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.installed-backend-summary.is-empty { color: var(--fg-muted); }
+.installed-backend-summary.is-stale { color: var(--yellow); border-color: var(--yellow-border); background: var(--yellow-subtle); }
+.installed-backend-summary.is-installed { color: var(--green); border-color: var(--green-border); background: var(--green-subtle); }
+
 .app-update-note { margin-top: var(--space-2); font-size: 12px; color: var(--fg-muted); }
 
 /* ════════════════════════════════════════════

--- a/ui/index.html
+++ b/ui/index.html
@@ -138,12 +138,16 @@
             <div class="page-header">
                 <div>
                     <div class="page-title">Install llama.cpp</div>
-                    <div class="page-title-sub">Download releases, select a backend, and manage your llama.cpp installation.</div>
+                    <div class="page-title-sub">Download releases, choose an install target, and manage your llama.cpp installation.</div>
                 </div>
             </div>
 
             <div class="card">
                 <div id="install-status" class="status-box"></div>
+
+                <div id="installed-backend-summary" class="installed-backend-summary" aria-live="polite">
+                    Installed backend: checking...
+                </div>
 
                 <div class="form-group" id="release-group">
                     <label class="form-label">Version</label>
@@ -156,7 +160,7 @@
                 </div>
 
                 <div class="form-group">
-                    <label class="form-label">Backend</label>
+                    <label class="form-label">Backend to install</label>
                     <select id="backend-select">
                         <option value="">Loading available backends...</option>
                     </select>

--- a/ui/js/manager.js
+++ b/ui/js/manager.js
@@ -8,18 +8,42 @@ let installPollFailCount = 0;
 let installPollInFlight = false;
 let latestStatus = null;
 let latestAppUpdateStatus = null;
+let pendingInstallBackendId = null;
 
 const INSTALL_POLL_TIMEOUT_MS = 10 * 60 * 1000;
 const INSTALL_POLL_MAX_FAILS = 5;
+
+function normalizeBackendId(value) {
+    return String(value || "").trim();
+}
+
+function backendOptionsFromStatus(status) {
+    return Array.isArray(status && status.available_backends)
+        ? status.available_backends
+        : [];
+}
+
+function hasBackendOption(options, backendId) {
+    return options.some((backend) => backend && backend.id === backendId);
+}
+
+function backendLabelFromStatus(status, backendId) {
+    const id = normalizeBackendId(backendId);
+    const match = backendOptionsFromStatus(status).find((backend) => backend && backend.id === id);
+    return match && match.label ? match.label : (id || "None");
+}
+
+function installedBackendIdFromStatus(status) {
+    return normalizeBackendId(status && status.backend);
+}
 
 function renderBackendOptions(status) {
     const backendSelect = document.getElementById("backend-select");
     if (!backendSelect) return;
 
-    const availableBackends = Array.isArray(status && status.available_backends)
-        ? status.available_backends
-        : [];
-    const currentValue = status && status.backend ? status.backend : backendSelect.value;
+    const availableBackends = backendOptionsFromStatus(status);
+    const previousValue = normalizeBackendId(backendSelect.value);
+    const installedValue = installedBackendIdFromStatus(status);
 
     backendSelect.innerHTML = "";
 
@@ -40,8 +64,72 @@ function renderBackendOptions(status) {
         backendSelect.appendChild(opt);
     }
 
-    const hasCurrentValue = Array.from(backendSelect.options).some((opt) => opt.value === currentValue);
-    backendSelect.value = hasCurrentValue ? currentValue : availableBackends[0].id;
+    const pendingIsValid = pendingInstallBackendId && hasBackendOption(availableBackends, pendingInstallBackendId);
+    const installedIsValid = installedValue && hasBackendOption(availableBackends, installedValue);
+    const previousIsValid = previousValue && hasBackendOption(availableBackends, previousValue);
+
+    if (pendingInstallBackendId && !pendingIsValid) {
+        pendingInstallBackendId = null;
+    }
+
+    backendSelect.value = pendingIsValid
+        ? pendingInstallBackendId
+        : installedIsValid
+            ? installedValue
+            : previousIsValid
+                ? previousValue
+                : availableBackends[0].id;
+}
+
+function updateInstalledBackendSummary(status) {
+    const el = document.getElementById("installed-backend-summary");
+    if (!el) return;
+
+    const installedBackend = installedBackendIdFromStatus(status);
+    const label = backendLabelFromStatus(status, installedBackend);
+    el.className = "installed-backend-summary";
+
+    if (status && status.installed && installedBackend) {
+        el.textContent = "Installed backend: " + label;
+        el.classList.add("is-installed");
+    } else if (status && status.config_stale && installedBackend) {
+        el.textContent = "Configured backend: " + label + " (incomplete)";
+        el.classList.add("is-stale");
+    } else {
+        el.textContent = "Installed backend: None";
+        el.classList.add("is-empty");
+    }
+}
+
+function syncInstallActionButtons(status, selectedInstallBackend) {
+    const updateBtn = document.getElementById("btn-update");
+    const repairBtn = document.getElementById("btn-repair");
+    const installTarget = normalizeBackendId(selectedInstallBackend);
+    const installedBackend = installedBackendIdFromStatus(status);
+    const hasInstalledBackend = Boolean(status && status.installed && installedBackend);
+    const hasStaleBackendConfig = Boolean(status && status.config_stale && installedBackend);
+    const customTargetSelected = installTarget === "custom";
+
+    if (updateBtn) {
+        const canUpdate = !customTargetSelected && hasInstalledBackend && installedBackend !== "custom";
+        updateBtn.disabled = !canUpdate;
+        updateBtn.title = canUpdate
+            ? "Check the installed backend for updates"
+            : customTargetSelected || installedBackend === "custom"
+                ? "Custom backend installations are managed manually"
+                : "Install llama.cpp before checking for updates";
+    }
+
+    if (repairBtn) {
+        const canRepair = !customTargetSelected && hasStaleBackendConfig && installedBackend !== "custom";
+        repairBtn.classList.toggle("hidden", !canRepair && !customTargetSelected);
+        repairBtn.disabled = !canRepair;
+        repairBtn.title = customTargetSelected
+            ? "Custom backend files are managed manually"
+            : canRepair
+                ? "Reinstall the configured backend files"
+                : "Repair is available only for incomplete default backend installs";
+    }
 }
 
 async function fetchJson(url, options) {
@@ -113,11 +201,15 @@ function showOfficialBackendControls() {
 
 function onBackendChange() {
     const backend = selectedBackendId();
+    const installedBackend = installedBackendIdFromStatus(latestStatus);
+    pendingInstallBackendId = backend && backend !== installedBackend ? backend : null;
     if (backend === "custom") {
         showCustomBackendControls();
+        syncInstallActionButtons(latestStatus, backend);
         return;
     }
     showOfficialBackendControls();
+    syncInstallActionButtons(latestStatus, backend);
     fetchReleases(backend);
 }
 
@@ -226,20 +318,23 @@ function updateStatusUI(status) {
     const sidebarStatus = document.getElementById("sidebar-status");
     const sidebarStatusText = document.getElementById("sidebar-status-text");
     const info = document.getElementById("installed-info");
-    const repairBtn = document.getElementById("btn-repair");
     const backendSelect = document.getElementById("backend-select");
     const releaseSelect = document.getElementById("release-select");
     const installBtn = document.getElementById("btn-install");
 
+    const installedBackend = installedBackendIdFromStatus(status);
+    if (
+        pendingInstallBackendId
+        && installedBackend
+        && pendingInstallBackendId === installedBackend
+        && (status.installed || status.config_stale)
+    ) {
+        pendingInstallBackendId = null;
+    }
+
+    updateInstalledBackendSummary(status);
     renderBackendOptions(status);
     installBtn.disabled = !status.available_backends || status.available_backends.length === 0;
-
-    if ((status.installed || status.config_stale) && status.backend && backendSelect) {
-        const hasBackendOption = Array.from(backendSelect.options).some((opt) => opt.value === status.backend);
-        if (hasBackendOption) {
-            backendSelect.value = status.backend;
-        }
-    }
 
     const activeBackend = backendSelect ? backendSelect.value || "" : "";
     if (activeBackend === "custom") {
@@ -247,6 +342,7 @@ function updateStatusUI(status) {
     } else {
         showOfficialBackendControls();
     }
+    syncInstallActionButtons(status, activeBackend);
 
     if (backendSelect) {
         const targetBackend = activeBackend;
@@ -278,10 +374,6 @@ function updateStatusUI(status) {
         if (sidebarStatusText) sidebarStatusText.textContent = (status.active_process_tool || "llama.cpp") + " running";
     } else {
         if (sidebarStatus) sidebarStatus.style.display = "none";
-    }
-
-    if (activeBackend !== "custom") {
-        repairBtn.classList.toggle("hidden", !status.config_stale);
     }
 
     info.textContent = "";


### PR DESCRIPTION
Adds support for custom backend installations by introducing:

- New 'installed-backend-summary' display showing currently installed backend status separate from install target selector
- Helper functions to manage backend option validation, normalization, and label mapping
- Pending install backend tracking to preserve user's install target selection across status updates
- syncInstallActionButtons() to disable Update/Repair buttons when custom backend is selected or installed
- Refactored renderBackendOptions() to prioritize pending selection, then installed backend, then previous selection
- Updated UI labels from 'Backend' to 'Backend to install' and subtitle text for clarity
- Added comprehensive unit tests covering custom backend workflows, button state management, and install target persistence

This separates the concept of 'currently installed backend' from 'backend to install next', preventing custom-installed backends from being auto-updated by default options and providing clearer UX.