### PR TITLE
Read pasted URLs and local files directly in chat (no Web Search toggle)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -83,6 +83,18 @@ WEB_SEARCH_USER_AGENT = (
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36"
 )
 
+# Local files whose text may be read into chat context, by extension. A file the
+# user references by path in a chat message is read and added as context. PDF and
+# DOCX need the optional pypdf / python-docx packages.
+WEB_FILE_MAX_BYTES = 8 * 1024 * 1024
+WEB_FILE_TEXT_SUFFIXES = (
+    ".txt", ".md", ".markdown", ".json", ".csv", ".tsv", ".log",
+    ".html", ".htm", ".xml", ".yaml", ".yml", ".rtf",
+)
+WEB_FILE_IMAGE_SUFFIXES = (
+    ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tif", ".tiff",
+)
+
 GITHUB_API = "https://api.github.com/repos/ggml-org/llama.cpp/releases"
 APP_REPO_URL = "https://github.com/thomas9120/LLama-GUI.git"
 # Branch that release tags are cut from. Auto-update always compares against

--- a/backend/routes/chat.py
+++ b/backend/routes/chat.py
@@ -10,6 +10,7 @@ from backend import config
 from backend.http import SseWriter, sanitize_sse_error
 from backend.services import chat as chat_service
 from backend.services import external_server
+from backend.services import local_files
 from backend.services import web_search
 
 
@@ -48,39 +49,99 @@ def completions(request, response, ctx):
         messages = list(body.get("messages") or [])
         proxied_messages = messages
 
-        if body.get("web_search"):
+        # Detect content the user referenced directly -- a pasted URL and/or a
+        # local file path -- so it can be read without toggling Web Search.
+        latest_user = chat_service.get_latest_user_message(messages)
+        pasted_urls = chat_service.extract_urls(latest_user)
+        file_paths = local_files.extract_file_paths(latest_user)
+        refs_from_history = False
+        if not pasted_urls and not file_paths and chat_service.references_previous_page(latest_user):
+            history_urls = chat_service.find_recent_urls(messages)
+            history_files = local_files.find_recent_file_paths(messages)
+            if history_urls or history_files:
+                pasted_urls = history_urls
+                file_paths = history_files
+                refs_from_history = True
+        has_direct_content = bool(pasted_urls or file_paths)
+
+        # Run the read/search pipeline when Web Search is on, or whenever the
+        # user referenced a URL/file (so reading "just works" without the toggle).
+        if body.get("web_search") or has_direct_content:
             max_results = get_web_search_result_count(body)
-            latest_user = chat_service.get_latest_user_message(messages)
-            queries = chat_service.build_search_queries(latest_user)
-            if not queries:
-                writer.write({"error": {"message": "Add a text question to search the web for."}})
-                writer.write("[DONE]")
-                return
             all_results = []
             fetched_pages = {}
 
-            for query in queries:
-                writer.write({"type": "web_status", "content": f"Searching: {query}"})
-                search_response = web_search.web_search(query, max_results=max_results)
-                if not search_response.get("ok"):
-                    writer.write({"error": {"message": search_response.get("error", "Search unavailable")}})
+            if has_direct_content:
+                if refs_from_history:
+                    writer.write(
+                        {
+                            "type": "web_status",
+                            "content": "Using the link/file from earlier in the conversation.",
+                        }
+                    )
+                for file_path in file_paths[:max_results]:
+                    name = file_path.rsplit("\\", 1)[-1].rsplit("/", 1)[-1]
+                    writer.write({"type": "web_status", "content": f"Reading file: {name}"})
+                    file_result = local_files.read_local_file(file_path)
+                    key = f"file:///{file_path}"
+                    fetched_pages[key] = file_result
+                    if not file_result.get("ok"):
+                        writer.write(
+                            {
+                                "type": "web_status",
+                                "content": f"Could not read {name}: {str(file_result.get('error', ''))[:160]}",
+                            }
+                        )
+                    all_results.append({"title": file_path, "url": key, "snippet": ""})
+                for url in pasted_urls[:max_results]:
+                    host = urllib.parse.urlparse(url).hostname or url
+                    if host.startswith("www."):
+                        host = host[4:]
+                    writer.write({"type": "web_status", "content": f"Reading: {host}"})
+                    page = web_search.fetch_page_text(url, ssl_context=ctx.services.ssl_context)
+                    fetched_pages[url] = page
+                    if not page.get("ok"):
+                        writer.write(
+                            {
+                                "type": "web_status",
+                                "content": f"Could not read {host}: {str(page.get('error', ''))[:160]}",
+                            }
+                        )
+                    all_results.append({"title": url, "url": url, "snippet": ""})
+            else:
+                queries = chat_service.build_search_queries(latest_user)
+                if not queries:
+                    writer.write({"error": {"message": "Add a text question to search the web for."}})
                     writer.write("[DONE]")
                     return
