### PR TITLE
Add HTTP(S)_PROXY / NO_PROXY support for web search and fetching

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -83,6 +83,38 @@ WEB_SEARCH_USER_AGENT = (
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36"
 )
 
+
+def _first_nonempty_env(*names: str) -> str:
+    for name in names:
+        value = os.environ.get(name)
+        if value and value.strip():
+            return value.strip()
+    return ""
+
+
+def _parse_host_suffixes(value: object) -> tuple[str, ...]:
+    hosts: list[str] = []
+    for raw in str(value or "").replace(";", ",").split(","):
+        host = raw.strip().lower().lstrip("*").strip(".")
+        if host and host not in hosts:
+            hosts.append(host)
+    return tuple(hosts)
+
+
+# Upstream proxy used to reach the internet for web search/fetch. Defaults to the
+# standard HTTP(S)_PROXY environment variables (e.g. a corporate proxy), matching
+# how other tools discover a proxy. Set LLAMA_GUI_WEB_PROXY to override, or "" to
+# disable proxy usage entirely.
+WEB_SEARCH_PROXY = _first_nonempty_env(
+    "LLAMA_GUI_WEB_PROXY", "HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"
+)
+
+# Host suffixes that bypass the proxy and are fetched directly, taken from the
+# standard NO_PROXY environment variable (LLAMA_GUI_WEB_NO_PROXY overrides).
+WEB_SEARCH_NO_PROXY = _parse_host_suffixes(
+    _first_nonempty_env("LLAMA_GUI_WEB_NO_PROXY", "NO_PROXY", "no_proxy")
+)
+
 GITHUB_API = "https://api.github.com/repos/ggml-org/llama.cpp/releases"
 APP_REPO_URL = "https://github.com/thomas9120/LLama-GUI.git"
 # Branch that release tags are cut from. Auto-update always compares against

--- a/backend/services/web_search.py
+++ b/backend/services/web_search.py
@@ -184,15 +184,82 @@ class _PinnedHTTPSConnection(http.client.HTTPSConnection):
         self.sock = self._context.wrap_socket(sock, server_hostname=self.host)
 
 
+def _split_proxy(proxy_url: Any) -> tuple[Optional[str], Optional[int]]:
+    value = str(proxy_url or "").strip()
+    if not value:
+        return None, None
+    if "://" not in value:
+        value = "http://" + value
+    parsed = urllib.parse.urlparse(value)
+    if not parsed.hostname:
+        return None, None
+    return parsed.hostname, parsed.port or 3128
+
+
+def host_bypasses_proxy(hostname: Any) -> bool:
+    """True when the host should be reached directly (matches NO_PROXY)."""
+    host = str(hostname or "").strip().lower().rstrip(".")
+    if not host:
+        return False
+    for suffix in config.WEB_SEARCH_NO_PROXY:
+        if suffix == "*" or host == suffix or host.endswith("." + suffix):
+            return True
+    return False
+
+
+def _request_headers() -> dict[str, str]:
+    return {
+        "User-Agent": config.WEB_SEARCH_USER_AGENT,
+        "Accept": "text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.2",
+    }
+
+
+def _open_via_proxy(
+    parsed: urllib.parse.ParseResult,
+    port: int,
+    timeout: float,
+    ssl_context: Optional[Any],
+    proxy_url: str,
+) -> tuple[int, str, Any, bytes]:
+    proxy_host, proxy_port = _split_proxy(proxy_url)
+    if not proxy_host:
+        raise OSError(f"Invalid proxy URL: {proxy_url!r}")
+    if parsed.scheme == "https":
+        connection = http.client.HTTPSConnection(
+            proxy_host, proxy_port, timeout=timeout, context=ssl_context
+        )
+        connection.set_tunnel(parsed.hostname, port)
+        target = urllib.parse.urlunparse(("", "", parsed.path or "/", parsed.params, parsed.query, ""))
+    else:
+        connection = http.client.HTTPConnection(proxy_host, proxy_port, timeout=timeout)
+        target = urllib.parse.urlunparse(
+            (parsed.scheme, parsed.netloc, parsed.path or "/", parsed.params, parsed.query, "")
+        )
+    try:
+        connection.request("GET", target, headers=_request_headers())
+        response = connection.getresponse()
+        raw = response.read(config.WEB_SEARCH_FETCH_BYTES)
+        return response.status, response.reason, response.headers, raw
+    finally:
+        connection.close()
+
+
 def _open_validated_url(
     parsed: urllib.parse.ParseResult,
     addresses: list[Any],
     timeout: float,
     ssl_context: Optional[Any],
 ) -> tuple[int, str, Any, bytes]:
