### PR TITLE
Add optional headless-browser rendering for JavaScript pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ docs/code-audit.md
 /.claude
 /mockups
 /docs/design-docs
+
+# Persistent browser profile for headless page rendering (Playwright)
+/browser_profile

--- a/backend/config.py
+++ b/backend/config.py
@@ -83,6 +83,33 @@ WEB_SEARCH_USER_AGENT = (
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36"
 )
 
+# Headless-browser rendering (optional; requires the "playwright" package and a
+# browser). When enabled, a page whose plain HTTP fetch looks like an empty
+# JavaScript shell is re-fetched through a real headless browser so its
+# client-rendered content is captured. It degrades to the plain fetch whenever
+# Playwright is not installed, so it stays a no-op unless you opt in.
+WEB_RENDER_ENABLED = parse_bool_env(os.environ.get("LLAMA_GUI_WEB_RENDER", "1"))
+# Browser channel to drive ("msedge"/"chrome" reuse an installed browser and
+# avoid a Chromium download; set to "" to use Playwright's bundled Chromium).
+WEB_RENDER_CHANNEL = os.environ.get("LLAMA_GUI_WEB_RENDER_CHANNEL", "msedge").strip()
+# Persistent browser profile directory so an interactive login can survive
+# across fetches (log in once, reuse the session). Gitignored.
+WEB_RENDER_PROFILE_DIR = ROOT_DIR / "browser_profile"
+WEB_RENDER_TIMEOUT = 45
+# Extra settle time (ms) after network idle to let late XHR/templating finish.
+WEB_RENDER_SETTLE_MS = 1200
+# When a plain GET yields fewer than this many characters the page is treated
+# as a JS shell and rendering is attempted.
+WEB_RENDER_MIN_TEXT = 600
+# Optional CSS selectors clicked after load to dismiss cookie/consent banners or
+# popups. Empty by default; set LLAMA_GUI_WEB_RENDER_DISMISS_SELECTORS to a
+# comma-separated list to enable.
+WEB_RENDER_DISMISS_SELECTORS = tuple(
+    s.strip()
+    for s in os.environ.get("LLAMA_GUI_WEB_RENDER_DISMISS_SELECTORS", "").split(",")
+    if s.strip()
+)
+
 GITHUB_API = "https://api.github.com/repos/ggml-org/llama.cpp/releases"
 APP_REPO_URL = "https://github.com/thomas9120/LLama-GUI.git"
 # Branch that release tags are cut from. Auto-update always compares against

--- a/backend/routes/chat.py
+++ b/backend/routes/chat.py
@@ -10,6 +10,7 @@ from backend import config
 from backend.http import SseWriter, sanitize_sse_error
 from backend.services import chat as chat_service
 from backend.services import external_server
+from backend.services import web_render
 from backend.services import web_search
 
 
@@ -78,7 +79,7 @@ def completions(request, response, ctx):
                 if host.startswith("www."):
                     host = host[4:]
                 writer.write({"type": "web_status", "content": f"Reading: {host}"})
-                fetched_pages[url] = web_search.fetch_page_text(url, ssl_context=ctx.services.ssl_context)
+                fetched_pages[url] = web_render.fetch_page_smart(url, ssl_context=ctx.services.ssl_context)
 
             context, sources = chat_service.build_search_context(all_results, fetched_pages)
             if not context:

--- a/backend/routes/search.py
+++ b/backend/routes/search.py
@@ -1,6 +1,7 @@
 """Routes for web search and page fetching."""
 
 from backend import config
+from backend.services import web_render
 from backend.services import web_search
 
 
@@ -9,7 +10,7 @@ def search(request, response, ctx):
     query = body.get("query", "")
     url = body.get("url", "")
     if url:
-        response.json(web_search.fetch_page_text(url, ssl_context=ctx.services.ssl_context))
+        response.json(web_render.fetch_page_smart(url, ssl_context=ctx.services.ssl_context))
         return
     try:
         max_results = int(body.get("max_results") or config.WEB_SEARCH_MAX_RESULTS)

