### PR TITLE
Add DeepSeek v4 template and preset

### DIFF
--- a/docs/directory.md
+++ b/docs/directory.md
@@ -32,7 +32,7 @@
 | `backend/` | Python package: HTTP server, routes, services, state |
 | `ui/` | Static frontend: `index.html`, `js/`, `css/`, `templates/` |
 | `ui/js/flags/` | Ordered pure-data modules for flag definitions |
-| `ui/templates/` | 14 bundled Jinja chat template files |
+| `ui/templates/` | 15 bundled Jinja chat template files |
 | `tests/` | Frontend (Node/Playwright) + backend (unittest) tests |
 | `docs/` | Documentation: todo, flag audit, architecture, bugtracker |
 | `llama/` | Downloaded `llama.cpp` binaries at runtime |
@@ -318,6 +318,7 @@ Files under `ui/templates/`:
 - `alpaca.jinja`
 - `chatml-nonthinking.jinja`
 - `deepseek-v31-nonthinking.jinja`
+- `deepseek-v4.jinja`
 - `gemma4.jinja`
 - `gemma4-e2b-e4b.jinja`
 - `gemma4-e2b-e4b-nothink.jinja`
@@ -330,7 +331,9 @@ Files under `ui/templates/`:
 - `seed-oss-nonthinking.jinja`
 - `openai-harmony-nonthinking.jinja`
 
-These use a small generic Jinja message loop with preset-specific start/end tokens. Used for non-thinking variants, renamed presets that don't map cleanly to a single built-in, and special tag formats not represented by built-ins.
+Most use a small generic Jinja message loop with preset-specific start/end tokens. Used for non-thinking variants, renamed presets that don't map cleanly to a single built-in, and special tag formats not represented by built-ins.
+
+`deepseek-v4.jinja` is the exception: it is a verbatim copy of upstream `models/templates/deepseek-ai-DeepSeek-V4.jinja` (llama.cpp PR `ggml-org/llama.cpp#24162`, build `b9840`). There is no `deepseek4` built-in template name; `llama.cpp` detects V4 from the template body and routes it through its DeepSeek V3.2/V4 parser. Thinking is off unless `enable_thinking` is set at runtime. Re-sync this file from upstream rather than hand-editing it.
 
 ### Built-In Mappings
 

