### PR TITLE
Use toast notifications for presets/samplers

### DIFF
--- a/tests/frontend/flag_sync_smoke.cjs
+++ b/tests/frontend/flag_sync_smoke.cjs
@@ -373,6 +373,8 @@ async function main() {
             buffer: Buffer.from(JSON.stringify({ flags: { temperature: 0.45 } })),
         });
         await page.waitForFunction(() => document.querySelector("#preset-status")?.textContent.includes("already exists"));
+        await page.waitForFunction(() => Array.from(document.querySelectorAll(".toast-message"))
+            .some((toast) => /already exists/i.test(toast.textContent)));
         assert.equal(presetSaveBodies.length, 0, "a colliding launch preset import must not write");
 
         await page.setInputFiles("#preset-import", {
@@ -381,6 +383,8 @@ async function main() {
             buffer: Buffer.from(JSON.stringify({ flags: { temperature: 0.45 } })),
         });
         await page.waitForFunction(() => document.querySelector("#preset-status")?.textContent.includes('Imported preset "new-import"'));
+        await page.waitForFunction(() => Array.from(document.querySelectorAll(".toast-message"))
+            .some((toast) => toast.textContent.includes('Imported preset "new-import"')));
         assert.equal(presetSaveBodies.length, 1);
         assert.equal(presetSaveBodies[0].name, "new-import");
         assert.equal(presetSaveBodies[0].overwrite, false, "launch preset imports must ask the backend to reject races");
@@ -967,15 +971,13 @@ async function main() {
             const preset = raw && JSON.parse(raw)["Smoke Sampler"];
             return preset?.temperature === 0.64 && preset?.presence_penalty === 0.4;
         });
+        await page.waitForFunction(() => Array.from(document.querySelectorAll(".toast-message"))
+            .some((toast) => toast.textContent.includes('Saved sampler preset "Smoke Sampler"')));
         await setRangeValue(page, "#quick-temperature", "0.11");
         await page.fill("#quick-sampler-name", "smoke sampler");
-        let samplerCollisionMessage = "";
-        page.once("dialog", async (dialog) => {
-            samplerCollisionMessage = dialog.message();
-            await dialog.accept();
-        });
         await page.click("#btn-quick-sampler-save");
-        assert.match(samplerCollisionMessage, /already exists/i);
+        await page.waitForFunction(() => Array.from(document.querySelectorAll(".toast-message"))
+            .some((toast) => /already exists/i.test(toast.textContent)));
         const samplerStoreAfterCollision = await page.evaluate(
             () => JSON.parse(localStorage.getItem("llama_gui_sampler_presets_v1") || "{}")
         );
@@ -1041,6 +1043,8 @@ async function main() {
             return Object.prototype.hasOwnProperty.call(store, "Renamed Smoke Sampler")
                 && !Object.prototype.hasOwnProperty.call(store, "Smoke Sampler");
         });
+        await page.waitForFunction(() => Array.from(document.querySelectorAll(".toast-message"))
+            .some((toast) => toast.textContent.includes('Renamed sampler preset to "Renamed Smoke Sampler"')));
         assert.equal(
             await page.inputValue(configSamplerSelect),
             "custom|Renamed Smoke Sampler",
@@ -1058,8 +1062,9 @@ async function main() {
         // A built-in is not renameable, and the attempt must not disturb the store.
         await page.selectOption(configSamplerSelect, "builtin|Balanced");
         await page.dispatchEvent(configSamplerSelect, "change");
-        page.once("dialog", (dialog) => dialog.accept());
         await page.locator(".sampler-presets button", { hasText: "Rename" }).click();
+        await page.waitForFunction(() => Array.from(document.querySelectorAll(".toast-message"))
+            .some((toast) => toast.textContent.includes("Built-in sampler presets cannot be renamed.")));
         assert.equal(
             await page.evaluate(() => document.querySelector("#prompt-modal")?.classList.contains("hidden")),
             true,
@@ -1071,7 +1076,6 @@ async function main() {
             "a refused rename must leave the sampler store untouched"
         );
 
-        const samplerImportDialog = page.waitForEvent("dialog");
         await page.setInputFiles('.sampler-presets input[type="file"]', {
             name: "samplers.json",
             mimeType: "application/json",
@@ -1082,16 +1086,14 @@ async function main() {
                 },
             })),
         });