-                for result in search_response.get("results", []):
-                    if result.get("url") and all(r.get("url") != result.get("url") for r in all_results):
-                        all_results.append(result)
-                    if len(all_results) >= max_results:
-                        break
 
-            for result in all_results[:max_results]:
-                url = result.get("url", "")
-                host = urllib.parse.urlparse(url).hostname or url
-                if host.startswith("www."):
-                    host = host[4:]
-                writer.write({"type": "web_status", "content": f"Reading: {host}"})
-                fetched_pages[url] = web_search.fetch_page_text(url, ssl_context=ctx.services.ssl_context)
+                for query in queries:
+                    writer.write({"type": "web_status", "content": f"Searching: {query}"})
+                    search_response = web_search.web_search(query, max_results=max_results)
+                    if not search_response.get("ok"):
+                        writer.write({"error": {"message": search_response.get("error", "Search unavailable")}})
+                        writer.write("[DONE]")
+                        return
+                    for result in search_response.get("results", []):
+                        if result.get("url") and all(r.get("url") != result.get("url") for r in all_results):
+                            all_results.append(result)
+                        if len(all_results) >= max_results:
+                            break
 
-            context, sources = chat_service.build_search_context(all_results, fetched_pages)
+                for result in all_results[:max_results]:
+                    url = result.get("url", "")
+                    host = urllib.parse.urlparse(url).hostname or url
+                    if host.startswith("www."):
+                        host = host[4:]
+                    writer.write({"type": "web_status", "content": f"Reading: {host}"})
+                    fetched_pages[url] = web_search.fetch_page_text(url, ssl_context=ctx.services.ssl_context)
+
+            # Direct URL/file reads get a larger per-source budget than search
+            # snippets so a full page or document (e.g. a CV) reaches the model.
+            max_source_chars = 12000 if has_direct_content else 3500
+            context, sources = chat_service.build_search_context(
+                all_results, fetched_pages, max_source_chars=max_source_chars
+            )
             if not context:
                 writer.write({"error": {"message": "Search returned no usable sources."}})
                 writer.write("[DONE]")

--- a/backend/services/chat.py
+++ b/backend/services/chat.py
@@ -56,7 +56,65 @@ def build_search_queries(user_text: Any) -> list[str]:
     return [query] if query else []
 
 