--- a/backend/services/web_render.py
+++ b/backend/services/web_render.py
@@ -1,0 +1,160 @@
+"""Headless-browser page rendering using Playwright.
+
+Single-page applications build their content with JavaScript after the initial
+HTML loads, so a plain HTTP GET only ever sees an empty shell. This module opens
+such pages in a real headless browser, lets the JavaScript run, optionally
+dismisses cookie/consent popups, and returns the fully-rendered text.
+
+Playwright is imported lazily so the rest of the backend keeps working when it
+is not installed; callers fall back to the plain HTTP fetch in that case.
+"""
+
+import re
+import threading
+import urllib.parse
+from typing import Any, Optional
+
+from backend import config
+from backend.services import web_search
+
+# Persistent browser profiles cannot be opened concurrently from the same
+# directory, so serialise render calls.
+_RENDER_LOCK = threading.Lock()
+
+
+def is_available() -> bool:
+    try:
+        import playwright  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def _dismiss_popups(page: Any) -> None:
+    for selector in config.WEB_RENDER_DISMISS_SELECTORS:
+        try:
+            locator = page.locator(selector).first
+            if locator.count() > 0 and locator.is_visible():
+                locator.click(timeout=1500)
+                page.wait_for_timeout(200)
+        except Exception:
+            continue
+
+
+def _extract_text(page: Any) -> str:
+    """Return clean visible text. inner_text already yields rendered text; only
+    fall back to HTML parsing if it fails."""
+    try:
+        raw = page.inner_text("body")
+    except Exception:
+        return web_search.html_to_readable_text(page.content())
+    raw = re.sub(r"[ \t\r\f\v]+", " ", raw)
+    raw = re.sub(r"\n\s+", "\n", raw)
+    raw = re.sub(r"\n{3,}", "\n\n", raw)
+    return raw.strip()
+
+
+def render_page(
+    url: Any,
+    max_chars: int = config.WEB_SEARCH_PAGE_CHARS,
+    timeout: int = config.WEB_RENDER_TIMEOUT,
+    click_selectors: Optional[list[str]] = None,
+    headless: bool = True,
+) -> dict[str, Any]:
+    parsed = urllib.parse.urlparse(str(url or "").strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return {"ok": False, "error": "Blocked: only http/https URLs can be rendered."}
+
+    # Enforce the same SSRF public-address guard the plain fetch uses.
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    addresses, reason = web_search.resolve_public_addresses(parsed.hostname, port)
+    if addresses is None:
+        return {"ok": False, "error": reason}
+
+    try:
+        from playwright.sync_api import sync_playwright
+    except Exception as exc:
+        return {"ok": False, "error": f"Rendering unavailable: Playwright not installed ({exc})."}
+
+    launch_kwargs: dict[str, Any] = {"headless": headless}
+    if config.WEB_RENDER_CHANNEL:
+        launch_kwargs["channel"] = config.WEB_RENDER_CHANNEL
+
+    config.WEB_RENDER_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
+
+    with _RENDER_LOCK:
+        context = None
+        try:
+            with sync_playwright() as p:
+                try:
+                    context = p.chromium.launch_persistent_context(
+                        str(config.WEB_RENDER_PROFILE_DIR), **launch_kwargs
+                    )
+                except Exception:
+                    # Fall back to bundled Chromium if the requested channel is missing.
+                    if "channel" in launch_kwargs:
+                        launch_kwargs.pop("channel", None)
+                        context = p.chromium.launch_persistent_context(
+                            str(config.WEB_RENDER_PROFILE_DIR), **launch_kwargs
+                        )
+                    else:
+                        raise
+
+                page = context.pages[0] if context.pages else context.new_page()
+                page.set_default_timeout(timeout * 1000)
+                page.goto(str(url), wait_until="domcontentloaded", timeout=timeout * 1000)
+                try:
+                    page.wait_for_load_state("networkidle", timeout=timeout * 1000)
+                except Exception:
+                    pass
+                page.wait_for_timeout(config.WEB_RENDER_SETTLE_MS)
+
+                _dismiss_popups(page)
+                for selector in click_selectors or []:
+                    try:
+                        page.locator(selector).first.click(timeout=3000)
+                        page.wait_for_timeout(config.WEB_RENDER_SETTLE_MS)
+                    except Exception:
+                        continue
+
+                final_url = page.url
+                text = _extract_text(page)
+        except Exception as exc:
+            return {"ok": False, "error": f"Failed to render URL: {exc}"}
+        finally:
+            if context is not None:
+                try:
+                    context.close()
+                except Exception:
+                    pass
+
+    text = (text or "").strip()
+    if len(text) > max_chars:
+        text = text[:max_chars].rstrip() + f"\n\n... (truncated, {len(text)} chars total)"
+    return {"ok": True, "url": final_url, "text": text or "(page rendered no readable text)"}
+
+
+def fetch_page_smart(
+    url: Any,
+    ssl_context: Optional[Any] = None,
+    max_chars: int = config.WEB_SEARCH_PAGE_CHARS,
+) -> dict[str, Any]:
+    """Fetch a page's readable text, upgrading to a headless browser when the
+    plain fetch looks like an empty JavaScript shell.
+
+    This is a safe drop-in for web_search.fetch_page_text: it falls back to the
+    plain fetch whenever rendering is disabled, unavailable, or unsuccessful.
+    """
+    parsed = urllib.parse.urlparse(str(url or "").strip())
+    render_ok = config.WEB_RENDER_ENABLED and is_available() and parsed.scheme in {"http", "https"}
+    if not render_ok:
+        return web_search.fetch_page_text(url, max_chars=max_chars, ssl_context=ssl_context)
+
+    plain = web_search.fetch_page_text(url, max_chars=max_chars, ssl_context=ssl_context)
+    if plain.get("ok") and len(plain.get("text", "")) >= config.WEB_RENDER_MIN_TEXT:
+        return plain
+    rendered = render_page(url, max_chars=max_chars)
+    if rendered.get("ok"):
+        return rendered
+    return plain if plain.get("ok") else rendered

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -3,6 +3,7 @@ import hashlib
 import io
 import json
 import subprocess
+import sys
 import tempfile
 import unittest
 import urllib.error
@@ -22,6 +23,7 @@ from backend.services import git_update as srv
 from backend.services import lifecycle as lifecycle_service
 from backend.services import llama_manager
 from backend.services import process_manager
+from backend.services import web_render
 from backend.services import web_search
 
 
@@ -2351,17 +2353,17 @@ class ExtractedRouteTests(unittest.TestCase):
             response = DummyResponse()
 
             with mock.patch.object(
-                web_search,
-                "fetch_page_text",
+                web_render,
+                "fetch_page_smart",
                 return_value={"ok": True, "url": "https://example.com", "text": "Example"},
-            ) as fetch_page_text:
+            ) as fetch_page_smart:
                 search.search(
                     Request("POST", "/api/web-search", "", {}, body={"url": "https://example.com"}),
                     response,
                     ctx,
                 )
 