-        const samplerImportCollision = await samplerImportDialog;
-        assert.match(samplerImportCollision.message(), /already exists/i);
-        await samplerImportCollision.accept();
+        await page.waitForFunction(() => Array.from(document.querySelectorAll(".toast-message"))
+            .some((toast) => /already exists/i.test(toast.textContent)));
         assert.deepEqual(
             await page.evaluate(() => Object.keys(JSON.parse(localStorage.getItem("llama_gui_sampler_presets_v1") || "{}"))),
             ["Renamed Smoke Sampler"],
             "a colliding sampler import must reject the entire batch before writing"
         );
 
-        const malformedSamplerDialog = page.waitForEvent("dialog");
         await page.setInputFiles('.sampler-presets input[type="file"]', {
             name: "malformed-samplers.json",
             mimeType: "application/json",
@@ -1102,9 +1104,8 @@ async function main() {
                 },
             })),
         });
-        const malformedSamplerAlert = await malformedSamplerDialog;
-        assert.match(malformedSamplerAlert.message(), /must contain an object of sampler values/i);
-        await malformedSamplerAlert.accept();
+        await page.waitForFunction(() => Array.from(document.querySelectorAll(".toast-message"))
+            .some((toast) => /must contain an object of sampler values/i.test(toast.textContent)));
         assert.deepEqual(
             await page.evaluate(() => Object.keys(JSON.parse(localStorage.getItem("llama_gui_sampler_presets_v1") || "{}"))),
             ["Renamed Smoke Sampler"],
@@ -1125,6 +1126,8 @@ async function main() {
             const raw = localStorage.getItem("llama_gui_sampler_presets_v1");
             return raw && Object.prototype.hasOwnProperty.call(JSON.parse(raw), "Renamed Again Sampler");
         });