-def build_search_context(search_results: Sequence[Mapping[str, Any]], fetched_pages: Mapping[str, Mapping[str, Any]]):
+_URL_PATTERN = re.compile(r"https?://[^\s`'\"<>]+", re.IGNORECASE)
+
+
+def extract_urls(text: Any) -> list[str]:
+    """Extract http(s) URLs from free text.
+
+    Stops at whitespace and common wrapping characters (backticks, quotes,
+    angle brackets) so a URL pasted as `url`, "url", or <url> is captured
+    cleanly, and trims trailing sentence punctuation.
+    """
+    urls: list[str] = []
+    for match in _URL_PATTERN.findall(str(text or "")):
+        cleaned = match.rstrip(".,;:!?)]}>`'\"")
+        if cleaned and cleaned not in urls:
+            urls.append(cleaned)
+    return urls
+
+
+def find_recent_urls(messages: Sequence[Mapping[str, Any]], max_lookback: int = 10) -> list[str]:
+    """Return URLs from the most recent conversation message that contains any.
+
+    Scans newest-first (across user and assistant messages) so a follow-up like
+    "try again" can reuse a link mentioned earlier in the chat when the current
+    message itself has no URL.
+    """
+    for msg in list(reversed(list(messages or [])))[:max_lookback]:
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            urls = extract_urls(content)
+            if urls:
+                return urls
+    return []
+
+
+_REFERENCE_HINTS = (
+    "again", "retry", "the page", "that page", "this page", "the site",
+    "the website", "that website", "the url", "that url", "the link",
+    "that link", "the content", "the file", "that file", "this file",
+    "the document", "the pdf", "the cv", "my profile", "my cv", "fetch it",
+    "fetch the", "retrieve it", "retrieve the", "read it", "read the",
+    "same url", "same link", "same page", "load it", "open it", "view it",
+    "look at it",
+)
+
+
+def references_previous_page(text: Any) -> bool:
+    """Heuristic: does a URL-less message refer back to a page/file mentioned
+    earlier? Used to decide whether a follow-up such as "could you try again?"
+    should reuse an earlier link/file instead of running a fresh text search.
+    """
+    low = str(text or "").lower()
+    return any(hint in low for hint in _REFERENCE_HINTS)
+
+
+def build_search_context(
+    search_results: Sequence[Mapping[str, Any]],
+    fetched_pages: Mapping[str, Mapping[str, Any]],
+    max_source_chars: int = 3500,
+):
     sources = []
     context_parts = []
     for idx, result in enumerate(search_results, 1):