-    # Connects directly to the pre-validated addresses (no system proxy
-    # support): routing through a proxy would bypass the SSRF IP pinning.
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    proxy_url = config.WEB_SEARCH_PROXY or None
+    if proxy_url and not host_bypasses_proxy(parsed.hostname):
+        # Reach the host through the configured proxy. The caller has already
+        # verified (via resolve_public_addresses) that the host resolves to a
+        # public address, so this does not widen the SSRF surface; the proxy
+        # performs its own name resolution for the tunnelled connection.
+        return _open_via_proxy(parsed, port, timeout, ssl_context, proxy_url)
+    # No proxy (or a NO_PROXY host): connect directly to the pre-validated,
+    # pinned addresses so the SSRF IP check cannot be bypassed.
     connection_class = _PinnedHTTPSConnection if parsed.scheme == "https" else _PinnedHTTPConnection
     if parsed.scheme == "https":
         connection = connection_class(parsed.hostname, port, addresses, timeout, ssl_context)
@@ -200,14 +267,7 @@ def _open_validated_url(
         connection = connection_class(parsed.hostname, port, addresses, timeout)
     target = urllib.parse.urlunparse(("", "", parsed.path or "/", parsed.params, parsed.query, ""))
     try:
-        connection.request(
-            "GET",
-            target,
-            headers={
-                "User-Agent": config.WEB_SEARCH_USER_AGENT,
-                "Accept": "text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.2",
-            },
-        )
+        connection.request("GET", target, headers=_request_headers())
         response = connection.getresponse()
         raw = response.read(config.WEB_SEARCH_FETCH_BYTES)
         return response.status, response.reason, response.headers, raw
@@ -233,7 +293,14 @@ def fetch_page_text(
         port = parsed.port or (443 if parsed.scheme == "https" else 80)
         addresses, reason = resolve_public_addresses(parsed.hostname, port)
         if addresses is None:
-            return {"ok": False, "error": reason}
+            # A private-address SSRF block is always fatal. A plain resolution
+            # failure is tolerated when the host will be reached through the
+            # proxy, since the proxy performs its own DNS (the local machine may
+            # have no direct public resolver).
+            proxied = bool(config.WEB_SEARCH_PROXY) and not host_bypasses_proxy(parsed.hostname)
+            if reason.startswith("Blocked:") or not proxied:
+                return {"ok": False, "error": reason}
+            addresses = []
 
         try:
             status, status_reason, headers, raw = _open_validated_url(

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -4608,5 +4608,77 @@ class LifecycleTests(unittest.TestCase):
         mock_of.assert_called_once_with(self.ctx.paths.models)
 
 
+class WebProxyTests(unittest.TestCase):
+    """Proxy support honoring HTTP(S)_PROXY / NO_PROXY."""
+
+    def test_host_bypasses_proxy_matches_no_proxy_suffixes(self):
+        with mock.patch.object(web_search.config, "WEB_SEARCH_NO_PROXY", ("example.com", "10.corp")):
+            self.assertTrue(web_search.host_bypasses_proxy("example.com"))
+            self.assertTrue(web_search.host_bypasses_proxy("api.example.com"))
+            self.assertTrue(web_search.host_bypasses_proxy("host.10.corp"))
+            self.assertFalse(web_search.host_bypasses_proxy("example.org"))
+            self.assertFalse(web_search.host_bypasses_proxy(""))
+        with mock.patch.object(web_search.config, "WEB_SEARCH_NO_PROXY", ("*",)):
+            self.assertTrue(web_search.host_bypasses_proxy("anything.test"))
+
+    def test_open_validated_url_routes_through_proxy(self):
+        parsed = web_search.urllib.parse.urlparse("https://example.com/page")
+        with mock.patch.object(web_search.config, "WEB_SEARCH_PROXY", "http://127.0.0.1:3128"), mock.patch.object(
+            web_search.config, "WEB_SEARCH_NO_PROXY", ()
+        ), mock.patch.object(
+            web_search, "_open_via_proxy", return_value=(200, "OK", Message(), b"ok")
+        ) as via_proxy:
+            status, _, _, raw = web_search._open_validated_url(parsed, [], 10, None)
+        self.assertEqual((status, raw), (200, b"ok"))
+        via_proxy.assert_called_once()
+        self.assertEqual(via_proxy.call_args.args[4], "http://127.0.0.1:3128")
+
+    def test_open_validated_url_direct_for_no_proxy_host(self):
+        parsed = web_search.urllib.parse.urlparse("https://intranet.corp/page")
+        addresses = [(web_search.socket.AF_INET, web_search.socket.SOCK_STREAM, 6, "", ("10.0.0.5", 443))]
+        fake_conn = mock.Mock()
+        fake_conn.getresponse.return_value = mock.Mock(status=200, reason="OK", headers=Message())
+        fake_conn.getresponse.return_value.read.return_value = b"direct"
+        with mock.patch.object(web_search.config, "WEB_SEARCH_PROXY", "http://127.0.0.1:3128"), mock.patch.object(
+            web_search.config, "WEB_SEARCH_NO_PROXY", ("corp",)
+        ), mock.patch.object(
+            web_search, "_open_via_proxy"
+        ) as via_proxy, mock.patch.object(
+            web_search, "_PinnedHTTPSConnection", return_value=fake_conn
+        ):
+            status, _, _, raw = web_search._open_validated_url(parsed, addresses, 10, None)
+        self.assertEqual((status, raw), (200, b"direct"))
+        via_proxy.assert_not_called()
+        fake_conn.request.assert_called_once()
+
+    def test_fetch_page_text_tolerates_dns_failure_when_proxied(self):
+        with mock.patch.object(web_search.config, "WEB_SEARCH_PROXY", "http://127.0.0.1:3128"), mock.patch.object(
+            web_search.config, "WEB_SEARCH_NO_PROXY", ()
+        ), mock.patch.object(
+            web_search,
+            "resolve_public_addresses",
+            return_value=(None, "Failed to resolve host: getaddrinfo failed"),
+        ), mock.patch.object(
+            web_search, "_open_validated_url", return_value=(200, "OK", Message(), b"<html>hi</html>")
+        ) as open_url:
+            result = web_search.fetch_page_text("https://example.com")
+        self.assertTrue(result["ok"])
+        open_url.assert_called_once()
+        self.assertEqual(open_url.call_args.args[1], [])
+
+    def test_fetch_page_text_still_blocks_private_ip_when_proxied(self):
+        with mock.patch.object(web_search.config, "WEB_SEARCH_PROXY", "http://127.0.0.1:3128"), mock.patch.object(
+            web_search.config, "WEB_SEARCH_NO_PROXY", ()
+        ), mock.patch.object(
+            web_search,
+            "resolve_public_addresses",
+            return_value=(None, "Blocked: refusing to fetch non-public address 10.0.0.5."),
+        ), mock.patch.object(web_search, "_open_validated_url") as open_url:
+            result = web_search.fetch_page_text("https://sneaky.example.com")
+        self.assertFalse(result["ok"])
+        self.assertIn("non-public address", result["error"])
+        open_url.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Web search and page fetching connected directly to the resolved address only —
`_open_validated_url` even noted "no system proxy support". On a machine behind
a corporate proxy that means search and fetch cannot reach the internet at all.

## Change

- Discover a proxy from the standard `HTTP(S)_PROXY` environment variables
  (override with `LLAMA_GUI_WEB_PROXY`, disable with an empty value) and route
  requests through it (HTTP absolute-URI for `http://`, `CONNECT` tunnel for
  `https://`).
- Honor `NO_PROXY` (and `LLAMA_GUI_WEB_NO_PROXY`): listed host suffixes bypass
  the proxy and are fetched directly.

## Security

The SSRF public-address guard is preserved. Hosts are still resolved and
checked locally before use, and `NO_PROXY` hosts keep the existing pinned
direct connection so the IP check cannot be bypassed. A local DNS-resolution
failure is tolerated **only** when the request will go through the proxy (the
proxy resolves the name itself), which is what lets a proxy-only machine with no
direct public resolver still fetch pages. A private-address block remains fatal.

## Testing

- Added `WebProxyTests`: `NO_PROXY` matching, proxy routing vs. direct for a
  `NO_PROXY` host, DNS-failure tolerance when proxied, and that a private-IP
  block is still enforced when a proxy is configured.
- Full backend suite passes (488 tests).
