### PR TITLE
List models recursively and normalize model paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ If you use [Pinokio](https://pinokio.computer/), install via [thomas9120/llama-g
 
 ## Getting Models
 
-Place `llama.cpp`-compatible `.gguf` files in `models/` (or use **Open Models**). They appear in **Quick Launch** and **Configure**.
+Place `llama.cpp`-compatible `.gguf` files in `models/` or any subfolder under it (or use **Open Models**). They appear in **Quick Launch** and **Configure**. The `models/mmproj/` folder is reserved for vision projectors and is not listed as a launch model.
 
 Or download in-app from **Quick Launch**:
 1. Enter a Hugging Face repo ID such as `owner/model-GGUF`.
 2. Click **Find GGUF Files**, pick a file, then **Download**.
 
-For vision/multimodal models, also download the matching `mmproj` file when the repo provides one. Projector files land in `models/mmproj/` and the Multimodal Projector setting is applied automatically.
+Downloads land under `models/<owner_repo>/` (repo id with `/` → `_`). For vision/multimodal models, also download the matching `mmproj` file when the repo provides one. Projector files land in `models/mmproj/<owner_repo>/` and the Multimodal Projector setting is applied automatically.
 
 ## First Run
 

--- a/backend/routes/models.py
+++ b/backend/routes/models.py
@@ -1,12 +1,65 @@
 """Model file API routes."""
 
+# Reserved subfolder: vision projectors live here and are applied via the mmproj
+# flag, so they must never appear in the launch model list.
+MMPROJ_DIR_NAME = "mmproj"
+
+
+def _iter_gguf_files(models_dir):
+    """Yield .gguf files under ``models_dir``, recursively.
+
+    Symlinks are followed, since linking a large model or a whole folder of them
+    into ``models/`` is a normal way to avoid copying gigabytes. Each directory is
+    visited at most once by resolved path, so a link cycle cannot hang the route.
+
+    Files are yielded unresolved on purpose: the caller names them by their path
+    relative to ``models/``, which is what the user sees in the folder and what
+    ``-m models/<name>`` needs. Naming them by their resolved target would put a
+    symlinked model outside ``models/`` and drop it from the list entirely.
+    """
+    seen_dirs = set()
+    stack = [(models_dir, True)]
+    while stack:
+        current, is_root = stack.pop()
+        try:
+            resolved = current.resolve()
+            if resolved in seen_dirs:
+                continue
+            seen_dirs.add(resolved)
+            entries = list(current.iterdir())
+        except OSError:
+            continue
+
+        for entry in entries:
+            try:
+                if entry.is_dir():
+                    if is_root and entry.name.lower() == MMPROJ_DIR_NAME:
+                        continue
+                    stack.append((entry, False))
+                elif entry.is_file() and entry.suffix.lower() == ".gguf":
+                    yield entry
+            except OSError:
+                # A broken or unreadable link is simply not a model.
+                continue
+
 
 def list_models(request, response, ctx):
-    models = []
     models_dir = ctx.paths.models
-    if models_dir.exists():
-        for path in sorted(models_dir.iterdir()):
-            if path.is_file() and path.suffix.lower() == ".gguf":
-                size_mb = path.stat().st_size / (1024 * 1024)
-                models.append({"name": path.name, "size_mb": round(size_mb, 2)})
-    response.json(models)
+    if not models_dir.exists():
+        response.json([])
+        return
+
+    found = []
+    for path in _iter_gguf_files(models_dir):
+        try:
+            size_mb = path.stat().st_size / (1024 * 1024)
+        except OSError:
+            continue
+        found.append(
+            {
+                "name": path.relative_to(models_dir).as_posix(),
+                "size_mb": round(size_mb, 2),
+            }
+        )
+
+    response.json(sorted(found, key=lambda item: item["name"].lower()))

--- a/backend/services/file_picker.py
+++ b/backend/services/file_picker.py
@@ -99,22 +99,27 @@ def select_file_in_native_dialog(
         root.destroy()
 
 
+# `purpose` is the flag id (see getPathPickerRequest in ui/js/app.js). "model" has
+# no path flag today - the main model is a dropdown over models/ - but it is kept
+# here so a future model path flag gets the models/ folder and filter by default.
+MODEL_FILE_PURPOSES = frozenset({"model", "model_draft", "mmproj", "model_vocoder"})
+
+
 def get_select_file_options(ctx: AppContext, purpose: Any, title: Any) -> tuple[str, Path, FileTypes]:
     normalized_purpose = str(purpose or "").strip().lower()
     normalized_title = str(title or "Select File").strip() or "Select File"
 
-    initial_dir = (
-        ctx.paths.models
-        if normalized_purpose in {"model", "model_draft", "mmproj", "model_vocoder"}
-        else ctx.paths.root
-    )
+    is_model_file = normalized_purpose in MODEL_FILE_PURPOSES
+    initial_dir = ctx.paths.models if is_model_file else ctx.paths.root
 
     filetypes: FileTypes = [("All files", "*.*")]
-    if normalized_purpose in {"model", "model_draft", "mmproj", "model_vocoder"}:
+    if is_model_file:
+        # GGUF only, matching every other model path check in the app: llama.cpp
+        # dropped the legacy ggml .bin formats, and validate_hf_filename and the
+        # UI's normalizeModelRelPath both reject .bin. "All files" stays as the
+        # escape hatch for anything unusual.
         filetypes = [
-            ("Model files", "*.gguf *.bin"),
             ("GGUF files", "*.gguf"),
-            ("BIN files", "*.bin"),
             ("All files", "*.*"),
         ]
 

--- a/backend/services/hf_download.py
+++ b/backend/services/hf_download.py
@@ -60,6 +60,15 @@ def is_mmproj_filename(filename: Any) -> bool:
 
 
 def slugify_repo_id(repo_id: str) -> str:
+    """Folder name for a repo's downloads, under models/ and models/mmproj/.
+
+    Not injective: only "/" is substituted, so "owner/my_model" and
+    "owner_my/model" both slugify to "owner_my_model" and share a folder. Left
+    as-is deliberately - an injective scheme would rename every existing download
+    folder, and sharing one is benign: files keep their own names, and a same-name
+    clash is caught by the exists check in start_hf_model_download(), which
+    prompts before overwriting.
+    """
     return re.sub(r"[^A-Za-z0-9._-]+", "_", repo_id).strip("._-") or "repo"
 
 
@@ -231,18 +240,25 @@ def start_hf_model_download(
     if mmproj_file and not is_mmproj_filename(mmproj_file):
         raise ValueError("Choose an mmproj/projector file for the companion mmproj download.")
 
-    model_name = pathlib.PurePosixPath(model_file).name
-    model_dest = ctx.paths.models / model_name
+    repo_folder = slugify_repo_id(repo_id)
+    model_basename = pathlib.PurePosixPath(model_file).name
+    # Relative id under models/ so discovery + applyPresetModel select the new file.
+    model_name = f"{repo_folder}/{model_basename}"
+    model_dest = ctx.paths.models / repo_folder / model_basename
     mmproj_dest = None
     if mmproj_file:
         mmproj_dest = (
             ctx.paths.models
             / "mmproj"
-            / slugify_repo_id(repo_id)
+            / repo_folder
             / pathlib.PurePosixPath(mmproj_file).name
         )
 
-    existing = [path.name for path in [model_dest, mmproj_dest] if path and path.exists()]
+    existing = []
+    if model_dest.exists():
+        existing.append(model_name)
+    if mmproj_dest and mmproj_dest.exists():
+        existing.append(f"mmproj/{repo_folder}/{mmproj_dest.name}")
     if existing and not overwrite:
         raise FileExistsError(f"Already exists: {', '.join(existing)}")
 
@@ -257,7 +273,7 @@ def start_hf_model_download(
         if mmproj_dest:
             destinations.append(mmproj_dest)
         try:
-            ctx.paths.models.mkdir(parents=True, exist_ok=True)
+            model_dest.parent.mkdir(parents=True, exist_ok=True)
             if mmproj_dest:
                 mmproj_dest.parent.mkdir(parents=True, exist_ok=True)
             total = get_hf_file_size(repo_id, model_file, revision, token)

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -513,9 +513,9 @@ Select All, Clear, `★ Favorite`, `☆ Unfavorite`, Export, Delete. Favorite/un
 - An outdated or unsupported chat template.
 - Custom launch args, which may override UI controls.
 
-Missing-model detection matches each preset's model against the shared cache in `manager.js`, populated by `refreshModels()` from `/api/models`. `matchKnownModelName()` tries the full `models/`-relative path first (case-insensitive), then falls back to the file name, since presets saved before `models/` gained subfolders store a bare name. A bare name held by two subfolders is reported as `ambiguous` rather than resolved, and warns — guessing a folder would launch the wrong weights.
+Missing-model detection matches each preset's model against the shared cache in `manager.js`, populated by `refreshModels()` from `/api/models`. `matchKnownModelName()` tries the full `models/`-relative path first (case-insensitive), then falls back to the file name only for legacy bare names and absolute paths. A bare name held by two subfolders is reported as `ambiguous` rather than resolved, and warns — guessing a folder would launch the wrong weights. An explicit relative path never falls back to another folder's file.
 
-`applyPresetModel()` resolves through the same function so the two cannot disagree. It matches against the live `#model-select` options rather than the cache, because only the options carry the exact spelling the launch needs; an unresolved value is selected as-is and marked `(missing)` in the dropdown, matching what the preset warns about. When these drifted apart, a preset could report healthy while its launch emitted a path that did not exist.
+`resolvePresetModelName()` is shared by normal preset loads, Model Switcher launch preparation, and saved-preset benchmarks so every path uses the same nested filename. It matches against live model options or the benchmark model list because those carry the exact spelling the launch needs; an unresolved value is selected as-is and marked `(missing)` in the dropdown, matching what the preset warns about. When these drifted apart, a preset could report healthy while its launch emitted a path that did not exist.
 
 Detection is deliberately conservative: an unknown list, an empty models folder, and a preset with no model all stay silent, because a preset for a model kept on another machine is legitimate.
 

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -36,7 +36,7 @@
 | `tests/` | Frontend (Node/Playwright) + backend (unittest) tests |
 | `docs/` | Documentation: todo, flag audit, architecture, bugtracker |
 | `llama/` | Downloaded `llama.cpp` binaries at runtime |
-| `models/` | User model files (.gguf) |
+| `models/` | User model files (.gguf), in any subfolder; `models/mmproj/` is reserved for projectors |
 | `presets/` | Saved launcher preset JSON files |
 | `tools/` | Auto-downloaded `cloudflared` binary |
 | `scripts/` | `create_windows_shortcuts.ps1` |
@@ -86,7 +86,7 @@
 | `process.py` | `/api/launch`, `/api/launch/preflight`, `/api/presets/fingerprint`, `/api/llama/health`, generation-bound `/api/stop`, `/api/output`, `/api/send-input`, `/api/cleanup-llama` |
 | `install.py` | `/api/releases`, `/api/install`, `/api/update`, `/api/download-progress` |
 | `metrics.py` | `/api/llama/metrics`, `/api/llama/slots` — Prometheus proxy |
-| `models.py` | `/api/models` — list GGUF files |
+| `models.py` | `/api/models` — list GGUF files recursively as `models/`-relative names |
 | `presets.py` | `/api/presets` CRUD + shortcut export |
 | `hf_download.py` | `/api/hf/repo-files`, `/api/hf/download`, `/api/hf/download-status`, `/api/hf/download-cancel` |
 | `tunnel.py` | `/api/remote-tunnel/start`, `/api/remote-tunnel/stop`, `/api/remote-tunnel/status` |
@@ -256,8 +256,10 @@ A category may declare `submenuOrder: [...]` (`ui/js/flags/categories.js`) to co
 3. Skip speculative flags when not enabled.
 4. Build `[flag, value]` pairs.
 5. Parse + append custom args.
-6. Append model path as `-m models/<name>`.
+6. Append model path as `-m models/<name>` (relative path under `models/`, including subfolders; `mmproj/` is excluded from discovery).
 7. Return `{ args, error, warnings }`.
+
+`<name>` is checked by `flagCore.normalizeModelRelPath()`, which rejects absolute paths, `.`/`..` segments, empty segments, and anything not ending in `.gguf`. It is exported on the `flagCore` API and reused by `benchmark-ui.js` rather than restated, so the launch and benchmark `-m` values cannot drift apart; `benchmark-ui` fails closed if the export is missing. It stays in `flag-core.js` rather than being injected through `configure()`, so a missing `configure()` call can never disable the check.
 
 ### llama.cpp Compatibility
 
@@ -511,7 +513,11 @@ Select All, Clear, `★ Favorite`, `☆ Unfavorite`, Export, Delete. Favorite/un
 - An outdated or unsupported chat template.
 - Custom launch args, which may override UI controls.
 
-Missing-model detection compares each preset's model basename against the shared cache in `manager.js`, populated by `refreshModels()` from `/api/models`. It is deliberately conservative: an unknown list, an empty models folder, and a preset with no model all stay silent, because a preset for a model kept on another machine is legitimate.
+Missing-model detection matches each preset's model against the shared cache in `manager.js`, populated by `refreshModels()` from `/api/models`. `matchKnownModelName()` tries the full `models/`-relative path first (case-insensitive), then falls back to the file name, since presets saved before `models/` gained subfolders store a bare name. A bare name held by two subfolders is reported as `ambiguous` rather than resolved, and warns — guessing a folder would launch the wrong weights.
+
+`applyPresetModel()` resolves through the same function so the two cannot disagree. It matches against the live `#model-select` options rather than the cache, because only the options carry the exact spelling the launch needs; an unresolved value is selected as-is and marked `(missing)` in the dropdown, matching what the preset warns about. When these drifted apart, a preset could report healthy while its launch emitted a path that did not exist.
+
+Detection is deliberately conservative: an unknown list, an empty models folder, and a preset with no model all stay silent, because a preset for a model kept on another machine is legitimate.
 
 `null` from that cache means "not known yet" and must stay distinct from a known-empty folder. The summary surfaces this as `modelsChecked`; when false, the Missing Models stat renders `—` and the health line says the check did not run rather than giving a false all-clear.
 
@@ -634,10 +640,16 @@ Chat sidebar has sliders for temperature, top-p, top-k, min-p, repeat-penalty, a
 4. "Download" starts the download with progress bar.
 5. On completion, the model is auto-selected in the model dropdown and command preview updates.
 
+### Download Layout
+
+- Models land in `models/<slug>/<file>.gguf`, projectors in `models/mmproj/<slug>/<file>.gguf`, where `<slug>` is `slugify_repo_id(repo_id)`.
+- `model_name` in the status payload is the `models/`-relative path (`<slug>/<file>.gguf`), so it matches `/api/models` and `applyPresetModel()` can select it directly.
+- The slug is not injective: only `/` is substituted, so `owner/my_model` and `owner_my/model` share a folder. Accepted deliberately — an injective scheme would rename every existing download folder, and a shared folder is harmless because files keep their own names and a same-name clash hits the overwrite prompt below.
+
 ### Safety
 
 - Repo IDs, revisions, and filenames are validated with strict regex and path traversal checks.
-- Only `.gguf` files can be downloaded.
+- Only `.gguf` files can be downloaded. The path-flag file picker offers the same GGUF-only filter (plus "All files"); llama.cpp dropped the legacy ggml `.bin` formats.
 - mmproj files must contain `mmproj`, `clip`, or `projector` in the stem.
 - Duplicate downloads detect existing files and prompt for overwrite confirmation.
 - Partial downloads are cleaned up on error/cancellation.
@@ -885,7 +897,7 @@ Returns `{"selected": bool, "path": string}`.
 
 ### File Type Filters
 
-- Model files (purpose: model, model_draft, mmproj, model_vocoder): `*.gguf`, `*.bin`
+- Model files (purpose: model, model_draft, mmproj, model_vocoder): `*.gguf`, plus `*.*` as an escape hatch. `purpose` is the flag id; `model` has no path flag today (the main model is a dropdown over `models/`) and is listed so a future one gets the right folder and filter.
 - Other paths (grammar file, log file, etc.): `*.*`
 
 ---

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -167,11 +167,95 @@ class ExtractedRouteTests(unittest.TestCase):
             ctx.paths.models.mkdir(parents=True)
             (ctx.paths.models / "model.gguf").write_bytes(b"x" * 1024)
             (ctx.paths.models / "notes.txt").write_text("ignore")
+            nested = ctx.paths.models / "vendor" / "nested.gguf"
+            nested.parent.mkdir(parents=True)
+            nested.write_bytes(b"x" * 2048)
+            mmproj = ctx.paths.models / "mmproj" / "proj.gguf"
+            mmproj.parent.mkdir(parents=True)
+            mmproj.write_bytes(b"x" * 512)
             response = DummyResponse()
 
             models.list_models(Request("GET", "/api/models", "", {}), response, ctx)
 
-            self.assertEqual(response.payload, [{"name": "model.gguf", "size_mb": 0.0}])
+            self.assertEqual(
+                response.payload,
+                [
+                    {"name": "model.gguf", "size_mb": 0.0},
+                    {"name": "vendor/nested.gguf", "size_mb": 0.0},
+                ],
+            )
+
+    def test_models_route_lists_symlinked_models(self):
+        # Symlinking a large .gguf into models/ from another disk is a common way
+        # to avoid copying it. Resolving the path before building the name would
+        # place it outside models/ and silently drop it from the list.
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            ctx.paths.models.mkdir(parents=True)
+            external = Path(tmp) / "elsewhere"
+            external.mkdir()
+            (external / "external.gguf").write_bytes(b"x" * 1024)
+            try:
+                (ctx.paths.models / "linked.gguf").symlink_to(external / "external.gguf")
+                (ctx.paths.models / "vendor").symlink_to(external, target_is_directory=True)
+            except (OSError, NotImplementedError):
+                self.skipTest("symlinks are not available on this platform")
+            response = DummyResponse()
+
+            models.list_models(Request("GET", "/api/models", "", {}), response, ctx)
+
+            names = [item["name"] for item in response.payload]
+            # Each link is listed under the name it has in models/, which is what
+            # `-m models/<name>` needs; the OS follows it at launch.
+            self.assertIn("linked.gguf", names)
+            self.assertIn("vendor/external.gguf", names)
+            self.assertNotIn("external.gguf", names)
+
+    def test_models_route_survives_symlink_cycle(self):
+        # Following directory links means a cycle would otherwise recurse forever.
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            nested = ctx.paths.models / "vendor"
+            nested.mkdir(parents=True)
+            (nested / "nested.gguf").write_bytes(b"x" * 1024)
+            try:
+                (nested / "loop").symlink_to(ctx.paths.models, target_is_directory=True)
+            except (OSError, NotImplementedError):
+                self.skipTest("symlinks are not available on this platform")
+            response = DummyResponse()
+
+            models.list_models(Request("GET", "/api/models", "", {}), response, ctx)
+
+            self.assertEqual(
+                [item["name"] for item in response.payload],
+                ["vendor/nested.gguf"],
+            )
+
+    def test_models_route_skips_reserved_mmproj_folder_only_at_top_level(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            ctx.paths.models.mkdir(parents=True)
+            for rel in ("mmproj/proj.gguf", "vendor/mmproj/nested.gguf", "mmproj-extra/other.gguf"):
+                path = ctx.paths.models / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"x" * 16)
+            response = DummyResponse()
+
+            models.list_models(Request("GET", "/api/models", "", {}), response, ctx)
+
+            self.assertEqual(
+                [item["name"] for item in response.payload],
+                ["mmproj-extra/other.gguf", "vendor/mmproj/nested.gguf"],
+            )
+
+    def test_models_route_returns_empty_list_without_models_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            response = DummyResponse()
+
+            models.list_models(Request("GET", "/api/models", "", {}), response, ctx)
+
+            self.assertEqual(response.payload, [])
 
     def test_benchmark_wikitext2_route_reuses_existing_file(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -2202,8 +2286,9 @@ class ExtractedRouteTests(unittest.TestCase):
     def test_hf_download_route_reports_duplicate_with_code(self):
         with tempfile.TemporaryDirectory() as tmp:
             ctx = make_context(tmp)
-            ctx.paths.models.mkdir(parents=True)
-            (ctx.paths.models / "model.gguf").write_bytes(b"existing")
+            dest_dir = ctx.paths.models / "owner_model"
+            dest_dir.mkdir(parents=True)
+            (dest_dir / "model.gguf").write_bytes(b"existing")
             response = DummyResponse()
 
             hf_download.start_download(
@@ -2224,6 +2309,7 @@ class ExtractedRouteTests(unittest.TestCase):
 
             self.assertEqual(response.status, 409)
             self.assertEqual(response.payload["code"], "exists")
+            self.assertIn("owner_model/model.gguf", response.payload["error"])
 
     def test_hf_download_cancel_sets_cancelling_state(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -2864,7 +2950,12 @@ class ExtractedRouteTests(unittest.TestCase):
             _, kwargs = select_file.call_args
             self.assertEqual(kwargs["title"], "Pick Model")
             self.assertEqual(kwargs["initial_dir"], ctx.paths.models)
-            self.assertEqual(kwargs["filetypes"][0], ("Model files", "*.gguf *.bin"))
+            # GGUF only: llama.cpp dropped the legacy ggml .bin formats, and the
+            # HF download and launch-arg checks both reject .bin.
+            self.assertEqual(kwargs["filetypes"][0], ("GGUF files", "*.gguf"))
+            offered = " ".join(pattern for _, pattern in kwargs["filetypes"])
+            self.assertNotIn(".bin", offered)
+            self.assertIn(("All files", "*.*"), kwargs["filetypes"])
             self.assertEqual(response.payload, {"selected": True, "path": str(ctx.paths.models / "model.gguf")})
 
 

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -2403,6 +2403,89 @@ class SlugifyRepoIdTests(unittest.TestCase):
     def test_spaces_replaced(self):
         self.assertEqual(hf_service.slugify_repo_id("my model"), "my_model")
 
+    def test_slug_is_not_injective(self):
+        # Documents an accepted limitation rather than asserting desired output.
+        # Only "/" is substituted, so a repo whose name contains "_" can collide
+        # with one whose owner does. Both of these are valid repo ids and land in
+        # the same download folder. Kept deliberately: an injective scheme would
+        # rename every existing folder, files keep their own names, and a
+        # same-name clash still hits the exists/overwrite prompt. If this ever
+        # stops being acceptable, this test is the thing to change first.
+        for repo_id in ("owner/my_model", "owner_my/model"):
+            hf_service.validate_hf_repo_id(repo_id)
+        self.assertEqual(
+            hf_service.slugify_repo_id("owner/my_model"),
+            hf_service.slugify_repo_id("owner_my/model"),
+        )
+
+
+class StartHfModelDownloadPathTests(unittest.TestCase):
+    def test_downloads_into_repo_subfolder(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            payload = b"gguf-bytes"
+
+            def fake_urlopen(req, timeout=60):
+                return FakeDownloadResponse([payload], content_length=len(payload))
+
+            with (
+                mock.patch.object(hf_service, "get_hf_file_size", return_value=len(payload)),
+                mock.patch.object(
+                    hf_service,
+                    "build_hf_download_url",
+                    side_effect=lambda repo_id, filename, revision: f"https://example.test/{filename}",
+                ),
+            ):
+                hf_service.start_hf_model_download(
+                    ctx,
+                    repo_id="owner/model",
+                    revision="main",
+                    model_file="Q4/model.gguf",
+                    mmproj_file="mmproj-model.gguf",
+                    token=None,
+                    urlopen=fake_urlopen,
+                )
+                for _ in range(50):
+                    snap = hf_service.get_model_download_snapshot(ctx)
+                    if snap["status"] in {"done", "error", "cancelled"}:
+                        break
+                    import time
+
+                    time.sleep(0.02)
+
+            snap = hf_service.get_model_download_snapshot(ctx)
+            self.assertEqual(snap["status"], "done", snap)
+            self.assertEqual(snap["model_name"], "owner_model/model.gguf")
+            model_path = pathlib.Path(snap["model_path"])
+            self.assertEqual(model_path, ctx.paths.models / "owner_model" / "model.gguf")
+            self.assertTrue(model_path.is_file())
+            self.assertEqual(model_path.read_bytes(), payload)
+            mmproj_path = pathlib.Path(snap["mmproj_path"])
+            self.assertEqual(
+                mmproj_path,
+                ctx.paths.models / "mmproj" / "owner_model" / "mmproj-model.gguf",
+            )
+            self.assertTrue(mmproj_path.is_file())
+
+    def test_exists_check_uses_repo_relative_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            dest = ctx.paths.models / "owner_model" / "model.gguf"
+            dest.parent.mkdir(parents=True)
+            dest.write_bytes(b"existing")
+
+            with self.assertRaises(FileExistsError) as raised:
+                hf_service.start_hf_model_download(
+                    ctx,
+                    repo_id="owner/model",
+                    revision="main",
+                    model_file="model.gguf",
+                    mmproj_file="",
+                    token=None,
+                )
+
+            self.assertIn("owner_model/model.gguf", str(raised.exception))
+
 
 class HfFileToDictTests(unittest.TestCase):
     def test_extracts_rfilename(self):

--- a/tests/frontend/benchmark_args_unit.cjs
+++ b/tests/frontend/benchmark_args_unit.cjs
@@ -6,6 +6,10 @@ const vm = require("node:vm");
 const ROOT = path.resolve(__dirname, "..", "..");
 const outputCursorSource = fs.readFileSync(path.join(ROOT, "ui", "js", "output-cursor.js"), "utf8");
 const flagHelpersSource = fs.readFileSync(path.join(ROOT, "ui", "js", "flags", "helpers.js"), "utf8");
+// benchmark-ui borrows flagCore.normalizeModelRelPath so the -m rules stay in one
+// place; flag-core takes all its flag data through configure(), so loading it here
+// needs no other module.
+const flagCoreSource = fs.readFileSync(path.join(ROOT, "ui", "js", "flag-core.js"), "utf8");
 const source = fs.readFileSync(path.join(ROOT, "ui", "js", "benchmark-ui.js"), "utf8");
 
 const context = {
@@ -29,6 +33,7 @@ context.window.window = context.window;
 vm.createContext(context);
 vm.runInContext(outputCursorSource, context, { filename: "ui/js/output-cursor.js" });
 vm.runInContext(flagHelpersSource, context, { filename: "ui/js/flags/helpers.js" });
+vm.runInContext(flagCoreSource, context, { filename: "ui/js/flag-core.js" });
 vm.runInContext(source, context, { filename: "ui/js/benchmark-ui.js" });
 
 const adapter = context.window.LlamaGui.benchmarkUi;
@@ -82,6 +87,23 @@ function flat(result) {
     assert.ok(result.excluded.some((item) => item.label === "GPU Layers"));
     assert.ok(result.excluded.some((item) => item.label === "Temperature"));
     assert.ok(result.excluded.some((item) => item.label === "Custom Launch Args"));
+}
+
+{
+    const nested = adapter.buildBenchmarkArgs({
+        benchmarkType: "bench",
+        flags,
+        source: { model: "vendor/nested.gguf", flags: {} },
+    });
+    assert.equal(nested.error, null);
+    assert.ok(flat(nested).includes("models/vendor/nested.gguf"));
+
+    const escaped = adapter.buildBenchmarkArgs({
+        benchmarkType: "bench",
+        flags,
+        source: { model: "../secret.gguf", flags: {} },
+    });
+    assert.match(escaped.error, /Invalid model filename/);
 }
 
 {

--- a/tests/frontend/benchmark_args_unit.cjs
+++ b/tests/frontend/benchmark_args_unit.cjs
@@ -37,6 +37,13 @@ vm.runInContext(flagCoreSource, context, { filename: "ui/js/flag-core.js" });
 vm.runInContext(source, context, { filename: "ui/js/benchmark-ui.js" });
 
 const adapter = context.window.LlamaGui.benchmarkUi;
+context.window.LlamaGui.presets = {
+    resolvePresetModelName: (model, candidates) => (
+        model === "nested.gguf" && candidates.includes("vendor/nested.gguf")
+            ? "vendor/nested.gguf"
+            : model
+    ),
+};
 
 const flags = [
     { id: "ctx_size", flag: "-c", type: "int", label: "Context" },
@@ -97,6 +104,15 @@ function flat(result) {
     });
     assert.equal(nested.error, null);
     assert.ok(flat(nested).includes("models/vendor/nested.gguf"));
+
+    const legacyPreset = adapter.buildBenchmarkArgs({
+        benchmarkType: "bench",
+        flags,
+        source: { sourceType: "preset", model: "nested.gguf", flags: {} },
+        modelCandidates: ["vendor/nested.gguf"],
+    });
+    assert.equal(legacyPreset.error, null);
+    assert.ok(flat(legacyPreset).includes("models/vendor/nested.gguf"));
 
     const escaped = adapter.buildBenchmarkArgs({
         benchmarkType: "bench",

--- a/tests/frontend/launch_args_unit.cjs
+++ b/tests/frontend/launch_args_unit.cjs
@@ -425,6 +425,13 @@ function launchResult() {
         flags: {},
     })`, context);
     assert.match(absolute.error, /Invalid model filename/);
+
+    const windowsAbsolute = vm.runInContext(`window.LlamaGui.flagCore.buildLaunchArgs({
+        tool: "llama-server",
+        model: "C:/models/model.gguf",
+        flags: {},
+    })`, context);
+    assert.match(windowsAbsolute.error, /Invalid model filename/);
 }
 
 console.log("launch args unit tests passed");

--- a/tests/frontend/launch_args_unit.cjs
+++ b/tests/frontend/launch_args_unit.cjs
@@ -401,4 +401,30 @@ function launchResult() {
     assert.match(unsupported.error, /Unsupported/);
 }
 
+{
+    const nested = vm.runInContext(`window.LlamaGui.flagCore.buildLaunchArgs({
+        tool: "llama-server",
+        model: "vendor/nested.gguf",
+        flags: {},
+    })`, context);
+    assert.equal(nested.error, null);
+    const nestedFlat = nested.args.flat().map(String);
+    assert.ok(nestedFlat.includes("-m"));
+    assert.ok(nestedFlat.includes("models/vendor/nested.gguf"));
+
+    const escaped = vm.runInContext(`window.LlamaGui.flagCore.buildLaunchArgs({
+        tool: "llama-server",
+        model: "../secret.gguf",
+        flags: {},
+    })`, context);
+    assert.match(escaped.error, /Invalid model filename/);
+
+    const absolute = vm.runInContext(`window.LlamaGui.flagCore.buildLaunchArgs({
+        tool: "llama-server",
+        model: "/tmp/model.gguf",
+        flags: {},
+    })`, context);
+    assert.match(absolute.error, /Invalid model filename/);
+}
+
 console.log("launch args unit tests passed");

--- a/tests/frontend/presets_unit.cjs
+++ b/tests/frontend/presets_unit.cjs
@@ -448,8 +448,8 @@ assert.equal(
 const ambiguousModels = createModelContext(new Set(["vendor-a/dup.gguf", "vendor-b/dup.gguf"]));
 assert.equal(
     isMissing(ambiguousModels, "dup.gguf"),
-    true,
-    "a basename held by two subfolders must not be treated as resolved"
+    false,
+    "an ambiguous basename must warn without inflating the missing-model count"
 );
 assert.equal(
     ambiguousModels.window.LlamaGui.presets.getPresetModelIssue("dup.gguf"),
@@ -466,6 +466,12 @@ assert.equal(
     ambiguousModels.window.LlamaGui.presets.getPresetModelIssue("vendor-a/dup.gguf"),
     "",
     "the full relative path stays unambiguous"
+);
+const staleExplicitPath = createModelContext(new Set(["vendor-b/dup.gguf"]));
+assert.equal(
+    staleExplicitPath.window.LlamaGui.presets.getPresetModelIssue("vendor-a/dup.gguf"),
+    "missing",
+    "an explicit relative path must not fall back to a different folder"
 );
 
 // --- applyPresetModel must agree with the warning ---------------------------
@@ -492,7 +498,11 @@ function createSelectContext(optionValues, knownModelNames) {
     ctx.window = ctx;
     ctx.window.LlamaGui = {
         manager: { getKnownModelNames: () => knownModelNames },
-        flagCore: { setSelectedModelValue: (value) => selected.push(value) },
+        flagCore: {
+            setSelectedModelValue: (value) => selected.push(value),
+            buildEffectiveFlagValues: (values) => ({ ...values }),
+            getFlagValues: () => ({}),
+        },
     };
     vm.createContext(ctx);
     vm.runInContext(source, ctx, { filename: "presets.js" });
@@ -513,6 +523,15 @@ function createSelectContext(optionValues, knownModelNames) {
         false,
         "the warning must agree that the resolved model is present"
     );
+    assert.equal(
+        ctx.window.LlamaGui.presets.preparePresetLaunchState({
+            tool: "llama-server",
+            model: "nested.gguf",
+            flags: {},
+        }).model,
+        "vendor/nested.gguf",
+        "Model Switcher launch preparation must use the same resolved path"
+    );
 
     ctx.window.LlamaGui.presets.applyPresetModel("vendor/nested.gguf");
     assert.equal(select.value, "vendor/nested.gguf", "an exact relative path must select the same option");
@@ -532,9 +551,18 @@ function createSelectContext(optionValues, knownModelNames) {
     assert.equal(select.options.at(-1).textContent, "dup.gguf  (missing)", "it must be marked in the dropdown");
     assert.equal(
         ctx.window.LlamaGui.presets.isPresetModelMissing("dup.gguf"),
-        true,
-        "and the preset must warn to match the dropdown"
+        false,
+        "ambiguity is a warning, not a missing file"
     );
+}
+
+{
+    const known = new Set(["vendor-b/dup.gguf"]);
+    const { ctx, select } = createSelectContext(["", "vendor-b/dup.gguf"], known);
+
+    ctx.window.LlamaGui.presets.applyPresetModel("vendor-a/dup.gguf");
+    assert.equal(select.value, "vendor-a/dup.gguf", "a stale explicit path must not select another folder");
+    assert.equal(select.options.at(-1).textContent, "vendor-a/dup.gguf  (missing)");
 }
 
 {
@@ -571,6 +599,13 @@ assert.equal(summary.missingModelCount, 1, "only the preset pointing at gone.ggu
 assert.equal(summary.warningCount, 2, "one missing model plus one custom-args preset");
 assert.equal(summary.filtered, false, "no search or filter is active");
 assert.equal(summary.mostRecent, null, "an unused library has no most-recent preset");
+
+const ambiguousSummaryContext = createModelContext(new Set(["vendor-a/dup.gguf", "vendor-b/dup.gguf"]));
+ambiguousSummaryContext.__presets = [{ name: "ambiguous", data: { model: "dup.gguf", flags: {} } }];
+vm.runInContext("currentPresetGroups = buildPresetGroups(__presets)", ambiguousSummaryContext);
+const ambiguousSummary = vm.runInContext("getPresetLibrarySummary()", ambiguousSummaryContext);
+assert.equal(ambiguousSummary.warningCount, 1, "an ambiguous legacy name remains actionable");
+assert.equal(ambiguousSummary.missingModelCount, 0, "existing ambiguous files are not missing");
 
 // A filtered view must report what is visible, not the whole library, or the
 // summary would contradict the list and the count line next to it.

--- a/tests/frontend/presets_unit.cjs
+++ b/tests/frontend/presets_unit.cjs
@@ -405,7 +405,7 @@ function createModelContext(knownModelNames, initialStorage = {}) {
     return ctx;
 }
 
-const modelsPresent = createModelContext(new Set(["kept.gguf", "other.gguf"]));
+const modelsPresent = createModelContext(new Set(["kept.gguf", "other.gguf", "vendor/nested.gguf"]));
 const isMissing = (ctx, model) => ctx.window.LlamaGui.presets.isPresetModelMissing(model);
 
 assert.equal(isMissing(modelsPresent, "gone.gguf"), true, "a model absent from models/ must be flagged");
@@ -418,6 +418,9 @@ assert.equal(
     "a path-like model value must match on its file name"
 );
 assert.equal(isMissing(modelsPresent, "/srv/models/kept.gguf"), false, "posix paths must match on file name too");
+assert.equal(isMissing(modelsPresent, "vendor/nested.gguf"), false, "relative subfolder paths must match exactly");
+assert.equal(isMissing(modelsPresent, "nested.gguf"), false, "bare names must match a nested file basename");
+assert.equal(isMissing(modelsPresent, "vendor/gone.gguf"), true, "a missing relative path must be flagged");
 
 // An unknown list must never be read as proof that a model is gone.
 assert.equal(isMissing(createModelContext(null), "gone.gguf"), false, "a failed model fetch must not warn");
@@ -439,6 +442,114 @@ assert.equal(
     0,
     "a preset whose model still exists must be warning-free"
 );
+
+// A bare name held by two subfolders cannot be resolved, so it must warn rather
+// than silently pick one. applyPresetModel() below must agree with this.
+const ambiguousModels = createModelContext(new Set(["vendor-a/dup.gguf", "vendor-b/dup.gguf"]));
+assert.equal(
+    isMissing(ambiguousModels, "dup.gguf"),
+    true,
+    "a basename held by two subfolders must not be treated as resolved"
+);
+assert.equal(
+    ambiguousModels.window.LlamaGui.presets.getPresetModelIssue("dup.gguf"),
+    "ambiguous",
+    "an unresolvable basename must be reported as ambiguous, not as missing"
+);
+const ambiguousWarnings = ambiguousModels.window.LlamaGui.presets.getPresetWarnings({
+    model: "dup.gguf",
+    flags: {},
+});
+assert.equal(ambiguousWarnings.length, 1, "an ambiguous model must surface exactly one warning");
+assert.match(ambiguousWarnings[0], /more than one models subfolder/, "the warning must explain the ambiguity");
+assert.equal(
+    ambiguousModels.window.LlamaGui.presets.getPresetModelIssue("vendor-a/dup.gguf"),
+    "",
+    "the full relative path stays unambiguous"
+);
+
+// --- applyPresetModel must agree with the warning ---------------------------
+// Regression: a legacy preset storing a bare name once reported healthy while the
+// dropdown appended "<name>  (missing)" and the launch emitted a path that does
+// not exist. Resolution and warning now share matchKnownModelName().
+function createSelectContext(optionValues, knownModelNames) {
+    const select = {
+        options: optionValues.map((value) => ({ value, textContent: value })),
+        value: "",
+        appendChild(option) { this.options.push(option); },
+    };
+    const selected = [];
+    const ctx = {
+        window: {},
+        document: {
+            getElementById: (id) => (id === "model-select" ? select : null),
+            createElement: () => ({ value: "", textContent: "" }),
+        },
+        console: { ...console, debug: () => {}, warn: () => {} },
+        localStorage: { getItem: () => null, setItem: () => {} },
+        FLAGS: [],
+    };
+    ctx.window = ctx;
+    ctx.window.LlamaGui = {
+        manager: { getKnownModelNames: () => knownModelNames },
+        flagCore: { setSelectedModelValue: (value) => selected.push(value) },
+    };
+    vm.createContext(ctx);
+    vm.runInContext(source, ctx, { filename: "presets.js" });
+    return { ctx, select, selected };
+}
+
+{
+    const known = new Set(["kept.gguf", "vendor/nested.gguf"]);
+    const { ctx, select, selected } = createSelectContext(["", "kept.gguf", "vendor/nested.gguf"], known);
+    const optionCount = select.options.length;
+
+    ctx.window.LlamaGui.presets.applyPresetModel("nested.gguf");
+    assert.equal(select.value, "vendor/nested.gguf", "a legacy bare name must resolve to its nested path");
+    assert.equal(selected.at(-1), "vendor/nested.gguf", "the launch must use the resolved path");
+    assert.equal(select.options.length, optionCount, "resolving must not append a (missing) option");
+    assert.equal(
+        ctx.window.LlamaGui.presets.isPresetModelMissing("nested.gguf"),
+        false,
+        "the warning must agree that the resolved model is present"
+    );
+
+    ctx.window.LlamaGui.presets.applyPresetModel("vendor/nested.gguf");
+    assert.equal(select.value, "vendor/nested.gguf", "an exact relative path must select the same option");
+    assert.equal(select.options.length, optionCount, "an exact match must not append an option either");
+
+    ctx.window.LlamaGui.presets.applyPresetModel("VENDOR/NESTED.GGUF");
+    assert.equal(select.value, "vendor/nested.gguf", "resolution must restore the option's exact spelling");
+}
+
+{
+    // Both halves must still agree when the name genuinely cannot be resolved.
+    const known = new Set(["vendor-a/dup.gguf", "vendor-b/dup.gguf"]);
+    const { ctx, select } = createSelectContext(["", "vendor-a/dup.gguf", "vendor-b/dup.gguf"], known);
+
+    ctx.window.LlamaGui.presets.applyPresetModel("dup.gguf");
+    assert.equal(select.value, "dup.gguf", "an ambiguous basename must not silently pick a folder");
+    assert.equal(select.options.at(-1).textContent, "dup.gguf  (missing)", "it must be marked in the dropdown");
+    assert.equal(
+        ctx.window.LlamaGui.presets.isPresetModelMissing("dup.gguf"),
+        true,
+        "and the preset must warn to match the dropdown"
+    );
+}
+
+{
+    const known = new Set(["kept.gguf"]);
+    const { ctx, select } = createSelectContext(["", "kept.gguf"], known);
+
+    ctx.window.LlamaGui.presets.applyPresetModel("gone.gguf");
+    assert.equal(select.value, "gone.gguf", "a genuine miss keeps the saved value");
+    assert.equal(select.options.at(-1).textContent, "gone.gguf  (missing)", "a genuine miss is still marked");
+    assert.equal(
+        ctx.window.LlamaGui.presets.isPresetModelMissing("gone.gguf"),
+        true,
+        "a genuine miss must warn"
+    );
+}
 
 // --- Library summary (preset-todo item 6) ----------------------------------
 // The summary describes the visible presets, so its numbers always agree with

--- a/ui/js/benchmark-ui.js
+++ b/ui/js/benchmark-ui.js
@@ -138,6 +138,10 @@
         return { tool: null, model: "", flags: data };
     }
 
+    function getModelName(model) {
+        return typeof model === "string" ? model : (model && (model.name || model.filename)) || "";
+    }
+
     function cloneFlags(values) {
         const copy = {};
         for (const [key, value] of Object.entries(values || {})) {
@@ -245,7 +249,11 @@
         const tool = benchmarkType === "perplexity" ? "llama-perplexity" : "llama-bench";
         const flags = cloneFlags(source.flags || {});
         const defaultFlags = options.defaultFlags || {};
-        const model = String(source.model || "").trim();
+        const resolvePresetModelName = root.presets && root.presets.resolvePresetModelName;
+        const resolvedModel = source.sourceType === "preset" && typeof resolvePresetModelName === "function"
+            ? resolvePresetModelName(source.model, options.modelCandidates || [])
+            : source.model;
+        const model = String(resolvedModel || "").trim();
         const allFlags = options.flags || [];
         const args = [];
         const applied = [];
@@ -532,6 +540,7 @@
     function getBuildOptions() {
         return {
             source: getSourceSnapshot(),
+            modelCandidates: cachedModels.map(getModelName).filter(Boolean),
             benchmarkType: getSelectedBenchmarkType(),
             flags: getFlags(),
             defaultFlags: getDefaultFlagValues(),
@@ -683,14 +692,14 @@
         empty.textContent = "-- Select Model --";
         select.appendChild(empty);
         for (const model of cachedModels) {
-            const name = typeof model === "string" ? model : (model.name || model.filename || "");
+            const name = getModelName(model);
             if (!name) continue;
             const opt = document.createElement("option");
             opt.value = name;
             opt.textContent = name;
             select.appendChild(opt);
         }
-        if (current && cachedModels.some((model) => (typeof model === "string" ? model : model.name) === current)) {
+        if (current && cachedModels.some((model) => getModelName(model) === current)) {
             select.value = current;
         }
         renderCommand();

--- a/ui/js/benchmark-ui.js
+++ b/ui/js/benchmark-ui.js
@@ -252,11 +252,19 @@
         const excluded = [];
 
         if (model) {
-            if (model.includes("..") || model.includes("/") || model.includes("\\")) {
+            // Reuse flag-core's validator rather than restating the rules, so the
+            // benchmark and launch paths cannot drift apart. Missing means the
+            // module failed to load: fail closed instead of skipping the check.
+            const normalize = root.flagCore && root.flagCore.normalizeModelRelPath;
+            if (typeof normalize !== "function") {
+                return { tool, args, applied, excluded, error: "Model path validation is unavailable." };
+            }
+            const modelPath = normalize(model);
+            if (!modelPath) {
                 return { tool, args, applied, excluded, error: "Invalid model filename." };
             }
-            args.push(["-m", "models/" + model]);
-            applied.push({ label: "Model", value: model });
+            args.push(["-m", "models/" + modelPath]);
+            applied.push({ label: "Model", value: modelPath });
         }
 
         if (benchmarkType === "perplexity" && !hasSelectedModelArg(args)) {

--- a/ui/js/flag-core.js
+++ b/ui/js/flag-core.js
@@ -102,6 +102,19 @@
         return selectedModel;
     }
 
+    // Relative path under models/: bare name or folder/name.gguf. Rejects escapes.
+    // Exported on the flagCore API and used by benchmark-ui too: this is the one
+    // definition of the rule, so `-m models/<name>` cannot diverge between the
+    // launch and benchmark paths. Deliberately kept here rather than injected via
+    // configure(), so a missing configure() call can never disable the check.
+    function normalizeModelRelPath(modelName) {
+        const name = String(modelName || "").trim().replace(/\\/g, "/");
+        if (!name || name.startsWith("/") || !name.toLowerCase().endsWith(".gguf")) return "";
+        const parts = name.split("/");
+        if (parts.some((part) => !part || part === "." || part === "..")) return "";
+        return parts.join("/");
+    }
+
     function setMultipleFlagValues(patch, options = {}) {
         patchFlagValues(patch);
         if (typeof afterPatch === "function") {
@@ -431,9 +444,9 @@
             args.push(...parsedCustom.tokens);
         }
 
-        const modelName = model;
-        if (modelName) {
-            if (modelName.includes("..") || modelName.includes("/") || modelName.includes("\\")) {
+        if (model) {
+            const modelName = normalizeModelRelPath(model);
+            if (!modelName) {
                 return { args, error: "Invalid model filename.", warnings };
             }
             args.push(["-m", "models/" + modelName]);
@@ -492,6 +505,7 @@
         isValidGpuLayersValue,
         normalizeGpuLayersValue,
         parseCustomLaunchArgs,
+        normalizeModelRelPath,
         redactSensitiveTokens,
         hasLaunchModelArg,
         buildLaunchArgs,

--- a/ui/js/flag-core.js
+++ b/ui/js/flag-core.js
@@ -109,7 +109,12 @@
     // configure(), so a missing configure() call can never disable the check.
     function normalizeModelRelPath(modelName) {
         const name = String(modelName || "").trim().replace(/\\/g, "/");
-        if (!name || name.startsWith("/") || !name.toLowerCase().endsWith(".gguf")) return "";
+        if (
+            !name
+            || name.startsWith("/")
+            || /^[A-Za-z]:/.test(name)
+            || !name.toLowerCase().endsWith(".gguf")
+        ) return "";
         const parts = name.split("/");
         if (parts.some((part) => !part || part === "." || part === "..")) return "";
         return parts.join("/");

--- a/ui/js/presets.js
+++ b/ui/js/presets.js
@@ -141,16 +141,24 @@ function applyPresetModel(modelName) {
         return;
     }
 
-    const existingOption = Array.from(modelSelect.options).find(o => o.value === target);
-    if (!existingOption) {
+    // Resolve against the live options rather than the cached name set: only the
+    // options carry the exact spelling, and a preset saved before models/ gained
+    // subfolders stores a bare name that now lives at "<folder>/<name>". Falling
+    // back to the raw value keeps the "(missing)" marker for a genuine miss, and
+    // for an ambiguous basename that getPresetWarnings() also flags.
+    const options = Array.from(modelSelect.options);
+    const match = matchKnownModelName(target, options.map((option) => option.value));
+    const resolved = match.status === "found" ? match.name : target;
+
+    if (!options.some(o => o.value === resolved)) {
         const opt = document.createElement("option");
-        opt.value = target;
-        opt.textContent = `${target}  (missing)`;
+        opt.value = resolved;
+        opt.textContent = `${resolved}  (missing)`;
         modelSelect.appendChild(opt);
     }
 
-    modelSelect.value = target;
-    if (flagCore) flagCore.setSelectedModelValue(target);
+    modelSelect.value = resolved;
+    if (flagCore) flagCore.setSelectedModelValue(resolved);
     if (typeof syncQuickLaunchModelOptions === "function") {
         syncQuickLaunchModelOptions();
     }
@@ -217,15 +225,53 @@ function getPresetModelFileName(model) {
     return parts.length ? parts[parts.length - 1] : "";
 }
 
-// Deliberately conservative: only report a miss we are confident about. An
+// Match a saved preset model against a list of models/-relative names, which is
+// what /api/models now reports. Presets written before models/ gained subfolders
+// store a bare file name, so a bare name also matches a nested file's basename -
+// but only when exactly one folder holds that name. Two matches are reported as
+// ambiguous rather than resolved, because guessing between them would quietly
+// launch the wrong weights.
+//
+// Shared with applyPresetModel() on purpose: if the two disagreed, a preset could
+// report healthy while the dropdown showed it as missing and the launch failed.
+// Returns the matched name in its original spelling, since the launch needs the
+// exact case even though the cached list is lowercased.
+function matchKnownModelName(model, candidates) {
+    const raw = String(model || "").trim().replace(/\\/g, "/");
+    if (!raw) return { status: "empty", name: "" };
+
+    const names = [];
+    for (const entry of candidates || []) {
+        if (typeof entry === "string" && entry) names.push(entry);
+    }
+
+    const lower = raw.toLowerCase();
+    const exact = names.find((name) => name.toLowerCase() === lower);
+    if (exact) return { status: "found", name: exact };
+
+    const fileName = getPresetModelFileName(raw).toLowerCase();
+    if (!fileName) return { status: "missing", name: "" };
+    const sameFileName = names.filter(
+        (name) => getPresetModelFileName(name).toLowerCase() === fileName
+    );
+    if (sameFileName.length === 1) return { status: "found", name: sameFileName[0] };
+    if (sameFileName.length > 1) return { status: "ambiguous", name: "" };
+    return { status: "missing", name: "" };
+}
+
+// Deliberately conservative: only report a problem we are confident about. An
 // unknown model list, an empty models/ folder, or a preset with no model saved
 // all stay silent, since a preset for a model held on another machine is
 // legitimate and false warnings would make the Warnings filter useless.
+// Returns "" (no problem), "missing", or "ambiguous".
+function getPresetModelIssue(model, knownModelNames = getKnownModelNames()) {
+    if (!knownModelNames || knownModelNames.size === 0) return "";
+    const match = matchKnownModelName(model, knownModelNames);
+    return match.status === "missing" || match.status === "ambiguous" ? match.status : "";
+}
+
 function isPresetModelMissing(model, knownModelNames = getKnownModelNames()) {
-    if (!knownModelNames || knownModelNames.size === 0) return false;
-    const fileName = getPresetModelFileName(model);
-    if (!fileName) return false;
-    return !knownModelNames.has(fileName.toLowerCase());
+    return Boolean(getPresetModelIssue(model, knownModelNames));
 }
 
 function getPresetWarnings(presetData, knownModelNames = getKnownModelNames()) {
@@ -233,9 +279,13 @@ function getPresetWarnings(presetData, knownModelNames = getKnownModelNames()) {
     const flags = (presetData && presetData.flags) || {};
     const chatTemplate = flags.chat_template;
 
-    if (isPresetModelMissing(presetData && presetData.model, knownModelNames)) {
+    const modelIssue = getPresetModelIssue(presetData && presetData.model, knownModelNames);
+    if (modelIssue === "missing") {
         const fileName = getPresetModelFileName(presetData.model);
         warnings.push(`Model file "${fileName}" is not in the models folder. Add it back or point this preset at another model before launching.`);
+    } else if (modelIssue === "ambiguous") {
+        const fileName = getPresetModelFileName(presetData.model);
+        warnings.push(`Model file "${fileName}" is in more than one models subfolder, so this preset cannot say which one it means. Re-pick the model to save its full path.`);
     }
 
     if (chatTemplate && typeof isSupportedChatTemplateValue === "function" && !isSupportedChatTemplateValue(chatTemplate)) {
@@ -1974,6 +2024,9 @@ if (window.LlamaGui) {
         normalizeImportedPresetData,
         getPresetWarnings,
         isPresetModelMissing,
+        getPresetModelIssue,
+        matchKnownModelName,
+        applyPresetModel,
         getPresetModelFileName,
         getPresetLibrarySummary,
         getPresetHealthMessage,

--- a/ui/js/presets.js
+++ b/ui/js/presets.js
@@ -147,8 +147,7 @@ function applyPresetModel(modelName) {
     // back to the raw value keeps the "(missing)" marker for a genuine miss, and
     // for an ambiguous basename that getPresetWarnings() also flags.
     const options = Array.from(modelSelect.options);
-    const match = matchKnownModelName(target, options.map((option) => option.value));
-    const resolved = match.status === "found" ? match.name : target;
+    const resolved = resolvePresetModelName(target, options.map((option) => option.value));
 
     if (!options.some(o => o.value === resolved)) {
         const opt = document.createElement("option");
@@ -188,7 +187,7 @@ function preparePresetLaunchState(data, options = {}) {
     }
     return {
         tool: normalized.tool,
-        model: normalized.model,
+        model: resolvePresetModelName(normalized.model),
         flags,
     };
 }
@@ -228,12 +227,12 @@ function getPresetModelFileName(model) {
 // Match a saved preset model against a list of models/-relative names, which is
 // what /api/models now reports. Presets written before models/ gained subfolders
 // store a bare file name, so a bare name also matches a nested file's basename -
-// but only when exactly one folder holds that name. Two matches are reported as
-// ambiguous rather than resolved, because guessing between them would quietly
-// launch the wrong weights.
+// but only when exactly one folder holds that name. Legacy absolute paths get the
+// same compatibility fallback. Explicit relative paths must match exactly so a
+// stale path cannot silently select different weights from another folder.
 //
-// Shared with applyPresetModel() on purpose: if the two disagreed, a preset could
-// report healthy while the dropdown showed it as missing and the launch failed.
+// Shared by presence checks and every preset launch path: if they disagreed, a
+// preset could report healthy while the dropdown or launch used another value.
 // Returns the matched name in its original spelling, since the launch needs the
 // exact case even though the cached list is lowercased.
 function matchKnownModelName(model, candidates) {
@@ -249,6 +248,9 @@ function matchKnownModelName(model, candidates) {
     const exact = names.find((name) => name.toLowerCase() === lower);
     if (exact) return { status: "found", name: exact };
 
+    const canMatchBasename = !raw.includes("/") || raw.startsWith("/") || /^[A-Za-z]:\//.test(raw);
+    if (!canMatchBasename) return { status: "missing", name: "" };
+
     const fileName = getPresetModelFileName(raw).toLowerCase();
     if (!fileName) return { status: "missing", name: "" };
     const sameFileName = names.filter(
@@ -257,6 +259,18 @@ function matchKnownModelName(model, candidates) {
     if (sameFileName.length === 1) return { status: "found", name: sameFileName[0] };
     if (sameFileName.length > 1) return { status: "ambiguous", name: "" };
     return { status: "missing", name: "" };
+}
+
+function getModelSelectCandidateNames() {
+    if (typeof document === "undefined") return [];
+    const select = document.getElementById("model-select");
+    return select ? Array.from(select.options).map((option) => option.value).filter(Boolean) : [];
+}
+
+function resolvePresetModelName(model, candidates = getModelSelectCandidateNames()) {
+    const target = String(model || "");
+    const match = matchKnownModelName(target, candidates);
+    return match.status === "found" ? match.name : target;
 }
 
 // Deliberately conservative: only report a problem we are confident about. An
@@ -271,7 +285,7 @@ function getPresetModelIssue(model, knownModelNames = getKnownModelNames()) {
 }
 
 function isPresetModelMissing(model, knownModelNames = getKnownModelNames()) {
-    return Boolean(getPresetModelIssue(model, knownModelNames));
+    return getPresetModelIssue(model, knownModelNames) === "missing";
 }
 
 function getPresetWarnings(presetData, knownModelNames = getKnownModelNames()) {
@@ -2026,6 +2040,7 @@ if (window.LlamaGui) {
         isPresetModelMissing,
         getPresetModelIssue,
         matchKnownModelName,
+        resolvePresetModelName,
         applyPresetModel,
         getPresetModelFileName,
         getPresetLibrarySummary,


### PR DESCRIPTION
Add recursive discovery of .gguf files under models/ (excluding top-level models/mmproj), follow symlinks safely, and return models as models/-relative paths. Export flagCore.normalizeModelRelPath and use it from benchmark-ui and launch arg building to centralize and validate "-m models/<name>" rules. Make file picker default to models/ for model-related purposes and offer GGUF-first filters. Change HF download layout to models/<slug>/<file>.gguf and models/mmproj/<slug>/<file>.gguf via slugify_repo_id; check existence using repo-relative paths. Update presets logic to resolve nested names, detect ambiguous basenames, and keep applyPresetModel in sync. Update README/docs and tests accordingly.