--- a/ui/js/flags/chat-templates.js
+++ b/ui/js/flags/chat-templates.js
@@ -70,6 +70,9 @@ const CHAT_TEMPLATE_PRESETS = [
     { value: "command-r", label: "CommandR", mode: "builtin", builtin: "command-r" },
     { value: "deepseek3", label: "Deepseek v2.5 & v3", mode: "builtin", builtin: "deepseek3" },
     { value: "__deepseek_v31_nonthinking__", label: "Deepseek v3.1 Non-Thinking", mode: "bundled", path: "ui/templates/deepseek-v31-nonthinking.jinja" },
+    // No `deepseek4` built-in exists; llama.cpp routes V4 through its DeepSeek V3.2/V4
+    // parser based on template content, so this is bundled rather than builtin.
+    { value: "__deepseek_v4__", label: "Deepseek v4", mode: "bundled", path: "ui/templates/deepseek-v4.jinja" },
     { value: "gemma", label: "Gemma 2 & 3", mode: "builtin", builtin: "gemma" },
     { value: "__gemma4_e2b_e4b__", label: "Gemma 4 E2B & E4B", mode: "bundled", path: "ui/templates/gemma4-e2b-e4b.jinja" },
     { value: "__gemma4_e2b_e4b_nothink__", label: "Gemma 4 E2B & E4B NoThink", mode: "bundled", path: "ui/templates/gemma4-e2b-e4b-nothink.jinja" },

--- a/ui/templates/deepseek-v4.jinja
+++ b/ui/templates/deepseek-v4.jinja
@@ -1,0 +1,121 @@
+{%- if not add_generation_prompt is defined -%}
+  {%- set add_generation_prompt = false -%}
+{%- endif -%}
+{%- if not thinking is defined -%}
+  {%- if enable_thinking is defined -%}
+    {%- set thinking = enable_thinking -%}
+  {%- else -%}
+    {%- set thinking = false -%}
+  {%- endif -%}
+{%- endif -%}
+{%- if not drop_thinking is defined -%}
+  {%- set drop_thinking = false -%}
+{%- endif -%}
+{%- set dsml_token = '｜DSML｜' -%}
+{%- set thinking_start_token = '<think>' -%}
+{%- set thinking_end_token = '</think>' -%}
+{%- set tools_header = '## Tools\n\nYou have access to a set of tools to help answer the user\'s question. You can invoke tools by writing a "<' + dsml_token + 'tool_calls>" block like the following:\n\n<' + dsml_token + 'tool_calls>\n<' + dsml_token + 'invoke name="$TOOL_NAME">\n<' + dsml_token + 'parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</' + dsml_token + 'parameter>\n...\n</' + dsml_token + 'invoke>\n<' + dsml_token + 'invoke name="$TOOL_NAME2">\n...\n</' + dsml_token + 'invoke>\n</' + dsml_token + 'tool_calls>\n\nString parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.\n\nIf thinking_mode is enabled (triggered by ' + thinking_start_token + '), you MUST output your complete reasoning inside ' + thinking_start_token + '...' + thinking_end_token + ' BEFORE any tool calls or final response.\n\nOtherwise, output directly after ' + thinking_end_token + ' with tool calls or final response.\n\n### Available Tool Schemas\n\n' -%}
+{%- set tools_footer = '\nYou MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.\n' -%}
+{%- set ns = namespace(system_prompt='', is_first_sp=true, has_tool_calls=false) -%}
+{%- for message in messages -%}
+  {%- if message['role'] == 'system' -%}
+    {%- if ns.is_first_sp -%}
+      {%- set ns.system_prompt = ns.system_prompt + (message['content'] or '') -%}
+      {%- set ns.is_first_sp = false -%}
+    {%- else -%}
+      {%- set ns.system_prompt = ns.system_prompt + '\n\n' + (message['content'] or '') -%}
+    {%- endif -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- if tools is defined and tools -%}
+  {%- set ts = namespace(schemas='') -%}
+  {%- for tool in tools -%}
+    {%- if tool['type'] == 'function' -%}
+      {%- set ts.schemas = ts.schemas + (tool['function'] | tojson) + '\n' -%}
+    {%- endif -%}
+  {%- endfor -%}
+  {%- if ns.system_prompt -%}
+    {%- set ns.system_prompt = ns.system_prompt + '\n\n' + tools_header + ts.schemas + tools_footer -%}
+  {%- else -%}
+    {%- set ns.system_prompt = tools_header + ts.schemas + tools_footer -%}
+  {%- endif -%}
+{%- endif -%}
+{{- bos_token -}}
+{{- ns.system_prompt -}}
+{%- set last_user_idx = namespace(value=-1) -%}
+{%- for message in messages -%}
+  {%- if message['role'] == 'user' or message['role'] == 'developer' or message['role'] == 'tool' -%}
+    {%- set last_user_idx.value = loop.index0 -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- set state = namespace(in_user=false) -%}
+{%- for message in messages -%}
+  {%- if message['role'] == 'tool' -%}
+    {%- set ns.has_tool_calls = true -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- for message in messages -%}
+  {%- if message['role'] == 'user' or message['role'] == 'developer' -%}
+    {%- if state.in_user -%}
+      {{- '\n\n' -}}
+    {%- else -%}
+      {{- '<｜User｜>' -}}
+      {%- set state.in_user = true -%}
+    {%- endif -%}
+    {{- message['content'] or '' -}}
+  {%- elif message['role'] == 'tool' -%}
+    {%- if state.in_user -%}
+      {{- '\n\n' -}}
+    {%- else -%}
+      {{- '<｜User｜>' -}}
+      {%- set state.in_user = true -%}
+    {%- endif -%}
+    {{- '<tool_result>' + (message['content'] or '') + '</tool_result>' -}}
+  {%- elif message['role'] == 'assistant' -%}
+    {%- set state.in_user = false -%}
+    {{- '<｜Assistant｜>' -}}
+    {%- set is_after_last_user = loop.index0 > last_user_idx.value -%}
+    {%- set retain_reasoning = (not drop_thinking) or (is_after_last_user or ns.has_tool_calls) -%}
+    {%- if retain_reasoning and thinking -%}
+      {{- thinking_start_token -}}
+      {%- if message['reasoning_content'] is defined and message['reasoning_content'] -%}
+        {{- message['reasoning_content'] -}}
+      {%- endif -%}
+      {{- thinking_end_token -}}
+    {%- else -%}
+      {{- thinking_end_token -}}
+    {%- endif -%}
+    {%- if message['content'] is defined and message['content'] -%}
+      {{- message['content'] -}}
+    {%- endif -%}
+    {%- if message['tool_calls'] -%}
+      {{- '\n\n<' + dsml_token + 'tool_calls>\n' -}}
+      {%- for tool in message['tool_calls'] -%}
+        {%- set func = tool['function'] -%}
+        {{- '<' + dsml_token + 'invoke name="' + func['name'] + '">\n' -}}
+        {%- set args = func['arguments'] -%}
+        {%- if args is string -%}
+          {%- set args = args | from_json -%}
+        {%- endif -%}
+        {%- for key, val in args.items() -%}
+          {%- if val is string -%}
+            {{- '<' + dsml_token + 'parameter name="' + key + '" string="true">' + val + '</' + dsml_token + 'parameter>\n' -}}
+          {%- else -%}
+            {{- '<' + dsml_token + 'parameter name="' + key + '" string="false">' + (val | tojson) + '</' + dsml_token + 'parameter>\n' -}}
+          {%- endif -%}
+        {%- endfor -%}
+        {{- '</' + dsml_token + 'invoke>\n' -}}
+      {%- endfor -%}
+      {{- '</' + dsml_token + 'tool_calls>' -}}
+    {%- endif -%}
+    {{- '<｜end▁of▁sentence｜>' -}}
+  {%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+  {{- '<｜Assistant｜>' -}}
+  {%- if thinking -%}
+    {{- thinking_start_token -}}
+  {%- else -%}
+    {{- thinking_end_token -}}
+  {%- endif -%}
+{%- endif -%}


### PR DESCRIPTION
Add ui/templates/deepseek-v4.jinja (verbatim upstream DeepSeek V4 template), register it as a bundled chat template in ui/js/flags/chat-templates.js, and update docs/directory.md to reflect 15 bundled templates and note that DeepSeek v4 is a special-case file that should be re-synced from upstream (no builtin `deepseek4`, V4 is detected from the template body; thinking must be enabled at runtime).