### PR TITLE
Add optional SearXNG search backend with ddgs fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ OpenAI-compatible endpoint overview and copy-ready snippets (cURL, Python, JavaS
 
 Talks to a running `llama-server` — one launched here, or one registered on the API tab — via `/v1/chat/completions` with streaming Markdown, Focus mode, history/settings panels, system prompt, shared sampler controls, undo/regenerate/clear, code copy buttons, and collapsed reasoning when the server streams it.
 
-**Web Search** (optional): no API key. The local server searches (free `ddgs`), fetches public pages, injects graded source context, and shows source chips under answers. History is not polluted with raw search text. Leave off for fully local chat. See [Security Notes](#security-notes) for fetch limits.
+**Web Search** (optional): no API key. The local server searches (free `ddgs` by default, or an optional self-hosted [SearXNG](https://docs.searxng.org/) instance via `LLAMA_GUI_SEARXNG_URL`), fetches public pages, injects graded source context, and shows source chips under answers. History is not polluted with raw search text. Leave off for fully local chat. See [Security Notes](#security-notes) for fetch limits.
 
 ### Presets
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -83,6 +83,12 @@ WEB_SEARCH_USER_AGENT = (
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36"
 )
 
+# Optional SearXNG metasearch endpoint. When set (e.g. "http://127.0.0.1:8888")
+# it is preferred over the DuckDuckGo (ddgs) backend, which stays the fallback
+# whenever SearXNG is unset, unreachable, or returns no results. Leave
+# LLAMA_GUI_SEARXNG_URL unset/empty to use ddgs only (the default).
+WEB_SEARCH_SEARXNG_URL = os.environ.get("LLAMA_GUI_SEARXNG_URL", "").strip()
+
 GITHUB_API = "https://api.github.com/repos/ggml-org/llama.cpp/releases"
 APP_REPO_URL = "https://github.com/thomas9120/LLama-GUI.git"
 # Branch that release tags are cut from. Auto-update always compares against

--- a/backend/config.py
+++ b/backend/config.py
@@ -85,8 +85,10 @@ WEB_SEARCH_USER_AGENT = (
 
 # Optional SearXNG metasearch endpoint. When set (e.g. "http://127.0.0.1:8888")
 # it is preferred over the DuckDuckGo (ddgs) backend, which stays the fallback
-# whenever SearXNG is unset, unreachable, or returns no results. Leave
-# LLAMA_GUI_SEARXNG_URL unset/empty to use ddgs only (the default).
+# whenever SearXNG is unset, unreachable, or returns no results. The instance
+# must expose the JSON format (settings.yml must include "json" under
+# search.formats). Leave LLAMA_GUI_SEARXNG_URL unset/empty to use ddgs only
+# (the default).
 WEB_SEARCH_SEARXNG_URL = os.environ.get("LLAMA_GUI_SEARXNG_URL", "").strip()
 
 GITHUB_API = "https://api.github.com/repos/ggml-org/llama.cpp/releases"

--- a/backend/services/web_search.py
+++ b/backend/services/web_search.py
@@ -299,43 +299,92 @@ def ddgs_search(query: Any, max_results: int = config.WEB_SEARCH_MAX_RESULTS) ->
     return {"ok": True, "query": query, "results": results}
 
 
+def _searxng_valid_result_url(url: Any) -> bool:
+    """A SearXNG result URL must be a non-empty http(s) string with a hostname.
+
+    Rejecting anything else here keeps a malformed row (e.g. a non-string URL,
+    or one with an invalid port such as ``http://host:bad``) from reaching the
+    Chat caller, which would later pass it to urlparse()/fetch_page_text() and
+    raise there instead of falling back.
+    """
+    if not isinstance(url, str) or not url:
+        return False
+    try:
+        parsed = urllib.parse.urlparse(url)
+        # Accessing .port forces port validation: a non-numeric or out-of-range
+        # port raises ValueError here rather than later in fetch_page_text().
+        parsed.port
+    except ValueError:
+        return False
+    return parsed.scheme in {"http", "https"} and bool(parsed.hostname)
+
+
+def _searxng_text(value: Any) -> str:
+    """Normalize an optional text field: keep strings, drop anything else."""
+    return value if isinstance(value, str) else ""
+
+
 def searxng_search(query: Any, max_results: int = config.WEB_SEARCH_MAX_RESULTS) -> dict[str, Any]:
-    """Query a SearXNG JSON endpoint. Connects directly (ignoring any
-    environment proxy) because SearXNG is expected to be a local/trusted host."""
+    """Query a SearXNG JSON endpoint, returning normalized results.
+
+    Connects directly (ignoring any environment proxy) because SearXNG is
+    expected to be a local/trusted host. Any problem -- an invalid endpoint URL,
+    an unreachable instance, a non-JSON or non-object response, a missing results
+    list, a malformed result row, etc. -- is logged to stderr and reported as a
+    generic failure so that web_search() falls back to ddgs. The SearXNG instance
+    must expose the JSON format (its settings.yml must include ``json`` under
+    ``search.formats``).
+    """
     query = str(query or "").strip()
     if not query:
         return {"ok": False, "error": "No query provided.", "results": []}
     base = str(config.WEB_SEARCH_SEARXNG_URL or "").strip().rstrip("/")
     if not base:
         return {"ok": False, "error": "SearXNG endpoint not configured.", "results": []}
-    params = urllib.parse.urlencode({"q": query, "format": "json", "safesearch": "0"})
-    endpoint = f"{base}/search?{params}"
-    request = urllib.request.Request(
-        endpoint,
-        headers={"User-Agent": config.WEB_SEARCH_USER_AGENT, "Accept": "application/json"},
-    )
-    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+    # Everything below can fail on a misconfigured or hostile instance, so it is
+    # all guarded -- including endpoint parsing, which raises on inputs such as
+    # "http://[bad" -- and a failure falls back to ddgs via web_search().
     try:
+        parsed = urllib.parse.urlparse(base)
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            raise ValueError(f"invalid endpoint URL: {base!r}")
+        parsed.port  # force port validation (raises ValueError on a bad port)
+        # No safesearch override: the instance's configured policy applies.
+        params = urllib.parse.urlencode({"q": query, "format": "json"})
+        endpoint = f"{base}/search?{params}"
+        request = urllib.request.Request(
+            endpoint,
+            headers={"User-Agent": config.WEB_SEARCH_USER_AGENT, "Accept": "application/json"},
+        )
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
         with opener.open(request, timeout=config.WEB_SEARCH_TIMEOUT) as response:
             raw = response.read(config.WEB_SEARCH_FETCH_BYTES)
         data = json.loads(raw.decode("utf-8", errors="replace"))
+        if not isinstance(data, dict):
+            raise ValueError("response was not a JSON object")
+        rows = data.get("results")
+        if not isinstance(rows, list):
+            raise ValueError("response had no results list")
+        results = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            url = row.get("url")
+            if not _searxng_valid_result_url(url):
+                continue
+            results.append(
+                {
+                    "title": _searxng_text(row.get("title")) or url,
+                    "url": url,
+                    "snippet": _searxng_text(row.get("content")) or _searxng_text(row.get("snippet")),
+                }
+            )
+            if len(results) >= max_results:
+                break
     except Exception as exc:
-        return {"ok": False, "error": f"SearXNG search failed: {exc}", "results": []}
-
-    results = []
-    for row in data.get("results", []) or []:
-        url = row.get("url") or ""
-        if not url:
-            continue
-        results.append(
-            {
-                "title": row.get("title") or url,
-                "url": url,
-                "snippet": row.get("content") or row.get("snippet") or "",
-            }
-        )
-        if len(results) >= max_results:
-            break
+        print(f"[web_search] SearXNG search failed: {exc}", file=sys.stderr)
+        return {"ok": False, "error": "SearXNG search failed.", "results": []}
     return {"ok": True, "query": query, "results": results}
 
 

--- a/backend/services/web_search.py
+++ b/backend/services/web_search.py
@@ -3,6 +3,7 @@
 import html
 import http.client
 import ipaddress
+import json
 import re
 import socket
 import sys
@@ -265,7 +266,7 @@ def fetch_page_text(
     return {"ok": False, "error": "Failed to fetch URL: too many redirects."}
 
 
-def web_search(query: Any, max_results: int = config.WEB_SEARCH_MAX_RESULTS) -> dict[str, Any]:
+def ddgs_search(query: Any, max_results: int = config.WEB_SEARCH_MAX_RESULTS) -> dict[str, Any]:
     query = str(query or "").strip()
     if not query:
         return {"ok": False, "error": "No query provided.", "results": []}
@@ -296,3 +297,56 @@ def web_search(query: Any, max_results: int = config.WEB_SEARCH_MAX_RESULTS) -> 
             }
         )
     return {"ok": True, "query": query, "results": results}
+
+
+def searxng_search(query: Any, max_results: int = config.WEB_SEARCH_MAX_RESULTS) -> dict[str, Any]:
+    """Query a SearXNG JSON endpoint. Connects directly (ignoring any
+    environment proxy) because SearXNG is expected to be a local/trusted host."""
+    query = str(query or "").strip()
+    if not query:
+        return {"ok": False, "error": "No query provided.", "results": []}
+    base = str(config.WEB_SEARCH_SEARXNG_URL or "").strip().rstrip("/")
+    if not base:
+        return {"ok": False, "error": "SearXNG endpoint not configured.", "results": []}
+    params = urllib.parse.urlencode({"q": query, "format": "json", "safesearch": "0"})
+    endpoint = f"{base}/search?{params}"
+    request = urllib.request.Request(
+        endpoint,
+        headers={"User-Agent": config.WEB_SEARCH_USER_AGENT, "Accept": "application/json"},
+    )
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    try:
+        with opener.open(request, timeout=config.WEB_SEARCH_TIMEOUT) as response:
+            raw = response.read(config.WEB_SEARCH_FETCH_BYTES)
+        data = json.loads(raw.decode("utf-8", errors="replace"))
+    except Exception as exc:
+        return {"ok": False, "error": f"SearXNG search failed: {exc}", "results": []}
+
+    results = []
+    for row in data.get("results", []) or []:
+        url = row.get("url") or ""
+        if not url:
+            continue
+        results.append(
+            {
+                "title": row.get("title") or url,
+                "url": url,
+                "snippet": row.get("content") or row.get("snippet") or "",
+            }
+        )
+        if len(results) >= max_results:
+            break
+    return {"ok": True, "query": query, "results": results}
+
+
+def web_search(query: Any, max_results: int = config.WEB_SEARCH_MAX_RESULTS) -> dict[str, Any]:
+    """Run a web search, preferring SearXNG when configured and falling back to
+    DuckDuckGo (ddgs)."""
+    query = str(query or "").strip()
+    if not query:
+        return {"ok": False, "error": "No query provided.", "results": []}
+    if str(config.WEB_SEARCH_SEARXNG_URL or "").strip():
+        searxng_result = searxng_search(query, max_results=max_results)
+        if searxng_result.get("ok") and searxng_result.get("results"):
+            return searxng_result
+    return ddgs_search(query, max_results=max_results)

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -69,7 +69,7 @@
 - Handles preset, model file, and Hugging Face download APIs.
 - Selects binary based on platform (`win32`/`darwin`/`linux`) and backend type (e.g., `cuda-12.4`, `cuda-13.3`, `vulkan`, `hip`, `sycl`, `openvino`, `metal`).
 - Proxies OpenAI-compatible chat completions (`/v1/chat/completions`) to `llama-server` with streaming SSE support.
-- Built-in web search via DuckDuckGo (`ddgs` + page fetching with HTML-to-text parsing).
+- Built-in web search via DuckDuckGo (`ddgs` + page fetching with HTML-to-text parsing), with an optional self-hosted SearXNG backend (`LLAMA_GUI_SEARXNG_URL`) that is preferred when set and falls back to `ddgs`.
 - Cloudflare tunnel management (auto-downloads `cloudflared`, starts/stops tunnel, returns public URL).
 - Git-based app auto-updating (checks status, pulls, reinstalls dependencies, restarts server).
 - Native file picker (tkinter) for selecting model files and paths.
@@ -103,7 +103,7 @@
 | `llama_manager.py` | GitHub release fetch, install, SHA256 verify, binary extraction |
 | `process_manager.py` | Process launch/stop, output streaming, arg flattening, API target parsing |
 | `hf_download.py` | HF repo listing, file download with cancel, path validation |
-| `web_search.py` | DuckDuckGo search, HTML-to-text, page fetching |
+| `web_search.py` | DuckDuckGo (`ddgs`) and optional SearXNG search, HTML-to-text, page fetching |
 | `tunnel.py` | Cloudflare tunnel lifecycle, binary download, status polling |
 | `git_update.py` | Git fetch/pull/status, safe dirty path classification |
 | `lifecycle.py` | Server shutdown, restart, cleanup |
@@ -557,7 +557,7 @@ The Chat tab (`section-chat`) is a streaming OpenAI-compatible chat interface th
 The backend proxies `/api/chat/completions` to `llama-server`'s `/v1/chat/completions` endpoint:
 1. Frontend sends POST with messages, sampler params, and optional web_search flag.
 2. Backend resolves the destination from its own state — see [Chat Proxy Target](#chat-proxy-target) — and refuses the request when there is none.
-3. Backend optionally performs web search via DuckDuckGo, fetches result pages, injects context into the system prompt.
+3. Backend optionally performs web search (SearXNG when configured, otherwise DuckDuckGo), fetches result pages, injects context into the system prompt.
 4. Backend proxies the request to the resolved target and streams the SSE response back to the frontend.
 5. Frontend renders markdown and tracks source citations.
 
@@ -587,7 +587,7 @@ An unattended restore passes `require_identified=True`, so the `/health` respons
 ### Web Search
 
 When the web search toggle is enabled:
-- The backend extracts the latest user message and queries DuckDuckGo.
+- The backend extracts the latest user message and queries the search backend: a self-hosted SearXNG instance when `LLAMA_GUI_SEARXNG_URL` is set (its `settings.yml` must enable `json` under `search.formats`), otherwise DuckDuckGo (`ddgs`). SearXNG is preferred when configured and falls back to `ddgs` whenever it is unset, unreachable, or returns no usable results.
 - The Chat sidebar's "Result Count" setting controls both how many search results are requested and how many result pages are read for full text.
 - Result Count defaults to 5, is persisted in `localStorage` under `llama_gui_chat_web_search_max_results`, and is clamped to 1-10 by both frontend UI constraints and the backend chat route.
 - Search context is injected into the system prompt with source citations.

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -4608,5 +4608,84 @@ class LifecycleTests(unittest.TestCase):
         mock_of.assert_called_once_with(self.ctx.paths.models)
 
 
+class SearxngSearchTests(unittest.TestCase):
+    def _fake_opener(self, payload_bytes):
+        response = mock.MagicMock()
+        response.__enter__.return_value = response
+        response.read.return_value = payload_bytes
+        opener = mock.MagicMock()
+        opener.open.return_value = response
+        return opener
+
+    def test_searxng_search_parses_results(self):
+        payload = json.dumps(
+            {"results": [{"url": "https://a.com", "title": "A", "content": "snippet A"}]}
+        ).encode()
+        opener = self._fake_opener(payload)
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://127.0.0.1:8888"), \
+                mock.patch.object(web_search.urllib.request, "build_opener", return_value=opener):
+            result = web_search.searxng_search("hello", max_results=5)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["results"], [{"title": "A", "url": "https://a.com", "snippet": "snippet A"}])
+
+    def test_searxng_search_respects_max_results(self):
+        rows = [{"url": f"https://a{i}.com", "title": f"t{i}", "content": "c"} for i in range(10)]
+        opener = self._fake_opener(json.dumps({"results": rows}).encode())
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://127.0.0.1:8888"), \
+                mock.patch.object(web_search.urllib.request, "build_opener", return_value=opener):
+            result = web_search.searxng_search("q", max_results=3)
+        self.assertEqual(len(result["results"]), 3)
+
+    def test_searxng_search_errors_when_not_configured(self):
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", ""):
+            result = web_search.searxng_search("q")
+        self.assertFalse(result["ok"])
+        self.assertIn("not configured", result["error"])
+
+    def test_searxng_search_handles_network_failure(self):
+        opener = mock.MagicMock()
+        opener.open.side_effect = OSError("boom")
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://127.0.0.1:8888"), \
+                mock.patch.object(web_search.urllib.request, "build_opener", return_value=opener):
+            result = web_search.searxng_search("q")
+        self.assertFalse(result["ok"])
+        self.assertIn("SearXNG search failed", result["error"])
+
+    def test_web_search_prefers_searxng_when_configured(self):
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://127.0.0.1:8888"), \
+                mock.patch.object(web_search, "searxng_search", return_value={"ok": True, "results": [{"url": "x"}]}) as sx, \
+                mock.patch.object(web_search, "ddgs_search") as dd:
+            result = web_search.web_search("q")
+        sx.assert_called_once()
+        dd.assert_not_called()
+        self.assertEqual(result["results"], [{"url": "x"}])
+
+    def test_web_search_falls_back_to_ddgs_when_searxng_empty(self):
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://127.0.0.1:8888"), \
+                mock.patch.object(web_search, "searxng_search", return_value={"ok": True, "results": []}) as sx, \
+                mock.patch.object(web_search, "ddgs_search", return_value={"ok": True, "results": [{"url": "d"}]}) as dd:
+            result = web_search.web_search("q")
+        sx.assert_called_once()
+        dd.assert_called_once()
+        self.assertEqual(result["results"], [{"url": "d"}])
+
+    def test_web_search_falls_back_to_ddgs_when_searxng_fails(self):
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://127.0.0.1:8888"), \
+                mock.patch.object(web_search, "searxng_search", return_value={"ok": False, "error": "down", "results": []}), \
+                mock.patch.object(web_search, "ddgs_search", return_value={"ok": True, "results": [{"url": "d"}]}) as dd:
+            result = web_search.web_search("q")
+        dd.assert_called_once()
+        self.assertEqual(result["results"], [{"url": "d"}])
+
+    def test_web_search_skips_searxng_when_unset(self):
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", ""), \
+                mock.patch.object(web_search, "searxng_search") as sx, \
+                mock.patch.object(web_search, "ddgs_search", return_value={"ok": True, "results": [{"url": "d"}]}) as dd:
+            result = web_search.web_search("q")
+        sx.assert_not_called()
+        dd.assert_called_once()
+        self.assertEqual(result["results"], [{"url": "d"}])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -4651,6 +4651,136 @@ class SearxngSearchTests(unittest.TestCase):
         self.assertFalse(result["ok"])
         self.assertIn("SearXNG search failed", result["error"])
 
+    def test_searxng_search_rejects_malformed_url(self):
+        for bad in ("not-a-url", "ftp://example.com", "http://", "://nohost"):
+            with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", bad), \
+                    mock.patch.object(web_search.urllib.request, "build_opener") as build:
+                result = web_search.searxng_search("q")
+            self.assertFalse(result["ok"], bad)
+            build.assert_not_called()  # never attempts a request for a bad URL
+
+    def test_searxng_search_handles_non_object_json(self):
+        for payload in (b"[]", b"null", b'"a string"', b"123"):
+            opener = self._fake_opener(payload)
+            with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://127.0.0.1:8888"), \
+                    mock.patch.object(web_search.urllib.request, "build_opener", return_value=opener):
+                result = web_search.searxng_search("q")
+            self.assertFalse(result["ok"], payload)
+            self.assertEqual(result["results"], [])
+
+    def test_searxng_search_requires_results_list(self):
+        opener = self._fake_opener(json.dumps({"results": {"not": "a list"}}).encode())
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://127.0.0.1:8888"), \
+                mock.patch.object(web_search.urllib.request, "build_opener", return_value=opener):
+            result = web_search.searxng_search("q")
+        self.assertFalse(result["ok"])
+
+    def test_searxng_search_skips_malformed_rows(self):
+        rows = [
+            "not a dict",
+            None,
+            {"title": "no url"},
+            {"url": "https://good.com", "title": "Good", "content": "c"},
+        ]
+        opener = self._fake_opener(json.dumps({"results": rows}).encode())
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://127.0.0.1:8888"), \
+                mock.patch.object(web_search.urllib.request, "build_opener", return_value=opener):
+            result = web_search.searxng_search("q")
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["results"], [{"title": "Good", "url": "https://good.com", "snippet": "c"}])
+
+    def test_searxng_search_falls_back_on_invalid_bracketed_url(self):
+        # urlparse("http://[bad") raises ValueError; it must be caught so the
+        # caller falls back to ddgs rather than propagating the error.
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://[bad"), \
+                mock.patch.object(web_search.urllib.request, "build_opener") as build:
+            result = web_search.searxng_search("q")
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["results"], [])
+        build.assert_not_called()  # never reaches the request when the URL is invalid
+
+    def test_searxng_search_rejects_wrong_typed_result_fields(self):
+        rows = [
+            {"url": 123, "title": "int url"},              # non-string url -> skipped
+            {"url": "ftp://x.com", "title": "bad scheme"},  # non-http(s) -> skipped
+            {"url": "http://", "title": "no host"},        # no hostname -> skipped
+            {"url": "https://ok.com", "title": 999, "content": ["not", "text"]},  # bad title/snippet types
+        ]
+        opener = self._fake_opener(json.dumps({"results": rows}).encode())
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://127.0.0.1:8888"), \
+                mock.patch.object(web_search.urllib.request, "build_opener", return_value=opener):
+            result = web_search.searxng_search("q")
+        self.assertTrue(result["ok"])
+        # Only the well-typed URL survives; its non-string title falls back to the
+        # url and its non-string snippet becomes empty.
+        self.assertEqual(
+            result["results"],
+            [{"title": "https://ok.com", "url": "https://ok.com", "snippet": ""}],
+        )
+
+    def test_searxng_search_rejects_invalid_port_result_urls(self):
+        rows = [
+            {"url": "http://example.com:bad", "title": "non-numeric port"},
+            {"url": "http://example.com:99999", "title": "out-of-range port"},
+            {"url": "https://ok.com:8443", "title": "Valid", "content": "c"},
+        ]
+        opener = self._fake_opener(json.dumps({"results": rows}).encode())
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://127.0.0.1:8888"), \
+                mock.patch.object(web_search.urllib.request, "build_opener", return_value=opener):
+            result = web_search.searxng_search("q")
+        self.assertTrue(result["ok"])
+        # Only the valid-port URL survives; the bad-port rows are skipped.
+        self.assertEqual(
+            result["results"],
+            [{"title": "Valid", "url": "https://ok.com:8443", "snippet": "c"}],
+        )
+
+    def test_searxng_search_falls_back_on_invalid_port_endpoint(self):
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://127.0.0.1:bad"), \
+                mock.patch.object(web_search.urllib.request, "build_opener") as build:
+            result = web_search.searxng_search("q")
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["results"], [])
+        build.assert_not_called()
+
+    def test_web_search_falls_back_to_ddgs_on_invalid_bracketed_url(self):
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://[bad"), \
+                mock.patch.object(web_search, "ddgs_search", return_value={"ok": True, "results": [{"url": "d"}]}) as dd:
+            result = web_search.web_search("q")
+        dd.assert_called_once()
+        self.assertEqual(result["results"], [{"url": "d"}])
+
+    def test_searxng_search_omits_safesearch_override(self):
+        captured = {}
+
+        def fake_build_opener(*args, **kwargs):
+            opener = mock.MagicMock()
+
+            def fake_open(request, timeout):
+                captured["url"] = request.full_url
+                response = mock.MagicMock()
+                response.__enter__.return_value = response
+                response.read.return_value = json.dumps({"results": []}).encode()
+                return response
+
+            opener.open.side_effect = fake_open
+            return opener
+
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://127.0.0.1:8888"), \
+                mock.patch.object(web_search.urllib.request, "build_opener", side_effect=fake_build_opener):
+            web_search.searxng_search("q")
+        self.assertIn("format=json", captured["url"])
+        self.assertNotIn("safesearch", captured["url"])
+
+    def test_web_search_falls_back_to_ddgs_on_malformed_searxng_response(self):
+        opener = self._fake_opener(b"[]")  # non-object JSON would previously raise
+        with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://127.0.0.1:8888"), \
+                mock.patch.object(web_search.urllib.request, "build_opener", return_value=opener), \
+                mock.patch.object(web_search, "ddgs_search", return_value={"ok": True, "results": [{"url": "d"}]}) as dd:
+            result = web_search.web_search("q")
+        dd.assert_called_once()
+        self.assertEqual(result["results"], [{"url": "d"}])
+
     def test_web_search_prefers_searxng_when_configured(self):
         with mock.patch.object(web_search.config, "WEB_SEARCH_SEARXNG_URL", "http://127.0.0.1:8888"), \
                 mock.patch.object(web_search, "searxng_search", return_value={"ok": True, "results": [{"url": "x"}]}) as sx, \


### PR DESCRIPTION
## Problem

Web search is hard-wired to DuckDuckGo (`ddgs`). Users who run a
[SearXNG](https://docs.searxng.org/) instance (self-hosted, privacy-friendly,
aggregates many engines) have no way to use it.

## Change

Add an **opt-in** SearXNG backend:

- Set `LLAMA_GUI_SEARXNG_URL` (e.g. `http://127.0.0.1:8888`) to enable it.
  SearXNG is queried first; `ddgs` is used as a fallback whenever SearXNG is
  unset, unreachable, or returns no results.
- The default is empty, so **existing installs are unchanged** — they keep
  using `ddgs` only.

`web_search()` becomes a small dispatcher; the previous `ddgs` implementation
moves unchanged into `ddgs_search()`, and `searxng_search()` queries the JSON
API. Public callers keep calling `web_search()` with the same signature and
result shape.

## Notes

- `searxng_search()` connects directly (empty `ProxyHandler`) because a SearXNG
  instance is expected to be a local/trusted host, so it should not be routed
  through an environment proxy.
- Results are capped at `max_results`.

## Testing

- Added `SearxngSearchTests` (8 tests): result parsing, `max_results` cap,
  not-configured and network-failure handling, and the dispatcher preferring
  SearXNG vs. falling back to `ddgs` on empty/failed/unset.
- Full backend suite passes (491 tests).
