### PR TITLE
docs additions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md
 
+When changes are made to llama-gui, update the /docs/changelog.md (summaries are fine)
+
 ## Project Reference
 
 - Full architecture / module map: **`docs/directory.md`** (read before non-trivial work)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,3 @@
+--Changelog--
+
+Please give a brief summary of changes made to the program, include the date the changes were made.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
 --Changelog--
 
 Please give a brief summary of changes made to the program, include the date the changes were made.
+
+## 2026-08-04
+
+- Added `docs/upstream-changes.md` to track announced llama.cpp compatibility changes and any required Llama-GUI follow-up.

--- a/docs/upstream-changes.md
+++ b/docs/upstream-changes.md
@@ -1,0 +1,15 @@
+# Upstream Changes
+
+Track announced llama.cpp changes that may require coordinated Llama-GUI updates. Remove an entry after the local change is completed or deliberately declined.
+
+## Pending
+
+### llama-server default port: 8080 to 9931
+
+- **Upstream:** [ggml-org/llama.cpp#26508](https://github.com/ggml-org/llama.cpp/pull/26508)
+- **Status:** The advance-warning notice merged on 2026-08-03; the actual default-port change is still pending.
+- **Current impact:** None. Llama-GUI explicitly launches `llama-server` with `--port 8080`.
+- **Recheck when:** Upstream changes the actual default or a bundled llama.cpp release includes that change.
+- **Local decision:** Either keep Llama-GUI's explicit 8080 default or change the frontend, backend target fallback, external-server form, tests, and documentation to 9931 together.
+
+Last checked: 2026-08-04.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation tracking an upcoming llama.cpp default-port change from 8080 to 9931.
  * Clarified that the current application configuration remains unaffected.
  * Documented conditions for reassessing compatibility and available local configuration options.
  * Added a dated changelog entry for the upstream compatibility update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->