### PR TITLE
Fix stats bar KV usage and live speeds

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,13 @@
 
 Please give a brief summary of changes made to the program, include the date the changes were made.
 
+## 2026-08-06
+
+- Fixed the server stats bar KV-usage cell, which was stuck at `--%` on current llama.cpp: upstream removed `llamacpp:kv_cache_usage_ratio` from `/metrics`, and the `/slots` fallback expected `next_token` as an array while current builds return it as an object. `getSlotStats()` (`ui/js/app.js`) now accepts both shapes and uses `n_prompt_tokens` (prompt + generated tokens, including accepted MTP draft tokens) as the numerator instead of generated-only `n_decoded`.
+- Stats bar speeds no longer freeze mid-generation: `pollStats()` derives live rates from per-task `/slots` deltas (`n_prompt_tokens_processed` and `next_token.n_decoded`), while retaining llama-server's completed-request gauges as a compatibility fallback.
+- Fresh launches keep a zero baseline so work completed before the first poll is counted; reconnects seed from their first successful counter sample, and chat resets cannot snapshot unsampled zeroes into lifetime totals.
+- Expanded the frontend smoke check to cover current and legacy `next_token` shapes, fresh-launch and reconnect baselines, and live generation speed while the global completion counter remains unchanged.
+
 ## 2026-08-04
 
 - Added `docs/architecture.html` — a self-contained visual architecture guide for users and developers, covering the system context, layer map, backend route/service pairing, request lifecycle, frontend script-order dependency ladder, the `flagCore` shared-state contract, key flows (launch, chat, install, app update), the full 43-endpoint API surface, persistence, security boundaries, and where to edit for common changes.

--- a/tests/frontend/flag_sync_smoke.cjs
+++ b/tests/frontend/flag_sync_smoke.cjs
@@ -143,6 +143,32 @@ async function main() {
         const externalTargetRequests = [];
         let installedBackend = "cpu";
         let chatResponseMode = "ok";
+        let statsMetrics = {
+            promptTokens: 0,
+            promptSpeed: 0,
+            genTokens: 0,
+            genSpeed: 0,
+            processing: 0,
+        };
+        const idleStatsSlots = [
+            { id: 0, n_ctx: 1000, speculative: false, is_processing: false },
+            {
+                id: 1,
+                n_ctx: 1000,
+                speculative: false,
+                is_processing: false,
+                n_prompt_tokens: 125,
+                next_token: { has_next_token: true, n_decoded: 5, n_remain: 875 },
+            },
+            {
+                id: 2,
+                n_ctx: 1000,
+                speculative: false,
+                is_processing: false,
+                next_token: [{ n_decoded: 50, n_remain: 950 }],
+            },
+        ];
+        let statsSlots = idleStatsSlots;
 
         page.on("pageerror", (error) => {
             pageErrors.push(error.message || String(error));
@@ -337,10 +363,11 @@ async function main() {
                 status: 200,
                 contentType: "text/plain",
                 body: [
-                    "llamacpp:prompt_tokens_total 0",
-                    "llamacpp:prompt_tokens_seconds 0",
-                    "llamacpp:tokens_predicted_total 0",
-                    "llamacpp:predicted_tokens_seconds 0",
+                    `llamacpp:prompt_tokens_total ${statsMetrics.promptTokens}`,
+                    `llamacpp:prompt_tokens_seconds ${statsMetrics.promptSpeed}`,
+                    `llamacpp:tokens_predicted_total ${statsMetrics.genTokens}`,
+                    `llamacpp:predicted_tokens_seconds ${statsMetrics.genSpeed}`,
+                    `llamacpp:requests_processing ${statsMetrics.processing}`,
                 ].join("\n"),
             });
         });
@@ -350,16 +377,7 @@ async function main() {
             await route.fulfill({
                 status: 200,
                 contentType: "application/json",
-                body: JSON.stringify([
-                    { id: 0, n_ctx: 1000, speculative: false, is_processing: false },
-                    {
-                        id: 1,
-                        n_ctx: 1000,
-                        speculative: false,
-                        is_processing: false,
-                        next_token: [{ n_decoded: 125, n_remain: 875 }],
-                    },
-                ]),
+                body: JSON.stringify(statsSlots),
             });
         });
 
