### PR TITLE
Auto-load a matching mmproj so vision models just work

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -17,6 +17,7 @@ LLAMA_CUSTOM_DIR = LLAMA_DIR / "custom"
 LLAMA_CUSTOM_BIN_DIR = LLAMA_CUSTOM_DIR / "bin"
 LLAMA_CUSTOM_GRAMMARS_DIR = LLAMA_CUSTOM_DIR / "grammars"
 MODELS_DIR = ROOT_DIR / "models"
+MMPROJ_DIR = MODELS_DIR / "mmproj"
 PRESETS_DIR = ROOT_DIR / "presets"
 CONFIG_FILE = ROOT_DIR / "config.json"
 UI_DIR = ROOT_DIR / "ui"
@@ -82,6 +83,12 @@ WEB_SEARCH_USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36"
 )
+
+# Automatically pass a matching mmproj (multimodal projector) to llama-server so
+# vision models "just work". When enabled, launching a model that has a matching
+# mmproj file in models/mmproj/ (or models/) adds "-mm <path>" unless the user
+# already specified an mmproj or --no-mmproj.
+AUTO_MMPROJ_ENABLED = parse_bool_env(os.environ.get("LLAMA_GUI_AUTO_MMPROJ", "1"))
 
 GITHUB_API = "https://api.github.com/repos/ggml-org/llama.cpp/releases"
 APP_REPO_URL = "https://github.com/thomas9120/LLama-GUI.git"

--- a/backend/services/process_manager.py
+++ b/backend/services/process_manager.py
@@ -29,6 +29,13 @@ _MODEL_VALUE_FLAGS = ("-m", "--model", "-hf", "--hf-repo", "-mu", "--model-url")
 _LOCAL_MODEL_VALUE_FLAGS = ("-m", "--model")
 _REMOTE_MODEL_VALUE_FLAGS = ("-hf", "--hf-repo", "-mu", "--model-url")
 _ALIAS_VALUE_FLAGS = ("-a", "--alias")
+_MMPROJ_FLAGS = ("-mm", "--mmproj", "--mmproj-url", "--no-mmproj")
+# Quantization / precision tokens stripped when correlating a model file with
+# its mmproj companion (e.g. "...-Q4_K_M" vs "mmproj-...-BF16").
+_QUANT_TOKEN_RE = re.compile(
+    r"(?i)(?:^|[-_.])(?:q\d+(?:_k)?(?:_[sml])?|iq\d+[a-z0-9_]*|f16|f32|bf16|fp16|fp8|mxfp4|q\d_\d)(?=$|[-_.])"
+)
+_MODEL_SHARD_RE = re.compile(r"-\d{5}-of-\d{5}$")
 _FINGERPRINT_RE = re.compile(r"[0-9a-f]{64}\Z")
 _SENSITIVE_CUSTOM_ARG_RE = re.compile(r"(?<![A-Za-z0-9_-])--api-key(?=$|[=\s])")
 _HEALTH_TIMEOUT_SECONDS = 2
@@ -1152,6 +1159,106 @@ def preflight_launch(
     }
 
 
