### PR TITLE
Track process exit codes and cache runtime health

### DIFF
--- a/backend/routes/presets.py
+++ b/backend/routes/presets.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+import sys
 import urllib.parse
 
 
@@ -94,8 +95,11 @@ def list_presets(request, response, ctx):
                 if is_preset_bundle(data):
                     continue
                 presets.append({"name": path.stem, "data": data})
-            except (json.JSONDecodeError, OSError):
-                pass
+            except (json.JSONDecodeError, OSError) as exc:
+                print(
+                    f"[presets] skipping unreadable preset {path.name}: {type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                )
     response.json(presets)
 
 

--- a/backend/routes/status.py
+++ b/backend/routes/status.py
@@ -43,6 +43,7 @@ def get_status(request, response, ctx):
                 "models_dir": str(ctx.paths.models),
                 "running": running,
                 "active_process_tool": ctx.state.active_process_tool,
+                "last_exit_code": ctx.state.last_exit_code,
                 "api_target": api_target,
                 "platform": services.current_platform,
                 "platform_label": services.get_platform_label(),

--- a/backend/services/llama_manager.py
+++ b/backend/services/llama_manager.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import time
 import urllib.request
 import zipfile
 from typing import Any, Callable, Iterable, Mapping, Optional
@@ -18,6 +19,11 @@ from ..context import AppContext
 
 
 RPATH_LIBRARY_RE = re.compile(r"^\s*@rpath/([^\s(]+)")
+
+# Runtime dependency validation shells out to otool on macOS, so results are
+# cached briefly. Config-changing operations (install, cleanup, backend
+# activation) clear the cache to keep /api/status fresh.
+RUNTIME_HEALTH_CACHE_TTL_SECONDS = 5.0
 
 # Optional llamacpp-rocm backend (https://github.com/lemonade-sdk/llamacpp-rocm).
 # Publishes nightly ROCm 7 llama.cpp archives for Windows and Ubuntu, one asset
@@ -264,12 +270,38 @@ def validate_runtime_dependencies(
             "missing_runtime_files": [],
         }
 
+    tool_names = tuple(tools) if tools is not None else ()
+    if not tool_names:
+        tool_names = ("llama-cli", "llama-server")
+
+    try:
+        cfg = dict(ctx.services.load_config())
+    except Exception as e:
+        print(f"[llama_manager] load_config failed during runtime validation: {e}", file=sys.stderr)
+        cfg = {}
+
+    cache_key = (cfg.get("backend"), tool_names)
+    now = time.monotonic()
+    with ctx.state.runtime_health_lock:
+        cached = ctx.state.runtime_health_cache.get(cache_key)
+        if cached is not None and now - cached[0] < RUNTIME_HEALTH_CACHE_TTL_SECONDS:
+            return dict(cached[1])
+
+    result = _validate_runtime_dependencies_uncached(ctx, tool_names, cfg)
+    with ctx.state.runtime_health_lock:
+        ctx.state.runtime_health_cache[cache_key] = (time.monotonic(), result)
+    return dict(result)
+
+
+def _validate_runtime_dependencies_uncached(
+    ctx: AppContext, tool_names: tuple[str, ...], cfg: Mapping[str, Any]
+) -> dict[str, Any]:
     required: set[str] = set()
     checked_tools: list[str] = []
     unchecked_tools: list[str] = []
     missing_executables: list[str] = []
 
-    for tool in tools or ("llama-cli", "llama-server"):
+    for tool in tool_names:
         exe_path = ctx.services.find_tool_executable(tool)
         if not exe_path.exists():
             missing_executables.append(ctx.services.get_tool_filename(tool))
@@ -285,11 +317,6 @@ def validate_runtime_dependencies(
         ):
             unchecked_tools.append(tool)
 
-    try:
-        cfg = dict(ctx.services.load_config())
-    except Exception as e:
-        print(f"[llama_manager] load_config failed during runtime validation: {e}", file=sys.stderr)
-        cfg = {}
     runtime_dir = (
         ctx.paths.llama_custom_bin
         if cfg.get("backend") == "custom"
@@ -360,6 +387,7 @@ def activate_custom_backend(ctx: AppContext) -> dict[str, Any]:
         cfg["backend"] = "custom"
         cfg["tag"] = "custom"
         ctx.services.save_config(cfg)
+        ctx.state.clear_runtime_health_cache()
         return {
             "ok": True,
             "found": found,
@@ -699,6 +727,7 @@ def install_release(
         ctx.services.save_config(
             {"version": release.get("name", tag), "backend": backend, "tag": tag}
         )
+        ctx.state.clear_runtime_health_cache()
         set_download_progress(
             ctx, status="done", message=f"Installed {tag} ({backend})"
         )

--- a/backend/services/process_manager.py
+++ b/backend/services/process_manager.py
@@ -167,9 +167,22 @@ _ESTIMATE_BOOL_FLAGS = {
 }
 
 
+def _reap_finished_process(ctx: AppContext) -> None:
+    """Clear state left behind by a process that exited on its own.
+
+    Caller must hold ctx.state.process_lock.
+    """
+    process = ctx.state.process
+    if process is not None and process.poll() is not None:
+        ctx.state.last_exit_code = process.poll()
+        ctx.state.process = None
+        ctx.state.active_process_tool = None
+
+
 def is_process_running(ctx: AppContext) -> bool:
     with ctx.state.process_lock:
-        return ctx.state.process is not None and ctx.state.process.poll() is None
+        _reap_finished_process(ctx)
+        return ctx.state.process is not None
 
 
 def get_output_snapshot(ctx: AppContext, since: Optional[int] = None) -> dict[str, Any]:
@@ -553,7 +566,8 @@ def _build_process_env(ctx: AppContext) -> dict[str, str]:
 
 def launch_process(ctx: AppContext, tool: str, args_list: Optional[Iterable[Any]]) -> dict[str, Any]:
     with ctx.state.process_lock:
-        if ctx.state.process and ctx.state.process.poll() is None:
+        _reap_finished_process(ctx)
+        if ctx.state.process is not None:
             return {"error": "A process is already running"}
 
         exe_name = ctx.services.get_tool_filename(tool)
@@ -614,6 +628,7 @@ def launch_process(ctx: AppContext, tool: str, args_list: Optional[Iterable[Any]
                 daemon=True,
             ).start()
             ctx.state.active_process_tool = tool
+            ctx.state.last_exit_code = None
             if tool == "llama-server":
                 parse_launch_api_target(ctx, args_list)
             return {
@@ -627,27 +642,37 @@ def launch_process(ctx: AppContext, tool: str, args_list: Optional[Iterable[Any]
 
 def stop_process(ctx: AppContext) -> bool:
     with ctx.state.process_lock:
-        if ctx.state.process and ctx.state.process.poll() is None:
+        process = ctx.state.process
+        if process is not None and process.poll() is None:
             if sys.platform == "win32":
-                ctx.state.process.send_signal(signal.CTRL_BREAK_EVENT)
+                process.send_signal(signal.CTRL_BREAK_EVENT)
             else:
-                ctx.state.process.terminate()
+                process.terminate()
             try:
-                ctx.state.process.wait(timeout=5)
+                process.wait(timeout=5)
             except subprocess.TimeoutExpired:
-                ctx.state.process.kill()
+                process.kill()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
+            ctx.state.last_exit_code = process.poll()
+            ctx.state.process = None
             ctx.state.active_process_tool = None
             return True
+        _reap_finished_process(ctx)
         return False
 
 
 def send_input(ctx: AppContext, text: str) -> bool:
     with ctx.state.process_lock:
-        if ctx.state.process and ctx.state.process.poll() is None:
+        _reap_finished_process(ctx)
+        process = ctx.state.process
+        if process is not None:
             try:
-                if ctx.state.process.stdin:
-                    ctx.state.process.stdin.write(text + "\n")
-                    ctx.state.process.stdin.flush()
+                if process.stdin:
+                    process.stdin.write(text + "\n")
+                    process.stdin.flush()
                     return True
             except Exception as exc:
                 print(f"[process] failed to send input: {exc}", file=sys.stderr)
@@ -674,5 +699,6 @@ def remove_llama_files(ctx: AppContext) -> int:
         shutil.rmtree(llama_dll_dir)
 
     ctx.services.save_config({"version": None, "backend": None, "tag": None})
+    ctx.state.clear_runtime_health_cache()
 
     return removed_files

--- a/backend/state.py
+++ b/backend/state.py
@@ -75,6 +75,10 @@ class ServerState:
     output_generation: int = 0
     output_reader_count: int = 0
     active_process_tool: Optional[str] = None
+    last_exit_code: Optional[int] = None
+
+    runtime_health_cache: dict[Any, tuple[float, dict[str, Any]]] = field(default_factory=dict)
+    runtime_health_lock: threading.Lock = field(default_factory=threading.Lock)
 
     download_progress: AtomicDict = field(
         default_factory=lambda: AtomicDict(default_download_progress())
@@ -100,3 +104,7 @@ class ServerState:
         default_factory=lambda: AtomicDict(default_llama_api_target())
     )
     llama_api_target_lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def clear_runtime_health_cache(self) -> None:
+        with self.runtime_health_lock:
+            self.runtime_health_cache.clear()

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -1,3 +1,4 @@
+import contextlib
 import io
 import json
 import tempfile
@@ -172,6 +173,22 @@ class ExtractedRouteTests(unittest.TestCase):
             )
             presets.delete_preset(delete_request, delete_response, ctx)
             self.assertEqual(delete_response.payload, {"deleted": True})
+
+    def test_list_presets_skips_malformed_file_with_stderr_warning(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            ctx.paths.presets.mkdir(parents=True)
+            (ctx.paths.presets / "Good.json").write_text(json.dumps({"temperature": 0.7}))
+            (ctx.paths.presets / "Broken.json").write_text("{not valid json")
+            response = DummyResponse()
+            stderr = io.StringIO()
+
+            with contextlib.redirect_stderr(stderr):
+                presets.list_presets(Request("GET", "/api/presets", "", {}), response, ctx)
+
+            self.assertEqual(response.payload, [{"name": "Good", "data": {"temperature": 0.7}}])
+            self.assertIn("Broken.json", stderr.getvalue())
+            self.assertIn("JSONDecodeError", stderr.getvalue())
             self.assertFalse((ctx.paths.presets / "My_Preset.json").exists())
 
     def test_preset_delete_uses_same_sanitizer_as_save(self):
@@ -361,6 +378,7 @@ class ExtractedRouteTests(unittest.TestCase):
                 llama_tools=["llama-cli", "llama-server"],
                 load_config=lambda: {"tag": "b1", "backend": "cpu"},
             )
+            ctx.state.last_exit_code = 7
             response = DummyResponse()
 
             status.get_status(Request("GET", "/api/status", "", {}), response, ctx)
@@ -368,6 +386,8 @@ class ExtractedRouteTests(unittest.TestCase):
             self.assertTrue(response.payload["installed"])
             self.assertEqual(response.payload["models_dir"], str(ctx.paths.models))
             self.assertEqual(response.payload["available_backends"], [{"id": "cpu", "label": "CPU"}])
+            self.assertIsNone(response.payload["active_process_tool"])
+            self.assertEqual(response.payload["last_exit_code"], 7)
 
     def test_status_route_marks_install_stale_when_runtime_library_missing(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -14,6 +14,7 @@ from backend.services import chat as chat_service
 from backend.services import file_picker as file_picker_service
 from backend.services import hf_download as hf_service
 from backend.services import llama_manager
+from backend.services import process_manager
 from backend.services import web_search as web_search_service
 
 
@@ -550,6 +551,168 @@ class RuntimeDependencyValidationTests(unittest.TestCase):
         self.assertTrue(result["ok"])
         self.assertFalse(result["checked"])
         self.assertEqual(result["unchecked_tools"], ["llama-server"])
+
+    def test_validate_macos_runtime_dependencies_caches_repeat_calls(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = self.make_runtime_context(tmp)
+            (ctx.paths.llama_bin / "llama-server").write_text("binary")
+            (ctx.paths.llama_bin / "libllama-common.0.dylib").write_text("lib")
+
+            with mock.patch.object(
+                llama_manager,
+                "get_macos_rpath_libraries",
+                return_value=["libllama-common.0.dylib"],
+            ) as probe:
+                first = llama_manager.validate_runtime_dependencies(ctx, ["llama-server"])
+                second = llama_manager.validate_runtime_dependencies(ctx, ["llama-server"])
+
+        self.assertEqual(probe.call_count, 1)
+        self.assertEqual(first, second)
+
+    def test_validate_macos_runtime_cache_expires_after_ttl(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = self.make_runtime_context(tmp)
+            (ctx.paths.llama_bin / "llama-server").write_text("binary")
+
+            with mock.patch.object(
+                llama_manager, "RUNTIME_HEALTH_CACHE_TTL_SECONDS", 0.0
+            ), mock.patch.object(
+                llama_manager,
+                "get_macos_rpath_libraries",
+                return_value=[],
+            ) as probe:
+                llama_manager.validate_runtime_dependencies(ctx, ["llama-server"])
+                llama_manager.validate_runtime_dependencies(ctx, ["llama-server"])
+
+        self.assertEqual(probe.call_count, 2)
+
+    def test_validate_macos_runtime_cache_cleared_by_invalidation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = self.make_runtime_context(tmp)
+            (ctx.paths.llama_bin / "llama-server").write_text("binary")
+
+            with mock.patch.object(
+                llama_manager,
+                "get_macos_rpath_libraries",
+                return_value=[],
+            ) as probe:
+                llama_manager.validate_runtime_dependencies(ctx, ["llama-server"])
+                ctx.state.clear_runtime_health_cache()
+                llama_manager.validate_runtime_dependencies(ctx, ["llama-server"])
+
+        self.assertEqual(probe.call_count, 2)
+
+    def test_validate_macos_runtime_cache_keyed_by_backend(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = self.make_runtime_context(tmp)
+            (ctx.paths.llama_bin / "llama-server").write_text("binary")
+
+            with mock.patch.object(
+                llama_manager,
+                "get_macos_rpath_libraries",
+                return_value=[],
+            ) as probe:
+                llama_manager.validate_runtime_dependencies(ctx, ["llama-server"])
+                ctx.services.load_config = lambda: {"backend": "custom"}
+                llama_manager.validate_runtime_dependencies(ctx, ["llama-server"])
+
+        self.assertEqual(probe.call_count, 2)
+
+    def test_remove_llama_files_clears_runtime_health_cache(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = self.make_runtime_context(tmp)
+            ctx.services.save_config = lambda cfg: None
+            ctx.state.runtime_health_cache[("cpu", ("llama-server",))] = (0.0, {"ok": True})
+
+            process_manager.remove_llama_files(ctx)
+
+        self.assertEqual(ctx.state.runtime_health_cache, {})
+
+
+class FakeLaunchedProcess:
+    def __init__(self, returncode=None):
+        self.returncode = returncode
+        self.signals = []
+        self.killed = False
+        self.stdin = None
+
+    def poll(self):
+        return self.returncode
+
+    def send_signal(self, sig):
+        self.signals.append(sig)
+        if self.returncode is None:
+            self.returncode = 0
+
+    def terminate(self):
+        self.send_signal("terminate")
+
+    def wait(self, timeout=None):
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+
+class ProcessStateReapTests(unittest.TestCase):
+    def make_exited_context(self, exit_code):
+        ctx = AppContext()
+        ctx.state.process = FakeLaunchedProcess(returncode=exit_code)
+        ctx.state.active_process_tool = "llama-server"
+        return ctx
+
+    def test_is_process_running_reaps_naturally_exited_process(self):
+        ctx = self.make_exited_context(3)
+
+        self.assertFalse(process_manager.is_process_running(ctx))
+
+        self.assertIsNone(ctx.state.process)
+        self.assertIsNone(ctx.state.active_process_tool)
+        self.assertEqual(ctx.state.last_exit_code, 3)
+
+    def test_stop_process_reaps_naturally_exited_process(self):
+        ctx = self.make_exited_context(1)
+
+        self.assertFalse(process_manager.stop_process(ctx))
+
+        self.assertIsNone(ctx.state.process)
+        self.assertIsNone(ctx.state.active_process_tool)
+        self.assertEqual(ctx.state.last_exit_code, 1)
+
+    def test_stop_process_clears_state_for_running_process(self):
+        ctx = AppContext()
+        process = FakeLaunchedProcess(returncode=None)
+        ctx.state.process = process
+        ctx.state.active_process_tool = "llama-server"
+
+        self.assertTrue(process_manager.stop_process(ctx))
+
+        self.assertEqual(len(process.signals), 1)
+        self.assertIsNone(ctx.state.process)
+        self.assertIsNone(ctx.state.active_process_tool)
+        self.assertEqual(ctx.state.last_exit_code, 0)
+
+    def test_send_input_reaps_naturally_exited_process(self):
+        ctx = self.make_exited_context(0)
+
+        self.assertFalse(process_manager.send_input(ctx, "hello"))
+
+        self.assertIsNone(ctx.state.process)
+        self.assertIsNone(ctx.state.active_process_tool)
+        self.assertEqual(ctx.state.last_exit_code, 0)
+
+    def test_is_process_running_true_for_live_process(self):
+        ctx = AppContext()
+        ctx.state.process = FakeLaunchedProcess(returncode=None)
+        ctx.state.active_process_tool = "llama-cli"
+
+        self.assertTrue(process_manager.is_process_running(ctx))
+
+        self.assertIsNotNone(ctx.state.process)
+        self.assertEqual(ctx.state.active_process_tool, "llama-cli")
 
 
 class LlamaManagerDownloadTests(unittest.TestCase):


### PR DESCRIPTION
Add process exit code tracking via `last_exit_code` state and expose it in status API. Implement runtime dependency validation caching (5s TTL) to reduce expensive macOS otool lookups. Improve process state cleanup by automatically reaping naturally-exited processes. Add stderr logging for preset loading failures instead of silently skipping them.