### PR TITLE
Optimize install lock timing and tighten .env validation

### DIFF
--- a/backend/routes/install.py
+++ b/backend/routes/install.py
@@ -92,39 +92,46 @@ def start_update(request, response, ctx):
     if process_manager.is_process_running(ctx):
         response.error("Stop running process first", 400)
         return
-    with ctx.state.install_lock:
-        if ctx.state.install_in_progress:
-            response.error("Installation already in progress", 409)
-            return
-        ctx.state.install_in_progress = True
+    # Cheap early reject so a duplicate request fails fast instead of spending
+    # a GitHub round trip (and rate-limit quota) only to be refused below.
+    # This read is advisory; the authoritative check-and-set is under the lock.
+    if ctx.state.install_in_progress:
+        response.error("Installation already in progress", 409)
+        return
+
+    # The release lookup runs before the install slot is claimed: holding
+    # install_in_progress across a slow network call would make unrelated
+    # requests fail with a 409 for the whole duration of the lookup.
     try:
         backend_spec = ctx.services.backend_specs[backend]
         repo_api = llama_manager.resolve_repo_api(backend_spec, ctx)
         releases = llama_manager.get_releases(ctx, repo_api)
         latest = releases[0]["tag_name"] if releases else None
-        if latest and latest != tag:
+    except Exception as e:
+        response.error(sanitize_error(e, 500), 500)
+        return
 
-            def _update(latest_tag, backend_name):
-                try:
-                    llama_manager.install_release(
-                        ctx, latest_tag, backend_name, ctx.services.backend_specs
-                    )
-                finally:
-                    with ctx.state.install_lock:
-                        ctx.state.install_in_progress = False
+    if not latest or latest == tag:
+        response.json({"status": "already_latest"})
+        return
 
-            threading.Thread(
-                target=_update, args=(latest, backend), daemon=True
-            ).start()
-            response.json({"status": "started", "from": tag, "to": latest})
-        else:
+    with ctx.state.install_lock:
+        if ctx.state.install_in_progress:
+            response.error("Installation already in progress", 409)
+            return
+        ctx.state.install_in_progress = True
+
+    def _update(latest_tag, backend_name):
+        try:
+            llama_manager.install_release(
+                ctx, latest_tag, backend_name, ctx.services.backend_specs
+            )
+        finally:
             with ctx.state.install_lock:
                 ctx.state.install_in_progress = False
-            response.json({"status": "already_latest"})
-    except Exception as e:
-        with ctx.state.install_lock:
-            ctx.state.install_in_progress = False
-        response.error(sanitize_error(e, 500), 500)
+
+    threading.Thread(target=_update, args=(latest, backend), daemon=True).start()
+    response.json({"status": "started", "from": tag, "to": latest})
 
 
 def activate_custom(request, response, ctx):

--- a/backend/services/git_update.py
+++ b/backend/services/git_update.py
@@ -27,10 +27,17 @@ SAFE_DIRTY_PATH_PREFIXES = (
 
 SAFE_DIRTY_PATHS = {
     "config.json",
+    ".env",
     ".DS_Store",
     "Thumbs.db",
     "desktop.ini",
 }
+
+# Filename prefixes (as opposed to the directory prefixes above), for families
+# of local files like ".env.local". Keep these specific enough that they cannot
+# swallow unrelated neighbours: ".env." must not be loosened to ".env", which
+# would also match ".envrc".
+SAFE_DIRTY_FILE_PREFIXES = (".env.",)
 
 SAFE_DIRTY_SUFFIXES = (
     ".pyc",
@@ -83,7 +90,7 @@ def is_safe_dirty_path(path):
         return False
     if path in SAFE_DIRTY_PATHS:
         return True
-    if path.startswith(".env"):
+    if any(path.startswith(prefix) for prefix in SAFE_DIRTY_FILE_PREFIXES):
         return True
     if any(path.startswith(prefix) for prefix in SAFE_DIRTY_PATH_PREFIXES):
         return True

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -2868,6 +2868,59 @@ class InstallRouteTests(unittest.TestCase):
             self.ctx, "b2", "cpu", self.ctx.services.backend_specs
         )
 
+    def test_update_blocks_when_already_in_progress_without_calling_github(self):
+        with self.ctx.state.install_lock:
+            self.ctx.state.install_in_progress = True
+        response = DummyResponse()
+        with mock.patch.object(llama_manager, "get_releases") as gr:
+            install.start_update(
+                Request("POST", "/api/update", "", {}, body={}),
+                response,
+                self.ctx,
+            )
+        self.assertEqual(response.status, 409)
+        self.assertIn("Installation already in progress", response.payload["error"])
+        # The early reject must happen before the release lookup so a duplicate
+        # request costs no GitHub rate-limit quota.
+        gr.assert_not_called()
+
+    def test_update_reports_release_lookup_failure_without_claiming_slot(self):
+        response = DummyResponse()
+        immediate_thread = self.run_route_threads_immediately()
+        with (
+            mock.patch.object(install.threading, "Thread", immediate_thread),
+            mock.patch.object(
+                llama_manager, "get_releases", side_effect=RuntimeError("network down")
+            ),
+        ):
+            install.start_update(
+                Request("POST", "/api/update", "", {}, body={}),
+                response,
+                self.ctx,
+            )
+        self.assertEqual(response.status, 500)
+        self.assertFalse(self.ctx.state.install_in_progress)
+        self.assertEqual(immediate_thread.instances, [])
+
+    def test_update_leaves_slot_free_when_already_latest(self):
+        fake_releases = [
+            {
+                "tag_name": "b1",
+                "name": "b1 release",
+                "published_at": "2024-01-01T00:00:00Z",
+                "assets": [],
+            }
+        ]
+        response = DummyResponse()
+        with mock.patch.object(llama_manager, "get_releases", return_value=fake_releases):
+            install.start_update(
+                Request("POST", "/api/update", "", {}, body={}),
+                response,
+                self.ctx,
+            )
+        self.assertEqual(response.payload["status"], "already_latest")
+        self.assertFalse(self.ctx.state.install_in_progress)
+
     def test_get_releases_uses_backend_repo_api_for_lemonade(self):
         self.ctx.services.backend_specs["lemonade-rocm-gfx110X"] = {
             "label": "ROCm 7 gfx110X (Lemonade)",
@@ -3221,6 +3274,9 @@ class GitUpdateRouteTests(unittest.TestCase):
             "ui/js/app.js",
             "README.md",
             ".github/workflows/ci.yml",
+            # Must NOT match the loose ".env" prefix: only ".env" / ".env.*" are safe.
+            ".envrc",
+            ".environment_notes.md",
         ]
         for path in blocking:
             self.assertFalse(srv.is_safe_dirty_path(path), f"Expected blocking: {path}")


### PR DESCRIPTION
Move install lock acquisition to after GitHub API lookup so duplicate requests fail fast without blocking the network or consuming rate-limit quota. Early advisory check allows cheap rejection before expensive operations.

Also improve .env dirty-path validation by explicitly defining safe prefixes (.env, .env.*) instead of loose prefix matching that could incorrectly allow .envrc or .environment_notes.md.

Add three new tests verifying: early rejection without GitHub call, release lookup errors don't claim slot, and already-latest status leaves slot free.