### PR TITLE
Address PR #201 review findings

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -609,7 +609,9 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         raw_length = self.headers.get("Content-Length")
         if raw_length is None:
             return 0
-        if not raw_length.isdecimal():
+        # ASCII-only so the length-based comparison below stays lexicographically
+        # correct (isdecimal alone also accepts non-ASCII Unicode digits).
+        if not (raw_length.isascii() and raw_length.isdecimal()):
             self.send_error_json("Invalid Content-Length header", 400)
             return _BODY_HANDLED
         normalized_length = raw_length.lstrip("0") or "0"

--- a/backend/services/llama_manager.py
+++ b/backend/services/llama_manager.py
@@ -1,5 +1,6 @@
 """llama.cpp release management, download, and install helpers."""
 
+import copy
 import hashlib
 import json
 import os
@@ -285,12 +286,12 @@ def validate_runtime_dependencies(
     with ctx.state.runtime_health_lock:
         cached = ctx.state.runtime_health_cache.get(cache_key)
         if cached is not None and now - cached[0] < RUNTIME_HEALTH_CACHE_TTL_SECONDS:
-            return dict(cached[1])
+            return copy.deepcopy(cached[1])
 
     result = _validate_runtime_dependencies_uncached(ctx, tool_names, cfg)
     with ctx.state.runtime_health_lock:
         ctx.state.runtime_health_cache[cache_key] = (time.monotonic(), result)
-    return dict(result)
+    return copy.deepcopy(result)
 
 
 def _validate_runtime_dependencies_uncached(

--- a/backend/services/process_manager.py
+++ b/backend/services/process_manager.py
@@ -198,12 +198,17 @@ def get_output_snapshot(ctx: AppContext, since: Optional[int] = None) -> dict[st
             offset = cursor - start_cursor
         lines = list(ctx.state.output_buffer[offset:])
         readers_active = ctx.state.output_reader_count > 0
-    return {
+    snapshot = {
         "lines": lines,
         "next_cursor": next_cursor,
         "dropped": dropped,
         "running": is_process_running(ctx) or readers_active,
     }
+    if since is None:
+        # Deprecated alias for consumers that poll without a cursor and still
+        # read the pre-cursor "output" key.
+        snapshot["output"] = lines
+    return snapshot
 
 
 def stream_output(
@@ -596,6 +601,7 @@ def launch_process(ctx: AppContext, tool: str, args_list: Optional[Iterable[Any]
         args = [str(exe_path), *flatten_launch_args(args_list)]
         env = _build_process_env(ctx)
 
+        process = None
         try:
             process = subprocess.Popen(
                 args,
@@ -637,6 +643,19 @@ def launch_process(ctx: AppContext, tool: str, args_list: Optional[Iterable[Any]
                 "output_cursor": output_cursor,
             }
         except Exception as e:
+            if process is not None:
+                # Popen succeeded but wiring up state failed; don't leave an
+                # untracked process running.
+                try:
+                    process.kill()
+                    process.wait(timeout=5)
+                except Exception as cleanup_exc:
+                    print(
+                        f"[process] failed to clean up partially launched process: {cleanup_exc}",
+                        file=sys.stderr,
+                    )
+                ctx.state.process = None
+                ctx.state.active_process_tool = None
             return {"error": str(e)}
 
 
@@ -656,6 +675,14 @@ def stop_process(ctx: AppContext) -> bool:
                     process.wait(timeout=5)
                 except subprocess.TimeoutExpired:
                     pass
+            if process.poll() is None:
+                # Keep tracking the process so a new launch can't run
+                # alongside one that refused to die.
+                print(
+                    f"[process] PID {process.pid} survived kill; still tracking it",
+                    file=sys.stderr,
+                )
+                return False
             ctx.state.last_exit_code = process.poll()
             ctx.state.process = None
             ctx.state.active_process_tool = None

--- a/backend/services/web_search.py
+++ b/backend/services/web_search.py
@@ -132,7 +132,7 @@ class ManualRedirectHandler(urllib.request.HTTPRedirectHandler):
 NoRedirect = ManualRedirectHandler
 
 
-def _connect_validated(addresses: list[Any], timeout: int, source_address: Any = None) -> Any:
+def _connect_validated(addresses: list[Any], timeout: float, source_address: Any = None) -> Any:
     last_error = None
     for family, socktype, proto, _, sockaddr in addresses:
         sock = socket.socket(family, socktype, proto)
@@ -151,7 +151,7 @@ def _connect_validated(addresses: list[Any], timeout: int, source_address: Any =
 
 
 class _PinnedHTTPConnection(http.client.HTTPConnection):
-    def __init__(self, host: str, port: int, addresses: list[Any], timeout: int) -> None:
+    def __init__(self, host: str, port: int, addresses: list[Any], timeout: float) -> None:
         self._validated_addresses = addresses
         super().__init__(host, port=port, timeout=timeout)
 
@@ -169,7 +169,7 @@ class _PinnedHTTPSConnection(http.client.HTTPSConnection):
         host: str,
         port: int,
         addresses: list[Any],
-        timeout: int,
+        timeout: float,
         ssl_context: Optional[Any],
     ) -> None:
         self._validated_addresses = addresses
@@ -187,9 +187,11 @@ class _PinnedHTTPSConnection(http.client.HTTPSConnection):
 def _open_validated_url(
     parsed: urllib.parse.ParseResult,
     addresses: list[Any],
-    timeout: int,
+    timeout: float,
     ssl_context: Optional[Any],
 ) -> tuple[int, str, Any, bytes]:
+    # Connects directly to the pre-validated addresses (no system proxy
+    # support): routing through a proxy would bypass the SSRF IP pinning.
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
     connection_class = _PinnedHTTPSConnection if parsed.scheme == "https" else _PinnedHTTPConnection
     if parsed.scheme == "https":

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -173,6 +173,7 @@ class ExtractedRouteTests(unittest.TestCase):
             )
             presets.delete_preset(delete_request, delete_response, ctx)
             self.assertEqual(delete_response.payload, {"deleted": True})
+            self.assertFalse((ctx.paths.presets / "My_Preset.json").exists())
 
     def test_list_presets_skips_malformed_file_with_stderr_warning(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -189,7 +190,6 @@ class ExtractedRouteTests(unittest.TestCase):
             self.assertEqual(response.payload, [{"name": "Good", "data": {"temperature": 0.7}}])
             self.assertIn("Broken.json", stderr.getvalue())
             self.assertIn("JSONDecodeError", stderr.getvalue())
-            self.assertFalse((ctx.paths.presets / "My_Preset.json").exists())
 
     def test_preset_delete_uses_same_sanitizer_as_save(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -502,7 +502,13 @@ class ExtractedRouteTests(unittest.TestCase):
 
             self.assertEqual(
                 response.payload,
-                {"lines": ["one", "two"], "next_cursor": 2, "dropped": False, "running": False},
+                {
+                    "lines": ["one", "two"],
+                    "next_cursor": 2,
+                    "dropped": False,
+                    "running": False,
+                    "output": ["one", "two"],
+                },
             )
 
     def test_process_output_cursor_recovers_after_buffer_trim(self):

--- a/tests/backend/test_server_baseline.py
+++ b/tests/backend/test_server_baseline.py
@@ -212,6 +212,7 @@ class HandlerResponseTests(ServerStateIsolationMixin, unittest.TestCase):
         cases = [
             ("not-a-number", 400),
             ("-1", 400),
+            ("١٢٣", 400),  # non-ASCII Unicode digits pass isdecimal()
             ("9" * 5000, 413),
             (str(backend_app.MAX_REQUEST_BODY_SIZE + 1), 413),
         ]

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -1,7 +1,9 @@
+import contextlib
 import hashlib
 import io
 import json
 import pathlib
+import subprocess
 import tarfile
 import tempfile
 import unittest
@@ -694,6 +696,34 @@ class ProcessStateReapTests(unittest.TestCase):
         self.assertIsNone(ctx.state.process)
         self.assertIsNone(ctx.state.active_process_tool)
         self.assertEqual(ctx.state.last_exit_code, 0)
+
+    def test_stop_process_keeps_state_when_process_survives_kill(self):
+        class UnkillableProcess(FakeLaunchedProcess):
+            pid = 4242
+
+            def send_signal(self, sig):
+                self.signals.append(sig)
+
+            def terminate(self):
+                self.send_signal("terminate")
+
+            def wait(self, timeout=None):
+                raise subprocess.TimeoutExpired(cmd="llama-server", timeout=timeout)
+
+        ctx = AppContext()
+        process = UnkillableProcess(returncode=None)
+        process.kill = lambda: None
+        ctx.state.process = process
+        ctx.state.active_process_tool = "llama-server"
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr):
+            stopped = process_manager.stop_process(ctx)
+
+        self.assertFalse(stopped)
+        self.assertIs(ctx.state.process, process)
+        self.assertEqual(ctx.state.active_process_tool, "llama-server")
+        self.assertIn("survived kill", stderr.getvalue())
 
     def test_send_input_reaps_naturally_exited_process(self):
         ctx = self.make_exited_context(0)


### PR DESCRIPTION
- Restore the preset round-trip test's deletion assertion that was accidentally absorbed by the new malformed-preset test
- /api/output: keep a deprecated output alias on cursor-less requests so external consumers of the pre-cursor contract keep working (the response key was renamed to lines in the cursor protocol)
- Deep-copy runtime health cache entries so callers cannot mutate nested lists inside cached results
- stop_process: keep tracking a process that survives kill() instead of clearing state and allowing a concurrent second launch
- launch_process: kill and untrack a partially launched process if state wiring fails after Popen succeeds
- Content-Length: require ASCII digits so the lexicographic size check stays correct for Unicode decimal digits
- web_search: fix timeout annotations (int -> float) and document that bypassing system proxies is intentional for SSRF IP pinning