@@ -731,8 +749,68 @@ async function main() {
         await selectSection(page, "quick-launch");
         assert.equal(await page.inputValue("#quick-api-key"), "first-secret, second-secret");
 
-        await page.evaluate(() => startStatsPolling());
-        await page.waitForFunction(() => document.querySelector("#stats-kv-usage")?.textContent === "13%");
+        statsMetrics = {
+            promptTokens: 40,
+            promptSpeed: 4,
+            genTokens: 20,
+            genSpeed: 2,
+            processing: 1,
+        };
+        statsSlots = [{
+            id: 1,
+            id_task: 1,
+            n_ctx: 1000,
+            is_processing: true,
+            n_prompt_tokens: 60,
+            n_prompt_tokens_processed: 40,
+            next_token: { n_decoded: 20 },
+        }];
+        await page.evaluate(async () => {
+            startStatsPolling(null, { operation: "manual-launch" });
+            snapshotStatsBaseline();
+            await pollStats();
+        });
+        assert.equal(await page.textContent("#stats-prompt-tokens"), "40",
+            "fresh launches must retain tokens processed before the first stats poll");
+        assert.equal(await page.textContent("#stats-gen-tokens"), "20");
+
+        statsMetrics = {
+            promptTokens: 1000,
+            promptSpeed: 11,
+            genTokens: 500,
+            genSpeed: 7,
+            processing: 0,
+        };
+        statsSlots = idleStatsSlots;
+        await page.evaluate(async () => {
+            startStatsPolling();
+            snapshotStatsBaseline();
+            await pollStats();
+        });
+        assert.equal(await page.textContent("#stats-prompt-tokens"), "0",
+            "pre-poll chat resets must not expose lifetime prompt counters after reconnect");
+        assert.equal(await page.textContent("#stats-gen-tokens"), "0");
+        assert.equal(await page.textContent("#stats-kv-usage"), "13%");
+
+        statsMetrics.processing = 1;
+        statsSlots = [{
+            id: 1,
+            id_task: 77,
+            n_ctx: 1000,
+            is_processing: true,
+            n_prompt_tokens: 110,
+            n_prompt_tokens_processed: 100,
+            next_token: { n_decoded: 10 },
+        }];
+        await page.evaluate(() => pollStats());
+        await wait(1100);
+        statsSlots[0].n_prompt_tokens = 140;
+        statsSlots[0].next_token.n_decoded = 40;
+        await page.evaluate(() => pollStats());
+        const liveGenSpeed = Number(await page.textContent("#stats-gen-speed"));
+        assert.ok(liveGenSpeed > 20 && liveGenSpeed < 35,
+            `generation speed must use live slot deltas, got ${liveGenSpeed}`);
+
         await page.evaluate(() => stopStatsPolling());
         assert.equal(metricsHeaders.at(-1).authorization, "Bearer first-secret");
         assert.equal(slotsHeaders.at(-1).authorization, "Bearer first-secret");

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -23,8 +23,10 @@ const DEFAULT_TOAST_DURATION_MS = 4000;
 // Slow-load warning outlives default toasts: the model may still come up.
 const SLOW_LOAD_WARNING_TOAST_MS = 10000;
 
-let chatStatsBaseline = { promptTokens: 0, genTokens: 0 };
+let chatStatsBaseline = null;
 let chatStatsRaw = { promptTokens: 0, genTokens: 0 };
+let chatStatsSampled = false;
+let chatStatsRate = { at: 0, slots: {} };
 const scheduleMemoryEstimate = debounce(updateMemoryEstimate, 700);
 // Shared Quick Launch and sampler data is defined in app-data.js.
 const apiTab = window.LlamaGui.apiTab;
@@ -877,11 +879,16 @@ function stopOutputPolling() {
     processOutputCursor.reset();
 }
 
-function startStatsPolling() {
+function startStatsPolling(_runtime, lifecycleState) {
     stopStatsPolling();
     const epoch = statsEpoch;
-    chatStatsBaseline = { promptTokens: 0, genTokens: 0 };
+    // Fresh processes start their counters at zero. Restored processes need a
+    // first-poll baseline so their lifetime counters do not become session totals.
+    const freshLaunch = lifecycleState && lifecycleState.operation !== "restore";
+    chatStatsBaseline = freshLaunch ? { promptTokens: 0, genTokens: 0 } : null;
     chatStatsRaw = { promptTokens: 0, genTokens: 0 };
+    chatStatsSampled = false;
+    chatStatsRate = { at: 0, slots: {} };
     document.getElementById("stats-bar").classList.remove("hidden");
     statsInitialTimer = setTimeout(() => {
         statsInitialTimer = null;
@@ -983,8 +990,11 @@ async function updateMemoryEstimate() {
 }
 
 function snapshotStatsBaseline() {
-    chatStatsBaseline.promptTokens = chatStatsRaw.promptTokens;
-    chatStatsBaseline.genTokens = chatStatsRaw.genTokens;
+    if (!chatStatsSampled) return;
+    chatStatsBaseline = {
+        promptTokens: chatStatsRaw.promptTokens,
+        genTokens: chatStatsRaw.genTokens,
+    };
 }
 
 async function pollStats(epoch = statsEpoch) {
@@ -1012,26 +1022,72 @@ async function pollStats(epoch = statsEpoch) {
         const promptSpeed = metrics["llamacpp:prompt_tokens_seconds"];
         const genTokens = metrics["llamacpp:tokens_predicted_total"];
         const genSpeed = metrics["llamacpp:predicted_tokens_seconds"];
+        const slotStats = await fetchSlotStats(host, port, controller.signal);
         let kvUsage = metrics["llamacpp:kv_cache_usage_ratio"];
-        if (kvUsage === undefined) {
-            kvUsage = await fetchSlotKvUsage(host, port, controller.signal);
-        }
+        if (kvUsage === undefined) kvUsage = slotStats?.kvUsage;
         if (epoch !== statsEpoch) return;
+        const now = Date.now();
+        const requestsProcessing = metrics["llamacpp:requests_processing"] ?? slotStats?.processing;
+        let livePromptSpeed;
+        let liveGenSpeed;
+        if (slotStats && chatStatsRate.at > 0) {
+            const elapsed = (now - chatStatsRate.at) / 1000;
+            if (elapsed >= 1) {
+                let promptDelta = 0;
+                let genDelta = 0;
+                let promptComparable = false;
+                let genComparable = false;
+                for (const sample of slotStats.samples) {
+                    const previous = chatStatsRate.slots[sample.key];
+                    if (!previous) continue;
+                    if (sample.promptTokens !== null && previous.promptTokens !== null
+                        && sample.promptTokens >= previous.promptTokens) {
+                        promptDelta += sample.promptTokens - previous.promptTokens;
+                        promptComparable = true;
+                    }
+                    if (sample.genTokens !== null && previous.genTokens !== null
+                        && sample.genTokens >= previous.genTokens) {
+                        genDelta += sample.genTokens - previous.genTokens;
+                        genComparable = true;
+                    }
+                }
+                if (promptComparable) livePromptSpeed = promptDelta / elapsed;
+                else if (requestsProcessing === 0) livePromptSpeed = 0;
+                if (genComparable) liveGenSpeed = genDelta / elapsed;
+                else if (requestsProcessing === 0) liveGenSpeed = 0;
+            }
+        }
+        if (slotStats) {
+            chatStatsRate = {
+                at: now,
+                slots: Object.fromEntries(slotStats.samples.map(sample => [sample.key, sample])),
+            };
+        }
         if (promptTokens !== undefined) chatStatsRaw.promptTokens = promptTokens;
         if (genTokens !== undefined) chatStatsRaw.genTokens = genTokens;
-        const deltaPrompt = promptTokens !== undefined ? Math.max(0, promptTokens - chatStatsBaseline.promptTokens) : null;
-        const deltaGen = genTokens !== undefined ? Math.max(0, genTokens - chatStatsBaseline.genTokens) : null;
+        if (promptTokens !== undefined || genTokens !== undefined) chatStatsSampled = true;
+        if (!chatStatsBaseline && chatStatsSampled) {
+            snapshotStatsBaseline();
+        }
+        const deltaPrompt = promptTokens !== undefined && chatStatsBaseline
+            ? Math.max(0, promptTokens - chatStatsBaseline.promptTokens)
+            : null;
+        const deltaGen = genTokens !== undefined && chatStatsBaseline
+            ? Math.max(0, genTokens - chatStatsBaseline.genTokens)
+            : null;
         if (deltaPrompt !== null) {
             document.getElementById("stats-prompt-tokens").textContent = deltaPrompt.toLocaleString();
         }
-        if (promptSpeed !== undefined) {
-            document.getElementById("stats-prompt-speed").textContent = promptSpeed.toFixed(1);
+        const effectivePromptSpeed = livePromptSpeed !== undefined ? livePromptSpeed : promptSpeed;
+        if (effectivePromptSpeed !== undefined) {
+            document.getElementById("stats-prompt-speed").textContent = effectivePromptSpeed.toFixed(1);
         }
         if (deltaGen !== null) {
             document.getElementById("stats-gen-tokens").textContent = deltaGen.toLocaleString();
         }
-        if (genSpeed !== undefined) {
-            document.getElementById("stats-gen-speed").textContent = genSpeed.toFixed(1);
+        const effectiveGenSpeed = liveGenSpeed !== undefined ? liveGenSpeed : genSpeed;
+        if (effectiveGenSpeed !== undefined) {
+            document.getElementById("stats-gen-speed").textContent = effectiveGenSpeed.toFixed(1);
         }
         if (deltaPrompt !== null && deltaGen !== null) {
             document.getElementById("stats-context").textContent = (deltaPrompt + deltaGen).toLocaleString();
@@ -1076,7 +1132,7 @@ async function reconcileAuthoritativeStatus(status) {
     return outcome;
 }
 
-async function fetchSlotKvUsage(host, port, signal) {
+async function fetchSlotStats(host, port, signal) {
     try {
         const params = new URLSearchParams({ host, port: String(port) });
         const resp = await fetch(`/api/llama/slots?${params.toString()}`, {
@@ -1085,26 +1141,47 @@ async function fetchSlotKvUsage(host, port, signal) {
         });
         if (!resp.ok) return undefined;
         const slots = await resp.json();
-        return getSlotKvUsage(slots);
+        return getSlotStats(slots);
     } catch (e) {
-        console.debug("Failed to fetch llama-server slots for KV usage", e);
+        console.debug("Failed to fetch llama-server slot stats", e);
         return undefined;
     }
 }
 
-function getSlotKvUsage(slots) {
+function getSlotStats(slots) {
     if (!Array.isArray(slots)) return undefined;
     let maxUsage;
+    let processing = 0;
+    const samples = [];
     for (const slot of slots) {
+        if (slot?.is_processing) processing += 1;
+        const nextToken = Array.isArray(slot?.next_token) ? slot.next_token[0] : slot?.next_token;
+        const promptTokens = Number(slot?.n_prompt_tokens_processed);
+        const genTokens = Number(nextToken?.n_decoded);
+        if (slot?.is_processing && slot?.id !== undefined && (slot?.id_task !== undefined
+            || Number.isFinite(promptTokens) || Number.isFinite(genTokens))) {
+            samples.push({
+                key: `${slot.id}:${slot.id_task ?? ""}`,
+                promptTokens: Number.isFinite(promptTokens) && promptTokens >= 0 ? promptTokens : null,
+                genTokens: Number.isFinite(genTokens) && genTokens >= 0 ? genTokens : null,
+            });
+        }
+
         const nCtx = Number(slot?.n_ctx);
         if (!Number.isFinite(nCtx) || nCtx <= 0) continue;
-        const tokenState = Array.isArray(slot.next_token) ? slot.next_token[0] : null;
-        const nDecoded = Number(tokenState?.n_decoded);
-        if (!Number.isFinite(nDecoded) || nDecoded < 0) continue;
-        const usage = Math.max(0, Math.min(1, nDecoded / nCtx));
+        // Current llama-server reports total tokens held by the slot as
+        // n_prompt_tokens (prompt + generated, including accepted MTP draft
+        // tokens). Older builds only expose generated tokens via next_token,
+        // which is an object in current builds and was an array before.
+        let used = Number(slot?.n_prompt_tokens);
+        if (!Number.isFinite(used) || used < 0) {
+            used = Number(nextToken?.n_decoded);
+        }
+        if (!Number.isFinite(used) || used < 0) continue;
+        const usage = Math.max(0, Math.min(1, used / nCtx));
         maxUsage = maxUsage === undefined ? usage : Math.max(maxUsage, usage);
     }
-    return maxUsage;
+    return { kvUsage: maxUsage, processing, samples };
 }
 
 async function pollOutput() {


### PR DESCRIPTION
Handle upstream llama.cpp/llama-server changes for stats: accept both legacy and current next_token shapes, and use n_prompt_tokens (prompt+generated) to compute per-slot KV usage. Derive live prompt/gen speeds from per-slot deltas (with requests-processing fallback), and fix fresh-launch / reconnect baseline behavior so pre-poll counters aren't misreported. Add slot sampling (keyed samples) and unify slot fetch into fetchSlotStats/getSlotStats. Expanded frontend smoke test and docs changelog to cover the new behaviors. Files: ui/js/app.js, tests/frontend/flag_sync_smoke.cjs, docs/changelog.md.