-            fetch_page_text.assert_called_once_with("https://example.com", ssl_context=ctx.services.ssl_context)
+            fetch_page_smart.assert_called_once_with("https://example.com", ssl_context=ctx.services.ssl_context)
             self.assertEqual(response.payload["text"], "Example")
 
     def test_chat_search_context_includes_sources(self):
@@ -4606,6 +4608,90 @@ class LifecycleTests(unittest.TestCase):
             )
         self.assertEqual(self.response.payload, {"opened": True})
         mock_of.assert_called_once_with(self.ctx.paths.models)
+
+
+class WebRenderTests(unittest.TestCase):
+    def test_is_available_returns_bool(self):
+        self.assertIsInstance(web_render.is_available(), bool)
+
+    def test_fetch_page_smart_passthrough_when_disabled(self):
+        plain = {"ok": True, "text": "hi"}
+        with mock.patch.object(web_render.config, "WEB_RENDER_ENABLED", False), \
+                mock.patch.object(web_render.web_search, "fetch_page_text", return_value=plain) as ft, \
+                mock.patch.object(web_render, "render_page") as rp:
+            result = web_render.fetch_page_smart("https://example.com")
+        self.assertEqual(result, plain)
+        ft.assert_called_once()
+        rp.assert_not_called()
+
+    def test_fetch_page_smart_passthrough_when_unavailable(self):
+        plain = {"ok": True, "text": "hi"}
+        with mock.patch.object(web_render.config, "WEB_RENDER_ENABLED", True), \
+                mock.patch.object(web_render, "is_available", return_value=False), \
+                mock.patch.object(web_render.web_search, "fetch_page_text", return_value=plain) as ft, \
+                mock.patch.object(web_render, "render_page") as rp:
+            result = web_render.fetch_page_smart("https://example.com")
+        self.assertEqual(result, plain)
+        ft.assert_called_once()
+        rp.assert_not_called()
+
+    def test_fetch_page_smart_returns_plain_when_enough_text(self):
+        plain = {"ok": True, "text": "x" * 50}
+        with mock.patch.object(web_render.config, "WEB_RENDER_ENABLED", True), \
+                mock.patch.object(web_render.config, "WEB_RENDER_MIN_TEXT", 10), \
+                mock.patch.object(web_render, "is_available", return_value=True), \
+                mock.patch.object(web_render.web_search, "fetch_page_text", return_value=plain), \
+                mock.patch.object(web_render, "render_page") as rp:
+            result = web_render.fetch_page_smart("https://example.com")
+        self.assertEqual(result, plain)
+        rp.assert_not_called()
+
+    def test_fetch_page_smart_renders_when_shell(self):
+        plain = {"ok": True, "text": "x"}
+        rendered = {"ok": True, "text": "y" * 100, "url": "https://example.com"}
+        with mock.patch.object(web_render.config, "WEB_RENDER_ENABLED", True), \
+                mock.patch.object(web_render.config, "WEB_RENDER_MIN_TEXT", 10), \
+                mock.patch.object(web_render, "is_available", return_value=True), \
+                mock.patch.object(web_render.web_search, "fetch_page_text", return_value=plain), \
+                mock.patch.object(web_render, "render_page", return_value=rendered) as rp:
+            result = web_render.fetch_page_smart("https://example.com")
+        rp.assert_called_once()
+        self.assertEqual(result, rendered)
+
+    def test_fetch_page_smart_falls_back_to_plain_when_render_fails(self):
+        plain = {"ok": True, "text": "x"}
+        rendered = {"ok": False, "error": "boom"}
+        with mock.patch.object(web_render.config, "WEB_RENDER_ENABLED", True), \
+                mock.patch.object(web_render.config, "WEB_RENDER_MIN_TEXT", 10), \
+                mock.patch.object(web_render, "is_available", return_value=True), \
+                mock.patch.object(web_render.web_search, "fetch_page_text", return_value=plain), \
+                mock.patch.object(web_render, "render_page", return_value=rendered):
+            result = web_render.fetch_page_smart("https://example.com")
+        self.assertEqual(result, plain)
+
+    def test_render_page_blocks_non_http_scheme(self):
+        result = web_render.render_page("file:///etc/passwd")
+        self.assertFalse(result["ok"])
+        self.assertIn("only http/https", result["error"])
+
+    def test_render_page_blocks_non_public_address(self):
+        with mock.patch.object(
+            web_render.web_search,
+            "resolve_public_addresses",
+            return_value=(None, "Blocked: refusing to fetch non-public address 127.0.0.1."),
+        ):
+            result = web_render.render_page("https://internal.example")
+        self.assertFalse(result["ok"])
+        self.assertIn("non-public address", result["error"])
+
+    def test_render_page_reports_missing_playwright(self):
+        addresses = [(2, 1, 6, "", ("93.184.216.34", 443))]
+        with mock.patch.object(
+            web_render.web_search, "resolve_public_addresses", return_value=(addresses, "")
+        ), mock.patch.dict(sys.modules, {"playwright.sync_api": None}):
+            result = web_render.render_page("https://example.com")
+        self.assertFalse(result["ok"])
+        self.assertIn("Playwright not installed", result["error"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Heads-up for the maintainer

I'm not sure this functionality is something you want in the project — it adds
an **optional** dependency on [Playwright](https://playwright.dev/python/) and a
browser. It's built to be completely opt-in and to change nothing unless a user
installs Playwright, but please feel free to close this if it's out of scope.
Happy to adjust the approach.

## Problem

Single-page apps build their content with JavaScript after the initial HTML
loads, so the current plain HTTP fetch (`fetch_page_text`) only ever sees an
empty shell for those URLs.

## Change

Add `web_render.fetch_page_smart()`, a safe drop-in for `fetch_page_text`:

- Does the normal plain fetch first. If the result looks like a JS shell
  (fewer than `WEB_RENDER_MIN_TEXT` characters), it re-fetches through a
  headless browser (Playwright) so the client-rendered text is captured.
- Wired in at the **two existing** URL-fetch call sites — the chat web-search
  page reads and the `/api/web-search` `url` branch. No new endpoints.

## Safe by default / opt-in

- Playwright is imported lazily. When it isn't installed, or
  `LLAMA_GUI_WEB_RENDER=0`, `fetch_page_smart` **degrades to the existing plain
  fetch** — so there is no behaviour change unless a user opts in.
- Rendering enforces the **same SSRF public-address guard** as the plain fetch
  (`resolve_public_addresses`); non-public/unresolvable hosts are blocked.
- Uses a persistent browser profile (gitignored) so an interactive login can be
  reused across fetches.
- Can dismiss cookie/consent popups via optional CSS selectors
  (`LLAMA_GUI_WEB_RENDER_DISMISS_SELECTORS`), **empty by default**.

## Config (all optional)

| Env var | Default | Purpose |
|---|---|---|
| `LLAMA_GUI_WEB_RENDER` | `1` | Enable smart rendering (no-op without Playwright) |
| `LLAMA_GUI_WEB_RENDER_CHANNEL` | `msedge` | Browser channel; `""` = bundled Chromium |
| `LLAMA_GUI_WEB_RENDER_DISMISS_SELECTORS` | *(empty)* | Comma-separated selectors to click after load |

## Testing

- Added `WebRenderTests` (9 tests): plain-fetch passthrough when
  disabled/unavailable, render-only-on-shell heuristic, fallback when render
  fails, and the render guards (non-http scheme, SSRF block, Playwright missing).
- Updated the existing search-route test for the new delegation.
- Full backend suite passes (492 tests). Tests do not require a browser.