@@ -68,8 +126,8 @@ def build_search_context(search_results: Sequence[Mapping[str, Any]], fetched_pa
         if not text:
             text = snippet
         text = (text or "").strip()
-        if len(text) > 3500:
-            text = text[:3500].rstrip() + "\n... (source excerpt truncated)"
+        if len(text) > max_source_chars:
+            text = text[:max_source_chars].rstrip() + "\n... (source excerpt truncated)"
         sources.append({"index": idx, "title": title, "url": url, "snippet": snippet})
         context_parts.append(
             f"[{idx}] {title}\nURL: {url}\nSnippet: {snippet}\nContent excerpt:\n{text}"

--- a/backend/services/local_files.py
+++ b/backend/services/local_files.py
@@ -1,0 +1,157 @@
+"""Read local files into chat context.
+
+Lets the assistant ingest a file the user references by path in a chat message
+(for example an exported CV). Plain-text formats are read directly; PDF and DOCX
+are supported when the optional pypdf / python-docx packages are installed.
+"""
+
+import re
+from pathlib import Path
+from typing import Any
+
+from backend import config
+
+# File paths referenced in chat, in three forms:
+#  - quoted/backticked (may contain spaces): "C:\A\my file.txt"
+#  - unquoted ending in a file extension, allowing spaces up to that extension:
+#    C:\Users\me\OneDrive - Team\Report 2026.pdf
+#  - UNC paths: \\server\share\file.ext
+# The drive-letter rules never match URL schemes such as "https://".
+_QUOTED_PATH = re.compile(
+    r"""["'`]\s*([A-Za-z]:[\\/][^"'`\r\n]+|\\\\[^"'`\r\n]+?)\s*["'`]"""
+)
+# Lazily match from a drive letter up to the first ".ext" that is followed by a
+# natural boundary (whitespace, quote, bracket, end, or trailing punctuation).
+# This captures unquoted Windows paths that contain spaces.
+_UNQUOTED_PATH = re.compile(
+    r"""(?<![A-Za-z0-9])(
+        [A-Za-z]:[\\/](?![\\/])[^\r\n"'`<>|?*]*?\.[A-Za-z0-9]{1,8}
+        |
+        \\\\[^\r\n"'`<>|?*]*?\.[A-Za-z0-9]{1,8}
+    )(?=$|["'`\s)\]}>,;:!?]|\.\s|\.$)""",
+    re.VERBOSE,
+)
+_HAS_EXTENSION = re.compile(r"\.[A-Za-z0-9]{1,8}$")
+
+
+def extract_file_paths(text: Any) -> list[str]:
+    """Extract candidate local file paths (with a file extension) from text.
+
+    Quoted/backticked paths may contain spaces; unquoted paths stop at
+    whitespace. URL schemes like ``https://`` are deliberately not matched.
+    """
+    raw = str(text or "")
+    found: list[str] = []
+
+    def add(candidate: str) -> None:
+        cleaned = candidate.strip().strip("\"'`").rstrip(".,;:!?)]}>")
+        if not cleaned or not _HAS_EXTENSION.search(cleaned):
+            return
+        # Skip a truncated fragment of a path already captured (e.g. an
+        # unquoted match that stopped at a space inside a quoted path).
+        if any(existing.startswith(cleaned) for existing in found):
+            return
+        if cleaned not in found:
+            found.append(cleaned)
+
+    for match in _QUOTED_PATH.findall(raw):
+        add(match)
+    for match in _UNQUOTED_PATH.findall(raw):
+        add(match)
+    return found
+
+
+def find_recent_file_paths(messages: Any, max_lookback: int = 10) -> list[str]:
+    """Return file paths from the most recent message that contains any.
+
+    Lets a follow-up like "try again to read the file" reuse a path mentioned
+    earlier in the conversation (by the user or quoted back by the assistant).
+    """
+    for msg in list(reversed(list(messages or [])))[:max_lookback]:
+        content = msg.get("content", "") if isinstance(msg, dict) else ""
+        if isinstance(content, str):
+            paths = extract_file_paths(content)
+            if paths:
+                return paths
+    return []
+
+
+def _read_pdf(path: Path) -> tuple[bool, str]:
+    try:
+        from pypdf import PdfReader
+    except Exception:
+        try:
+            from PyPDF2 import PdfReader  # type: ignore
+        except Exception:
+            return False, "PDF support unavailable: install pypdf to read PDF files."
+    try:
+        reader = PdfReader(str(path))
+        parts = [page.extract_text() or "" for page in reader.pages]
+        return True, "\n".join(parts).strip()
+    except Exception as exc:
+        return False, f"Failed to read PDF: {exc}"
+
+
+def _read_docx(path: Path) -> tuple[bool, str]:
+    try:
+        import docx  # python-docx
+    except Exception:
+        return False, "DOCX support unavailable: install python-docx to read .docx files."
+    try:
+        document = docx.Document(str(path))
+        return True, "\n".join(p.text for p in document.paragraphs).strip()
+    except Exception as exc:
+        return False, f"Failed to read DOCX: {exc}"
+
+
+def _read_image_text(path: Path) -> tuple[bool, str]:
+    """Extract text from an image.
+
+    Reading text from an image needs OCR, which is not included here; return a
+    helpful message so the user knows to export the content as text/PDF instead.
+    """
+    return False, (
+        f"{path.suffix} is an image; reading text from images requires OCR, "
+        "which is not available in this build. Export the content as PDF or text."
+    )
+
+
+def read_local_file(path: Any, max_chars: int = config.WEB_SEARCH_PAGE_CHARS) -> dict[str, Any]:
+    try:
+        file_path = Path(str(path)).expanduser()
+    except Exception as exc:
+        return {"ok": False, "error": f"Invalid path: {exc}"}
+
+    if not file_path.exists() or not file_path.is_file():
+        return {"ok": False, "error": f"File not found: {file_path}"}
+    try:
+        size = file_path.stat().st_size
+    except OSError as exc:
+        return {"ok": False, "error": f"Cannot stat file: {exc}"}
+    if size > config.WEB_FILE_MAX_BYTES:
+        return {"ok": False, "error": f"File too large ({size} bytes; limit {config.WEB_FILE_MAX_BYTES})."}
+
+    suffix = file_path.suffix.lower()
+    if suffix == ".pdf":
+        ok, text = _read_pdf(file_path)
+    elif suffix == ".docx":
+        ok, text = _read_docx(file_path)
+    elif suffix in config.WEB_FILE_TEXT_SUFFIXES:
+        try:
+            text = file_path.read_text(encoding="utf-8", errors="replace")
+            ok = True
+        except Exception as exc:
+            ok, text = False, f"Failed to read file: {exc}"
+    elif suffix in config.WEB_FILE_IMAGE_SUFFIXES:
+        ok, text = _read_image_text(file_path)
+    else:
+        return {"ok": False, "error": f"Unsupported file type: {suffix or '(none)'}"}
+
+    if not ok:
+        return {"ok": False, "error": text}
+    text = (text or "").strip()
+    if not text:
+        return {"ok": False, "error": "No text could be extracted from the file."}
+    if len(text) > max_chars:
+        text = text[:max_chars].rstrip() + f"\n\n... (truncated, {len(text)} chars total)"
+    return {"ok": True, "path": str(file_path), "text": text}

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -21,6 +21,7 @@ from backend.services import external_server as external_server_service
 from backend.services import git_update as srv
 from backend.services import lifecycle as lifecycle_service
 from backend.services import llama_manager
+from backend.services import local_files
 from backend.services import process_manager
 from backend.services import web_search
 
@@ -4606,6 +4607,162 @@ class LifecycleTests(unittest.TestCase):
             )
         self.assertEqual(self.response.payload, {"opened": True})
         mock_of.assert_called_once_with(self.ctx.paths.models)
+
+
+class LocalFilesTests(unittest.TestCase):
+    def test_extract_file_paths_quoted_unquoted_and_unc(self):
+        text = (
+            'see "C:\\Users\\me\\my file.txt" and '
+            'C:\\Users\\me\\OneDrive - Team\\Report 2026.pdf and '
+            '\\\\server\\share\\doc.docx'
+        )
+        paths = local_files.extract_file_paths(text)
+        self.assertIn("C:\\Users\\me\\my file.txt", paths)
+        self.assertIn("C:\\Users\\me\\OneDrive - Team\\Report 2026.pdf", paths)
+        self.assertIn("\\\\server\\share\\doc.docx", paths)
+
+    def test_extract_file_paths_ignores_urls(self):
+        self.assertEqual(local_files.extract_file_paths("see https://example.com/a.txt"), [])
+
+    def test_find_recent_file_paths_scans_newest_first(self):
+        messages = [
+            {"role": "user", "content": "read C:\\a\\old.txt"},
+            {"role": "assistant", "content": "no path here"},
+            {"role": "user", "content": "and C:\\b\\new.pdf"},
+        ]
+        self.assertEqual(local_files.find_recent_file_paths(messages), ["C:\\b\\new.pdf"])
+
+    def test_read_local_file_reads_text(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "note.txt"
+            p.write_text("hello world", encoding="utf-8")
+            result = local_files.read_local_file(str(p))
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["text"], "hello world")
+
+    def test_read_local_file_not_found(self):
+        result = local_files.read_local_file("C:\\does\\not\\exist.txt")
+        self.assertFalse(result["ok"])
+        self.assertIn("File not found", result["error"])
+
+    def test_read_local_file_too_large(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "big.txt"
+            p.write_text("x" * 50, encoding="utf-8")
+            with mock.patch.object(local_files.config, "WEB_FILE_MAX_BYTES", 10):
+                result = local_files.read_local_file(str(p))
+        self.assertFalse(result["ok"])
+        self.assertIn("too large", result["error"])
+
+    def test_read_local_file_image_reports_needs_ocr(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "shot.png"
+            p.write_bytes(b"\x89PNG\r\n\x1a\n fake")
+            result = local_files.read_local_file(str(p))
+        self.assertFalse(result["ok"])
+        self.assertIn("requires OCR", result["error"])
+
+    def test_read_local_file_unsupported_type(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "data.bin"
+            p.write_bytes(b"\x00\x01\x02")
+            result = local_files.read_local_file(str(p))
+        self.assertFalse(result["ok"])
+        self.assertIn("Unsupported file type", result["error"])
+
+
+class ChatServiceReadHelperTests(unittest.TestCase):
+    def test_extract_urls_trims_wrappers_and_punctuation(self):
+        self.assertEqual(
+            chat_service.extract_urls("see `https://a.com/x`, and <https://b.com/y>."),
+            ["https://a.com/x", "https://b.com/y"],
+        )
+
+    def test_find_recent_urls_scans_newest_first(self):
+        messages = [
+            {"role": "user", "content": "https://old.com"},
+            {"role": "assistant", "content": "no link"},
+            {"role": "user", "content": "try https://new.com/page"},
+        ]
+        self.assertEqual(chat_service.find_recent_urls(messages), ["https://new.com/page"])
+
+    def test_references_previous_page(self):
+        self.assertTrue(chat_service.references_previous_page("could you try again?"))
+        self.assertTrue(chat_service.references_previous_page("read the file please"))
+        self.assertFalse(chat_service.references_previous_page("what is the capital of France?"))
+
+    def test_build_search_context_respects_max_source_chars(self):
+        results = [{"title": "T", "url": "u", "snippet": ""}]
+        pages = {"u": {"ok": True, "text": "y" * 100}}
+        context, _ = chat_service.build_search_context(results, pages, max_source_chars=10)
+        self.assertIn("source excerpt truncated", context)
+        context2, _ = chat_service.build_search_context(results, pages, max_source_chars=1000)
+        self.assertNotIn("source excerpt truncated", context2)
+
+
+class ChatDirectContentRouteTests(unittest.TestCase):
+    def test_reads_local_file_without_web_search(self):
+        captured = {}
+
+        def fake_urlopen(req, timeout):
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return FakeSseUpstream([b"data: [DONE]\n\n"])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            activate_llama_runtime(ctx)
+            response = DummySseResponse()
+            with mock.patch.object(
+                chat.local_files, "read_local_file",
+                return_value={"ok": True, "path": "C:\\t\\cv.txt", "text": "RESUME BODY"},
+            ) as read_file, mock.patch.object(chat.web_search, "web_search") as ws, \
+                    mock.patch.object(
+                        chat.chat_service, "get_local_chat_api_url",
+                        return_value="http://127.0.0.1:8080/v1/chat/completions",
+                    ), mock.patch.object(chat.urllib.request, "urlopen", side_effect=fake_urlopen):
+                chat.completions(
+                    Request("POST", "/api/chat/completions", "", {}, body={
+                        "messages": [{"role": "user", "content": "summarize C:\\t\\cv.txt"}],
+                    }),
+                    response, ctx,
+                )
+
+        read_file.assert_called_once()
+        ws.assert_not_called()
+        system_message = captured["body"]["messages"][0]
+        self.assertEqual(system_message["role"], "system")
+        self.assertIn("RESUME BODY", system_message["content"])
+
+    def test_reads_pasted_url_without_web_search(self):
+        captured = {}
+
+        def fake_urlopen(req, timeout):
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return FakeSseUpstream([b"data: [DONE]\n\n"])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            activate_llama_runtime(ctx)
+            response = DummySseResponse()
+            with mock.patch.object(
+                chat.web_search, "fetch_page_text",
+                return_value={"ok": True, "text": "PAGE BODY"},
+            ) as fetch, mock.patch.object(chat.web_search, "web_search") as ws, \
+                    mock.patch.object(
+                        chat.chat_service, "get_local_chat_api_url",
+                        return_value="http://127.0.0.1:8080/v1/chat/completions",
+                    ), mock.patch.object(chat.urllib.request, "urlopen", side_effect=fake_urlopen):
+                chat.completions(
+                    Request("POST", "/api/chat/completions", "", {}, body={
+                        "messages": [{"role": "user", "content": "read https://example.com/page"}],
+                    }),
+                    response, ctx,
+                )
+
+        fetch.assert_called_once()
+        ws.assert_not_called()
+        system_message = captured["body"]["messages"][0]
+        self.assertIn("PAGE BODY", system_message["content"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously a page was only fetched when Web Search was toggled on, and local files could not be read at all. Detect a URL and/or a local file path in the latest user message and read it directly: local files via a new local_files service (plain text always; PDF and DOCX when the optional pypdf / python-docx packages are installed), and URLs via the existing fetch_page_text. The fetched text is injected as system context, with a larger per-source budget for direct reads so a whole page or document reaches the model.

A URL-less follow-up such as "try again" or "read the file" reuses the most recent link/file from the conversation (references_previous_page plus find_recent_urls / find_recent_file_paths). When Web Search is on with no directly referenced content, the original search behaviour is unchanged. Images are recognised but report that OCR is needed (kept as a separate change).