+def _normalize_model_key(name: str) -> str:
+    """Reduce a model/mmproj filename to a comparable core key.
+
+    Drops the extension, shard suffix, a leading "mmproj" marker, and
+    quantization/precision tokens, then keeps only alphanumerics. This lets
+    "Nemotron-...-Q4_K_M.gguf" match "mmproj-Nemotron-...-BF16.gguf".
+    """
+    stem = str(name)
+    if stem.lower().endswith(".gguf"):
+        stem = stem[: -len(".gguf")]
+    stem = _MODEL_SHARD_RE.sub("", stem)
+    # Repeatedly strip quant tokens (they can appear more than once).
+    while True:
+        new_stem = _QUANT_TOKEN_RE.sub("", stem)
+        if new_stem == stem:
+            break
+        stem = new_stem
+    key = re.sub(r"[^a-z0-9]", "", stem.lower())
+    if key.startswith("mmproj"):
+        key = key[len("mmproj"):]
+    return key
+
+
+def _iter_mmproj_candidates(ctx: AppContext) -> list[Path]:
+    candidates: list[Path] = []
+    search_dirs = [config.MMPROJ_DIR, ctx.paths.models, ctx.paths.models / "mmproj"]
+    seen_dirs: set[Path] = set()
+    for directory in search_dirs:
+        try:
+            resolved = directory.resolve()
+        except Exception:
+            resolved = directory
+        if resolved in seen_dirs or not directory.exists():
+            continue
+        seen_dirs.add(resolved)
+        for path in directory.glob("*.gguf"):
+            if path.is_file() and "mmproj" in path.name.lower():
+                candidates.append(path)
+    return candidates
+
+
+def find_matching_mmproj(ctx: AppContext, model_path: str) -> Optional[Path]:
+    """Find an mmproj file whose name correlates with the given model file."""
+    model_key = _normalize_model_key(Path(model_path).name)
+    if not model_key:
+        return None
+    best: Optional[Path] = None
+    best_score = 0
+    for candidate in _iter_mmproj_candidates(ctx):
+        cand_key = _normalize_model_key(candidate.name)
+        if not cand_key:
+            continue
+        if cand_key == model_key:
+            return candidate
+        if cand_key in model_key or model_key in cand_key:
+            score = min(len(cand_key), len(model_key))
+            if score > best_score:
+                best, best_score = candidate, score
+    # Require a substantial overlap to avoid spurious matches.
+    if best is not None and best_score >= 8:
+        return best
+    return None
+
+
+def compute_auto_mmproj_args(
+    ctx: AppContext, tool: str, flat_launch_args: list[str]
+) -> list[str]:
+    """Return ["-mm", <path>] to add for a vision model, or [] when not needed."""
+    if not config.AUTO_MMPROJ_ENABLED:
+        return []
+    if tool not in {"llama-server", "llama-cli", "llama-mtmd-cli"}:
+        return []
+    # Respect an explicit user choice (mmproj already set, or disabled).
+    for arg in flat_launch_args:
+        base = arg.split("=", 1)[0]
+        if base in _MMPROJ_FLAGS:
+            return []
+    # Only local model files can be correlated with a local mmproj.
+    model_path: Optional[str] = None
+    i = 0
+    while i < len(flat_launch_args):
+        arg = flat_launch_args[i]
+        if arg in _LOCAL_MODEL_VALUE_FLAGS and i + 1 < len(flat_launch_args):
+            model_path = flat_launch_args[i + 1]
+            break
+        if arg.startswith("-m=") or arg.startswith("--model="):
+            model_path = arg.split("=", 1)[1]
+            break
+        i += 1
+    if not model_path:
+        return []
+    resolved_model = model_path
+    if not os.path.isabs(resolved_model):
+        resolved_model = str((ctx.paths.root / resolved_model))
+    match = find_matching_mmproj(ctx, resolved_model)
+    if match is None:
+        return []
+    return ["-mm", str(match)]
+
+
 def launch_process(
     ctx: AppContext,
     tool: str,
@@ -1172,6 +1279,13 @@ def launch_process(
             return {"error": environment_error}
 
         flat_launch_args = flatten_launch_args(args_list)
+        auto_mmproj_args = compute_auto_mmproj_args(ctx, tool, flat_launch_args)
+        if auto_mmproj_args:
+            flat_launch_args = [*flat_launch_args, *auto_mmproj_args]
+            print(
+                f"[process] vision enabled: auto-added mmproj {auto_mmproj_args[-1]}",
+                file=sys.stderr,
+            )
         args = [str(exe_path), *flat_launch_args]
         launch_api_keys = parse_launch_api_keys(flat_launch_args) if tool == "llama-server" else ()
         env = _build_process_env(ctx)

--- a/backend/services/process_manager.py
+++ b/backend/services/process_manager.py
@@ -19,6 +19,7 @@ from typing import Any, Iterable, Mapping, Optional
 
 from .. import config
 from ..context import AppContext
+from .hf_download import is_mmproj_filename
 from .subprocess_utils import get_no_window_creationflags
 
 
@@ -31,9 +32,11 @@ _REMOTE_MODEL_VALUE_FLAGS = ("-hf", "--hf-repo", "-mu", "--model-url")
 _ALIAS_VALUE_FLAGS = ("-a", "--alias")
 _MMPROJ_FLAGS = ("-mm", "--mmproj", "--mmproj-url", "--no-mmproj")
 # Quantization / precision tokens stripped when correlating a model file with
-# its mmproj companion (e.g. "...-Q4_K_M" vs "mmproj-...-BF16").
+# its mmproj companion (e.g. "...-Q4_K_M" vs "mmproj-...-BF16"). The q-quant
+# branch consumes the whole token, including legacy "Qn_n" forms such as Q4_0
+# and Q5_1 and k-quants such as Q4_K_M, so no trailing digit is left behind.
 _QUANT_TOKEN_RE = re.compile(
-    r"(?i)(?:^|[-_.])(?:q\d+(?:_k)?(?:_[sml])?|iq\d+[a-z0-9_]*|f16|f32|bf16|fp16|fp8|mxfp4|q\d_\d)(?=$|[-_.])"
+    r"(?i)(?:^|[-_.])(?:q\d+(?:_k(?:_[sml])?|_\d+)?|iq\d+[a-z0-9_]*|f16|f32|bf16|fp16|fp8|mxfp4)(?=$|[-_.])"
 )
 _MODEL_SHARD_RE = re.compile(r"-\d{5}-of-\d{5}$")
 _FINGERPRINT_RE = re.compile(r"[0-9a-f]{64}\Z")
@@ -1184,42 +1187,58 @@ def _normalize_model_key(name: str) -> str:
 
 def _iter_mmproj_candidates(ctx: AppContext) -> list[Path]:
     candidates: list[Path] = []
-    search_dirs = [config.MMPROJ_DIR, ctx.paths.models, ctx.paths.models / "mmproj"]
     seen_dirs: set[Path] = set()
-    for directory in search_dirs:
+    seen_files: set[Path] = set()
+
+    def add_from(directory: Path, recursive: bool) -> None:
         try:
-            resolved = directory.resolve()
+            resolved_dir = directory.resolve()
         except Exception:
-            resolved = directory
-        if resolved in seen_dirs or not directory.exists():
-            continue
-        seen_dirs.add(resolved)
-        for path in directory.glob("*.gguf"):
-            if path.is_file() and "mmproj" in path.name.lower():
-                candidates.append(path)
+            resolved_dir = directory
+        if resolved_dir in seen_dirs or not directory.exists():
+            return
+        seen_dirs.add(resolved_dir)
+        globber = directory.rglob("*.gguf") if recursive else directory.glob("*.gguf")
+        for path in globber:
+            # Recognize the same projector names the downloader accepts
+            # (mmproj / clip* / projector).
+            if not path.is_file() or not is_mmproj_filename(path.name):
+                continue
+            try:
+                resolved_file = path.resolve()
+            except Exception:
+                resolved_file = path
+            if resolved_file in seen_files:
+                continue
+            seen_files.add(resolved_file)
+            candidates.append(path)
+
+    # The dedicated mmproj tree is scanned recursively so a projector the
+    # integrated downloader stored under models/mmproj/<repo-slug>/<file>.gguf is
+    # rediscovered automatically after a reload.
+    add_from(config.MMPROJ_DIR, recursive=True)
+    add_from(ctx.paths.models / "mmproj", recursive=True)
+    # The plain models/ directory is scanned shallowly for manually placed
+    # files; recursing here would re-descend into mmproj/ and model repo folders.
+    add_from(ctx.paths.models, recursive=False)
     return candidates
 
 
 def find_matching_mmproj(ctx: AppContext, model_path: str) -> Optional[Path]:
-    """Find an mmproj file whose name correlates with the given model file."""
+    """Find an mmproj file whose name correlates with the given model file.
+
+    Matching requires the model and mmproj filenames to reduce to the *same*
+    normalized key (quantization/precision-insensitive). Substring or fuzzy
+    matching is deliberately avoided: attaching an incompatible same-family
+    projector (e.g. an "-V-2" projector to a "-V-2.6" model) can make the model
+    fail to load, so declining to auto-match is the safer default.
+    """
     model_key = _normalize_model_key(Path(model_path).name)
     if not model_key:
         return None
-    best: Optional[Path] = None
-    best_score = 0
     for candidate in _iter_mmproj_candidates(ctx):
-        cand_key = _normalize_model_key(candidate.name)
-        if not cand_key:
-            continue
-        if cand_key == model_key:
+        if _normalize_model_key(candidate.name) == model_key:
             return candidate
-        if cand_key in model_key or model_key in cand_key:
-            score = min(len(cand_key), len(model_key))
-            if score > best_score:
-                best, best_score = candidate, score
-    # Require a substantial overlap to avoid spurious matches.
-    if best is not None and best_score >= 8:
-        return best
     return None
 
 
@@ -1236,19 +1255,12 @@ def compute_auto_mmproj_args(
         base = arg.split("=", 1)[0]
         if base in _MMPROJ_FLAGS:
             return []
-    # Only local model files can be correlated with a local mmproj.
-    model_path: Optional[str] = None
-    i = 0
-    while i < len(flat_launch_args):
-        arg = flat_launch_args[i]
-        if arg in _LOCAL_MODEL_VALUE_FLAGS and i + 1 < len(flat_launch_args):
-            model_path = flat_launch_args[i + 1]
-            break
-        if arg.startswith("-m=") or arg.startswith("--model="):
-            model_path = arg.split("=", 1)[1]
-            break
-        i += 1
-    if not model_path:
+    # Use the effective (last) model source, matching how the rest of the app
+    # resolves repeated model flags: Custom Launch Args may repeat -m/--model and
+    # are placed before the UI-selected model, and a later -hf/--model-url wins.
+    # Only a local model file can be correlated with a local mmproj.
+    model_flag, model_path = _last_launch_flag_entry(flat_launch_args, _MODEL_VALUE_FLAGS)
+    if model_flag not in _LOCAL_MODEL_VALUE_FLAGS or not model_path:
         return []
     resolved_model = model_path
     if not os.path.isabs(resolved_model):

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -2616,5 +2616,75 @@ class WebSearchDirectTests(unittest.TestCase):
         self.assertIn("network down", result["error"])
 
 
+class AutoMmprojTests(unittest.TestCase):
+    def test_normalize_model_key_matches_quant_and_mmproj_variants(self):
+        self.assertEqual(
+            process_manager._normalize_model_key("Nemotron-3-Nano-Omni-30B-A3B-Reasoning-Q4_K_M.gguf"),
+            process_manager._normalize_model_key("mmproj-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16.gguf"),
+        )
+        self.assertEqual(
+            process_manager._normalize_model_key("Qwen3.6-35B-A3B-Q4_K_M.gguf"),
+            process_manager._normalize_model_key("mmproj-Qwen3.6-35B-A3B-BF16.gguf"),
+        )
+
+    def test_find_matching_mmproj_matches_companion_and_avoids_false_positive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            models = root / "models"
+            mmproj_dir = models / "mmproj"
+            mmproj_dir.mkdir(parents=True)
+            (models / "Nemotron-Omni-30B-Q4_K_M.gguf").write_bytes(b"x")
+            companion = mmproj_dir / "mmproj-Nemotron-Omni-30B-BF16.gguf"
+            companion.write_bytes(b"y")
+            (mmproj_dir / "mmproj-Qwen3-BF16.gguf").write_bytes(b"z")
+            ctx = SimpleNamespace(paths=SimpleNamespace(models=models, root=root))
+            with mock.patch.object(process_manager.config, "MMPROJ_DIR", mmproj_dir):
+                self.assertEqual(
+                    process_manager.find_matching_mmproj(
+                        ctx, str(models / "Nemotron-Omni-30B-Q4_K_M.gguf")
+                    ),
+                    companion,
+                )
+                (models / "LFM2-24B-Q4_K_M.gguf").write_bytes(b"x")
+                self.assertIsNone(
+                    process_manager.find_matching_mmproj(ctx, str(models / "LFM2-24B-Q4_K_M.gguf"))
+                )
+
+    def test_compute_auto_mmproj_args_and_overrides(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            models = root / "models"
+            mmproj_dir = models / "mmproj"
+            mmproj_dir.mkdir(parents=True)
+            (models / "Vis-30B-Q4_K_M.gguf").write_bytes(b"x")
+            companion = mmproj_dir / "mmproj-Vis-30B-BF16.gguf"
+            companion.write_bytes(b"y")
+            ctx = SimpleNamespace(paths=SimpleNamespace(models=models, root=root))
+            base = ["-m", str(models / "Vis-30B-Q4_K_M.gguf")]
+            with mock.patch.object(process_manager.config, "MMPROJ_DIR", mmproj_dir), mock.patch.object(
+                process_manager.config, "AUTO_MMPROJ_ENABLED", True
+            ):
+                self.assertEqual(
+                    process_manager.compute_auto_mmproj_args(ctx, "llama-server", base),
+                    ["-mm", str(companion)],
+                )
+                # explicit mmproj, --no-mmproj, and non-vision tools are respected
+                self.assertEqual(
+                    process_manager.compute_auto_mmproj_args(ctx, "llama-server", base + ["-mm", "x.gguf"]),
+                    [],
+                )
+                self.assertEqual(
+                    process_manager.compute_auto_mmproj_args(ctx, "llama-server", base + ["--no-mmproj"]),
+                    [],
+                )
+                self.assertEqual(
+                    process_manager.compute_auto_mmproj_args(ctx, "llama-cli-bench", base), []
+                )
+            with mock.patch.object(process_manager.config, "AUTO_MMPROJ_ENABLED", False):
+                self.assertEqual(
+                    process_manager.compute_auto_mmproj_args(ctx, "llama-server", ["-m", "x"]), []
+                )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -2627,6 +2627,26 @@ class AutoMmprojTests(unittest.TestCase):
             process_manager._normalize_model_key("mmproj-Qwen3.6-35B-A3B-BF16.gguf"),
         )
 
+    def test_normalize_model_key_consumes_legacy_qn_n_quant_tokens(self):
+        # Legacy "Qn_n" quant tokens (Q4_0, Q5_1) must be stripped whole, with no
+        # trailing digit left behind, so a quantized model still equals its
+        # BF16/F16 projector.
+        self.assertEqual(
+            process_manager._normalize_model_key("Vision-Model-Q4_0.gguf"),
+            process_manager._normalize_model_key("mmproj-Vision-Model-BF16.gguf"),
+        )
+        self.assertEqual(
+            process_manager._normalize_model_key("Vision-Model-Q5_1.gguf"),
+            process_manager._normalize_model_key("mmproj-Vision-Model-F16.gguf"),
+        )
+
+    def test_normalize_model_key_distinguishes_close_family_versions(self):
+        # A "-V-2.6" model must not reduce to the same key as a "-V-2" projector.
+        self.assertNotEqual(
+            process_manager._normalize_model_key("MiniCPM-V-2.6-Q4_K_M.gguf"),
+            process_manager._normalize_model_key("mmproj-MiniCPM-V-2-F16.gguf"),
+        )
+
     def test_find_matching_mmproj_matches_companion_and_avoids_false_positive(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = pathlib.Path(tmp)
@@ -2648,6 +2668,33 @@ class AutoMmprojTests(unittest.TestCase):
                 (models / "LFM2-24B-Q4_K_M.gguf").write_bytes(b"x")
                 self.assertIsNone(
                     process_manager.find_matching_mmproj(ctx, str(models / "LFM2-24B-Q4_K_M.gguf"))
+                )
+
+    def test_find_matching_mmproj_legacy_quant_matches_and_close_version_does_not(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            models = root / "models"
+            mmproj_dir = models / "mmproj"
+            mmproj_dir.mkdir(parents=True)
+            # Positive: a legacy Qn_n quantization still matches its BF16 projector.
+            (models / "Vision-Model-Q4_0.gguf").write_bytes(b"x")
+            companion = mmproj_dir / "mmproj-Vision-Model-BF16.gguf"
+            companion.write_bytes(b"y")
+            # Negative: a close-but-different family version must not be attached.
+            (models / "MiniCPM-V-2.6-Q4_K_M.gguf").write_bytes(b"x")
+            (mmproj_dir / "mmproj-MiniCPM-V-2-F16.gguf").write_bytes(b"z")
+            ctx = SimpleNamespace(paths=SimpleNamespace(models=models, root=root))
+            with mock.patch.object(process_manager.config, "MMPROJ_DIR", mmproj_dir):
+                self.assertEqual(
+                    process_manager.find_matching_mmproj(
+                        ctx, str(models / "Vision-Model-Q4_0.gguf")
+                    ),
+                    companion,
+                )
+                self.assertIsNone(
+                    process_manager.find_matching_mmproj(
+                        ctx, str(models / "MiniCPM-V-2.6-Q4_K_M.gguf")
+                    )
                 )
 
     def test_compute_auto_mmproj_args_and_overrides(self):
@@ -2684,6 +2731,84 @@ class AutoMmprojTests(unittest.TestCase):
                 self.assertEqual(
                     process_manager.compute_auto_mmproj_args(ctx, "llama-server", ["-m", "x"]), []
                 )
+
+    def test_compute_auto_mmproj_args_uses_last_model_source(self):
+        # Custom Launch Args may repeat -m and are placed before the UI-selected
+        # model; the last (effective) model source must drive projector matching.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            models = root / "models"
+            mmproj_dir = models / "mmproj"
+            mmproj_dir.mkdir(parents=True)
+            (models / "Old-30B-Q4_K_M.gguf").write_bytes(b"x")
+            (mmproj_dir / "mmproj-Old-30B-BF16.gguf").write_bytes(b"o")
+            (models / "Selected-30B-Q4_K_M.gguf").write_bytes(b"x")
+            selected_companion = mmproj_dir / "mmproj-Selected-30B-BF16.gguf"
+            selected_companion.write_bytes(b"s")
+            ctx = SimpleNamespace(paths=SimpleNamespace(models=models, root=root))
+            args = [
+                "-m", str(models / "Old-30B-Q4_K_M.gguf"),
+                "-m", str(models / "Selected-30B-Q4_K_M.gguf"),
+            ]
+            with mock.patch.object(process_manager.config, "MMPROJ_DIR", mmproj_dir), \
+                    mock.patch.object(process_manager.config, "AUTO_MMPROJ_ENABLED", True):
+                self.assertEqual(
+                    process_manager.compute_auto_mmproj_args(ctx, "llama-server", args),
+                    ["-mm", str(selected_companion)],
+                )
+
+    def test_compute_auto_mmproj_args_suppressed_by_effective_remote_source(self):
+        # A local -m followed by an effective remote -hf/--model-url source must
+        # not auto-attach the local projector.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            models = root / "models"
+            mmproj_dir = models / "mmproj"
+            mmproj_dir.mkdir(parents=True)
+            (models / "Local-30B-Q4_K_M.gguf").write_bytes(b"x")
+            (mmproj_dir / "mmproj-Local-30B-BF16.gguf").write_bytes(b"m")
+            ctx = SimpleNamespace(paths=SimpleNamespace(models=models, root=root))
+            args = ["-m", str(models / "Local-30B-Q4_K_M.gguf"), "-hf", "some/repo"]
+            with mock.patch.object(process_manager.config, "MMPROJ_DIR", mmproj_dir), \
+                    mock.patch.object(process_manager.config, "AUTO_MMPROJ_ENABLED", True):
+                self.assertEqual(
+                    process_manager.compute_auto_mmproj_args(ctx, "llama-server", args),
+                    [],
+                )
+
+    def test_find_matching_mmproj_discovers_downloaded_projector_in_subdir(self):
+        # The downloader stores projectors under models/mmproj/<repo-slug>/<file>;
+        # the recursive scan must rediscover them after a reload.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            models = root / "models"
+            repo_dir = models / "mmproj" / "some-org__some-repo"
+            repo_dir.mkdir(parents=True)
+            (models / "Downloaded-Vision-Q4_K_M.gguf").write_bytes(b"x")
+            companion = repo_dir / "mmproj-Downloaded-Vision-f16.gguf"
+            companion.write_bytes(b"y")
+            ctx = SimpleNamespace(paths=SimpleNamespace(models=models, root=root))
+            with mock.patch.object(process_manager.config, "MMPROJ_DIR", models / "mmproj"):
+                self.assertEqual(
+                    process_manager.find_matching_mmproj(
+                        ctx, str(models / "Downloaded-Vision-Q4_K_M.gguf")
+                    ),
+                    companion,
+                )
+
+    def test_iter_mmproj_candidates_recognizes_clip_and_projector_names(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            models = root / "models"
+            mmproj_dir = models / "mmproj"
+            mmproj_dir.mkdir(parents=True)
+            (mmproj_dir / "clip-vision-f16.gguf").write_bytes(b"a")
+            (mmproj_dir / "model-projector-f16.gguf").write_bytes(b"b")
+            (mmproj_dir / "regular-model-Q4_K_M.gguf").write_bytes(b"c")  # not a projector
+            ctx = SimpleNamespace(paths=SimpleNamespace(models=models, root=root))
+            with mock.patch.object(process_manager.config, "MMPROJ_DIR", mmproj_dir):
+                names = sorted(p.name for p in process_manager._iter_mmproj_candidates(ctx))
+            self.assertEqual(names, ["clip-vision-f16.gguf", "model-projector-f16.gguf"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Multimodal (vision) GGUF models need a companion multimodal projector
(`mmproj`) passed via `-mm`. Today the projector has to be located and wired up
by hand; if it is forgotten the model loads without vision and there is no
obvious hint why.

## Change

When a model is launched, look for an `mmproj` whose filename correlates with
the model file and pass it as `-mm` automatically:

- Searches the dedicated `models/mmproj/` tree recursively (so a projector the
  downloader stored under `models/mmproj/<repo-slug>/` is rediscovered after a
  reload) and `models/` shallowly, recognizing `mmproj` / `clip*` / `projector`
  names.
- Correlates by a normalized key that ignores quantization/precision tokens and
  shard suffixes, so e.g. `Nemotron-…-Q4_K_M.gguf` matches
  `mmproj-Nemotron-…-BF16.gguf`.
- Requires exact normalized-key equality, so a close-but-different family version
  (e.g. `-V-2.6` vs `-V-2`) or an unrelated model will not grab a stray
  projector.
- Uses the effective (last) model source, so a repeated `-m` or a later remote
  `-hf`/`--model-url` is honored rather than the first `-m`.
- Respects an explicit `-mm` / `--mmproj` / `--mmproj-url` / `--no-mmproj`, and
  only applies to `llama-server` / `llama-cli` / `llama-mtmd-cli`.
- Can be disabled with `LLAMA_GUI_AUTO_MMPROJ=0`.

## Testing

- Added `AutoMmprojTests` covering key normalization, companion matching,
  false-positive avoidance, and the override/disable paths.
- Full backend test suite passes (486 tests).