+        await page.waitForFunction(() => Array.from(document.querySelectorAll(".toast-message"))
+            .some((toast) => toast.textContent.includes('Renamed sampler preset to "Renamed Again Sampler"')));
         await selectSection(page, "configure");
         assert.equal(
             await page.inputValue(configSamplerSelect),
@@ -1141,6 +1144,8 @@ async function main() {
         await page.click("#btn-quick-sampler-delete");
         await page.click("#confirm-modal-ok");
         await deletePromise;
+        await page.waitForFunction(() => Array.from(document.querySelectorAll(".toast-message"))
+            .some((toast) => toast.textContent.includes('Deleted sampler preset "Renamed Again Sampler"')));
 
         await page.evaluate(() => {
             window.LlamaGui.flagCore.setMultipleFlagValues({

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -52,8 +52,10 @@ samplerPresets.configure({
     getDefaultFlagValues: getDefaultValues,
     confirmAction,
     promptAction,
+    showToast,
     refreshSamplerPresetSelect: (preferredValue) => quickLaunchUi.refreshSamplerPresetSelect(preferredValue),
 });
+presetsApi.configure({ showToast });
 const remoteTunnelUi = window.LlamaGui.remoteTunnelUi;
 remoteTunnelUi.configure({
     fetchJson,
@@ -102,6 +104,7 @@ quickLaunchUi.configure({
     getSamplerRenameMessage: samplerPresets.getSamplerRenameMessage,
     confirmAction,
     promptAction,
+    showToast,
     hasLaunchModelArg: flagCore.hasLaunchModelArg,
 });
 benchmarkUi.configure({

--- a/ui/js/presets.js
+++ b/ui/js/presets.js
@@ -1,6 +1,11 @@
 const SENSITIVE_PRESET_FLAG_IDS = new Set(["api_key"]);
 const SENSITIVE_CUSTOM_ARG_PATTERN = /(^|[^A-Za-z0-9_-])--api-key(?=$|[=\s])/;
 const SENSITIVE_CUSTOM_ARG_MESSAGE = "Presets cannot include --api-key in Custom Launch Args. Use the API Key field instead.";
+let presetDependencies = {};
+
+function configurePresetModule(options = {}) {
+    presetDependencies = Object.assign({}, presetDependencies, options);
+}
 
 function hasSensitiveCustomArgs(flags) {
     const raw = flags && flags.custom_args;
@@ -1530,6 +1535,14 @@ function showPresetStatus(message, type = "success", durationMs = 2200) {
     }, durationMs);
 }
 
+function showPresetActionStatus(message, type = "success", durationMs = 2200) {
+    showPresetStatus(message, type, durationMs);
+    const showToast = presetDependencies.showToast;
+    if (typeof showToast === "function") {
+        showToast(message, type, { duration: durationMs });
+    }
+}
+
 // Missing-model warnings are computed at build time from the cached model list,
 // so a model list that changes after the groups were built leaves the badges,
 // the Warnings filter, and the summary stale. loadPresets() already runs on
@@ -1722,13 +1735,13 @@ async function savePreset() {
         if (result.saved) {
             nameInput.value = "";
             loadPresets();
-            showPresetStatus(`Saved preset \"${result.name || name}\"`, "success");
+            showPresetActionStatus(`Saved preset \"${result.name || name}\"`, "success");
         }
     } catch (e) {
         const message = e && e.message === SENSITIVE_CUSTOM_ARG_MESSAGE
             ? SENSITIVE_CUSTOM_ARG_MESSAGE
             : "Failed to save preset";
-        showPresetStatus(message, "error", 5000);
+        showPresetActionStatus(message, "error", 5000);
         console.warn("Failed to save preset", e);
     }
 }
@@ -1808,7 +1821,7 @@ async function renamePreset(name) {
     );
     if (nextName === null) return;
     if (!nextName) {
-        showPresetStatus("Preset name cannot be empty", "error", 3200);
+        showPresetActionStatus("Preset name cannot be empty", "error", 3200);
         return;
     }
     if (nextName === name) return;
@@ -1829,11 +1842,11 @@ async function renamePreset(name) {
                 selectedPresetNames.add(savedName);
             }
             await loadPresets();
-            showPresetStatus(`Renamed to "${savedName}"`, "success");
+            showPresetActionStatus(`Renamed to "${savedName}"`, "success");
         }
     } catch (e) {
         const message = e && e.message ? e.message : "Failed to rename preset";
-        showPresetStatus(message, "error", 5000);
+        showPresetActionStatus(message, "error", 5000);
         console.warn("Failed to rename preset", e);
     }
 }
@@ -1872,9 +1885,9 @@ async function deletePreset(name) {
     try {
         await fetchJson("/api/presets/" + encodeURIComponent(name), { method: "DELETE" });
         loadPresets();
-        showPresetStatus(`Deleted preset \"${name}\"`, "success");
+        showPresetActionStatus(`Deleted preset \"${name}\"`, "success");
     } catch (e) {
-        showPresetStatus("Failed to delete preset", "error", 3200);
+        showPresetActionStatus("Failed to delete preset", "error", 3200);
         console.warn("Failed to delete preset", e);
     }
 }
@@ -1905,7 +1918,7 @@ async function favoriteSelectedPresets(favorite) {
 async function deleteSelectedPresets() {
     const names = Array.from(selectedPresetNames);
     if (names.length === 0) {
-        showPresetStatus("No presets selected", "error", 3200);
+        showPresetActionStatus("No presets selected", "error", 3200);
         return;
     }
 
@@ -1925,9 +1938,9 @@ async function deleteSelectedPresets() {
             selectedPresetName = "";
         }
         await loadPresets();
-        showPresetStatus(`Deleted ${names.length} preset${names.length === 1 ? "" : "s"}`, "success");
+        showPresetActionStatus(`Deleted ${names.length} preset${names.length === 1 ? "" : "s"}`, "success");
     } catch (e) {
-        showPresetStatus("Failed to delete selected presets", "error", 3200);
+        showPresetActionStatus("Failed to delete selected presets", "error", 3200);
         console.warn("Failed to delete selected presets", e);
         loadPresets();
     }
@@ -2056,7 +2069,7 @@ async function handlePresetImport(file) {
             for (const entry of bulkPresets) {
                 const name = sanitizeImportedPresetName(entry.name || "Imported-" + (++unnamedIdx));
                 if (!name) {
-                    showPresetStatus("Preset import contains an invalid name.", "error", 3200);
+                    showPresetActionStatus("Preset import contains an invalid name.", "error", 3200);
                     return;
                 }
                 const normalized = normalizeImportedPresetData(entry.data || {});
@@ -2066,7 +2079,7 @@ async function handlePresetImport(file) {
             const existingPresets = await fetchPresetEntries();
             const collision = findPresetImportNameCollision(existingPresets, pendingImports);
             if (collision) {
-                showPresetStatus(`Preset "${collision}" already exists. Rename or delete it before importing.`, "error", 5000);
+                showPresetActionStatus(`Preset "${collision}" already exists. Rename or delete it before importing.`, "error", 5000);
                 return;
             }
             try {
@@ -2080,29 +2093,29 @@ async function handlePresetImport(file) {
                     importedCount++;
                 }
                 loadPresets();
-                showPresetStatus(`Imported ${importedCount} preset(s)`, "success");
+                showPresetActionStatus(`Imported ${importedCount} preset(s)`, "success");
             } catch (e) {
                 console.warn("Preset import failed mid-loop", e);
                 loadPresets();
-                showPresetStatus("Failed to import some presets.", "error", 3200);
+                showPresetActionStatus("Failed to import some presets.", "error", 3200);
             }
             return;
         }
 
         const normalized = normalizeImportedPresetData(parsed);
         if (!hasUsablePresetData(normalized)) {
-            showPresetStatus("Preset file contains no usable data.", "error", 3200);
+            showPresetActionStatus("Preset file contains no usable data.", "error", 3200);
             return;
         }
         const name = sanitizeImportedPresetName(file.name.replace(/\.json$/i, ""));
         if (!name) {
-            showPresetStatus("Preset import contains an invalid name.", "error", 3200);
+            showPresetActionStatus("Preset import contains an invalid name.", "error", 3200);
             return;
         }
         const existingPresets = await fetchPresetEntries();
         const collision = findPresetImportNameCollision(existingPresets, [{ name }]);
         if (collision) {
-            showPresetStatus(`Preset "${collision}" already exists. Rename or delete it before importing.`, "error", 5000);
+            showPresetActionStatus(`Preset "${collision}" already exists. Rename or delete it before importing.`, "error", 5000);
             return;
         }
         await fetchJson("/api/presets", {
@@ -2111,18 +2124,19 @@ async function handlePresetImport(file) {
             body: JSON.stringify({ name, data: normalized, overwrite: false }),
         });
         loadPresets();
-        showPresetStatus(`Imported preset \"${name}\"`, "success");
+        showPresetActionStatus(`Imported preset \"${name}\"`, "success");
     } catch (err) {
         const message = err && err.message === SENSITIVE_CUSTOM_ARG_MESSAGE
             ? SENSITIVE_CUSTOM_ARG_MESSAGE
             : "Failed to import preset";
-        showPresetStatus(message, "error", 5000);
+        showPresetActionStatus(message, "error", 5000);
         console.warn("Failed to import preset", err);
     }
 }
 
 if (window.LlamaGui) {
     window.LlamaGui.presets = Object.assign(window.LlamaGui.presets || {}, {
+        configure: configurePresetModule,
         loadPreset,
         fetchPresetEntries,
         findPresetByName,

--- a/ui/js/quick-launch-ui.js
+++ b/ui/js/quick-launch-ui.js
@@ -27,6 +27,7 @@
     let getSamplerRenameMessage = () => "Failed to rename sampler preset.";
     let confirmAction = async () => false;
     let promptAction = async () => null;
+    let showToast = () => {};
     let hasLaunchModelArg = () => false;
 
     let quickLaunchFitCtxLinked = true;
@@ -59,6 +60,7 @@
         getSamplerRenameMessage = options.getSamplerRenameMessage || getSamplerRenameMessage;
         confirmAction = options.confirmAction || confirmAction;
         promptAction = options.promptAction || promptAction;
+        showToast = options.showToast || showToast;
         hasLaunchModelArg = options.hasLaunchModelArg || hasLaunchModelArg;
     }
 
@@ -706,12 +708,13 @@
             const name = typedName || selectedCustomName;
             if (!name) {
                 nameInput.focus();
+                showToast("Enter a sampler preset name.", "error");
                 return;
             }
 
             const result = saveSamplerPreset(name, selectedCustomName, collectSamplerValues());
             if (!result.ok) {
-                alert(getSamplerRenameMessage(result.reason) + " Rename or delete the existing preset first.");
+                showToast(getSamplerRenameMessage(result.reason) + " Rename or delete the existing preset first.", "error");
                 return;
             }
             nameInput.value = "";
@@ -719,13 +722,14 @@
             configFlagsUi.renderFlags();
             const samplerSelect = document.getElementById("quick-sampler-select");
             if (samplerSelect) samplerSelect.value = `custom|${result.name}`;
+            showToast(`Saved sampler preset "${result.name}"`, "success");
         });
 
         on("btn-quick-sampler-rename", "click", async () => {
             const selected = getSelectedSamplerEntry();
             if (!selected) return;
             if (selected.source !== "custom") {
-                alert(getSamplerRenameMessage("builtin"));
+                showToast(getSamplerRenameMessage("builtin"), "error");
                 return;
             }
 
@@ -740,19 +744,20 @@
 
             const result = renameSamplerPreset(selected.name, nextName);
             if (!result.ok) {
-                alert(getSamplerRenameMessage(result.reason));
+                showToast(getSamplerRenameMessage(result.reason), "error");
                 return;
             }
 
             refreshSamplerPresetSelect(`custom|${result.name}`);
             configFlagsUi.renderFlags();
+            showToast(`Renamed sampler preset to "${result.name}"`, "success");
         });
 
         on("btn-quick-sampler-delete", "click", async () => {
             const selected = getSelectedSamplerEntry();
             if (!selected) return;
             if (selected.source !== "custom") {
-                alert("Built-in sampler presets cannot be deleted.");
+                showToast("Built-in sampler presets cannot be deleted.", "error");
                 return;
             }
 
@@ -768,6 +773,7 @@
             saveSamplerPresetStore(store);
             refreshSamplerPresetSelect();
             configFlagsUi.renderFlags();
+            showToast(`Deleted sampler preset "${selected.name}"`, "success");
         });
 
         const quickSamplerFieldMap = {

--- a/ui/js/sampler-presets.js
+++ b/ui/js/sampler-presets.js
@@ -10,6 +10,12 @@
         dependencies = Object.assign({}, dependencies, options || {});
     }
 
+    function showSamplerPresetToast(message, type = "success", options = {}) {
+        if (typeof dependencies.showToast === "function") {
+            dependencies.showToast(message, type, options);
+        }
+    }
+
     function getFlagCore() {
         return dependencies.flagCore || window.LlamaGui.flagCore;
     }
@@ -363,23 +369,25 @@
             const name = typedName || selectedCustomName;
             if (!name) {
                 nameInput.focus();
+                showSamplerPresetToast("Enter a sampler preset name.", "error");
                 return;
             }
             const result = saveSamplerPreset(name, selectedCustomName, collectSamplerValues());
             if (!result.ok) {
-                alert(getSamplerRenameMessage(result.reason) + " Rename or delete the existing preset first.");
+                showSamplerPresetToast(getSamplerRenameMessage(result.reason) + " Rename or delete the existing preset first.", "error");
                 return;
             }
             refreshOptions(`custom|${result.name}`);
             refreshConsumers();
             nameInput.value = "";
+            showSamplerPresetToast(`Saved sampler preset "${result.name}"`, "success");
         });
 
         renameBtn.addEventListener("click", async () => {
             const selected = getSelectedPresetEntry();
             if (!selected) return;
             if (selected.source !== "custom") {
-                alert(getSamplerRenameMessage("builtin"));
+                showSamplerPresetToast(getSamplerRenameMessage("builtin"), "error");
                 return;
             }
 
@@ -397,19 +405,20 @@
 
             const result = renameSamplerPreset(selected.name, nextName);
             if (!result.ok) {
-                alert(getSamplerRenameMessage(result.reason));
+                showSamplerPresetToast(getSamplerRenameMessage(result.reason), "error");
                 return;
             }
 
             refreshOptions(`custom|${result.name}`);
             refreshConsumers(`custom|${result.name}`);
+            showSamplerPresetToast(`Renamed sampler preset to "${result.name}"`, "success");
         });
 
         delBtn.addEventListener("click", async () => {
             const selected = getSelectedPresetEntry();
             if (!selected) return;
             if (selected.source !== "custom") {
-                alert("Built-in sampler presets cannot be deleted.");
+                showSamplerPresetToast("Built-in sampler presets cannot be deleted.", "error");
                 return;
             }
             const confirmAction = dependencies.confirmAction;
@@ -427,6 +436,7 @@
             saveSamplerPresetStore(store);
             refreshOptions();
             refreshConsumers();
+            showSamplerPresetToast(`Deleted sampler preset "${selected.name}"`, "success");
         });
 
         exportBtn.addEventListener("click", () => {
@@ -459,7 +469,7 @@
 
                 const incoming = getSamplerPresetImportEntries(parsed);
                 if (!incoming) {
-                    alert("Invalid sampler preset JSON format. Every preset must contain an object of sampler values.");
+                    showSamplerPresetToast("Invalid sampler preset JSON format. Every preset must contain an object of sampler values.", "error");
                     return;
                 }
 
@@ -469,7 +479,7 @@
                 for (const item of incoming) {
                     const baseName = String(item.name || "Imported Sampler").trim() || "Imported Sampler";
                     if (isSamplerPresetNameTaken(baseName, pendingStore)) {
-                        alert(`A sampler preset named "${baseName}" already exists. Rename or delete it before importing.`);
+                        showSamplerPresetToast(`A sampler preset named "${baseName}" already exists. Rename or delete it before importing.`, "error");
                         return;
                     }
                     pendingStore[baseName] = normalizeSamplerPresetValues(item.values);
@@ -479,8 +489,9 @@
                 saveSamplerPresetStore(pendingStore);
                 refreshOptions(lastImportedName ? `custom|${lastImportedName}` : "");
                 refreshConsumers();
+                showSamplerPresetToast(`Imported ${incoming.length} sampler preset${incoming.length === 1 ? "" : "s"}`, "success");
             } catch (e) {
-                alert("Failed to import sampler preset: " + e.message);
+                showSamplerPresetToast("Failed to import sampler preset: " + e.message, "error");
             }
         });
 


### PR DESCRIPTION
Replace blocking alerts/dialogs with toast notifications across presets, quick-launch and sampler modules. Add showToast plumbing (app.js -> presets/quick-launch/sampler) and a configure hook for presets; introduce showPresetActionStatus to forward preset status messages to the toast system. Update sampler-presets and quick-launch-ui to call toasts instead of alert()/dialog(), and adjust frontend smoke test to wait for toast messages. This makes UX non-blocking and centralizes status display handling. Files: ui/js/{app,presets,quick-launch-ui,sampler-presets}.js and tests/frontend/flag_sync_smoke.cjs.

