### PR TITLE
Store downloaded mmproj files beside models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,10 @@ Deeper maps (services, data flow, script order): `docs/directory.md`.
 | Flag definitions | `npm run test:flag-definitions` |
 | Custom launch-args parser | `node tests/frontend/custom_launch_args_unit.cjs` |
 | Mirrored controls / flag state / command preview / shared setters | `npm run test:frontend` |
-| Backend | `python -m unittest discover tests -v` |
+| Backend | `.venv/Scripts/python.exe -m unittest discover tests -v` |
 | New or removed backend route | Also update the Route Modules table in `docs/directory.md` (including its endpoint count) and the API surface table in `docs/architecture.html` — `tests/backend/test_docs_sync.py` fails on drift in either direction |
 | Full frontend suite / more detail | `docs/tests.md` |
+
+Run backend tests with the **project venv** (`.venv/Scripts/python.exe` on Windows, `.venv/bin/python` elsewhere), not the system Python. System interpreters lack runtime deps like `huggingface_hub`, and HF download tests then error with misleading "require the huggingface_hub package" failures.
 
 Minimal diffs; reuse existing helpers and patterns; fix root causes, not symptoms.

--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ If you use [Pinokio](https://pinokio.computer/), install via [thomas9120/llama-g
 
 ## Getting Models
 
-Place `llama.cpp`-compatible `.gguf` files in `models/` or any subfolder under it (or use **Open Models**). They appear in **Quick Launch** and **Configure**. The `models/mmproj/` folder is reserved for vision projectors and is not listed as a launch model.
+Place `llama.cpp`-compatible `.gguf` files in `models/` or any subfolder under it (or use **Open Models**). They appear in **Quick Launch** and **Configure**. Vision projector filenames are excluded from the launch-model list; the legacy `models/mmproj/` folder remains excluded too.
 
 Or download in-app from **Quick Launch**:
 1. Enter a Hugging Face repo ID such as `owner/model-GGUF`.
 2. Click **Find GGUF Files**, pick a file, then **Download**.
 
-Downloads land under `models/<owner_repo>/` (repo id with `/` → `_`). For vision/multimodal models, also download the matching `mmproj` file when the repo provides one. Projector files land in `models/mmproj/<owner_repo>/` and the Multimodal Projector setting is applied automatically.
+Downloads land under `models/<owner_repo>/` (repo id with `/` → `_`). For vision/multimodal models, also download the matching `mmproj` file when the repo provides one. The projector lands beside its model in the same folder, and the Multimodal Projector setting is applied automatically.
 
 ## First Run
 

--- a/backend/routes/models.py
+++ b/backend/routes/models.py
@@ -1,6 +1,6 @@
 """Model file API routes."""
 
-from backend.services.hf_download import is_mmproj_filename
+from backend.services import hf_download
 
 
 # Keep the legacy projector folder hidden for existing installations.
@@ -41,7 +41,7 @@ def _iter_gguf_files(models_dir):
                 elif (
                     entry.is_file()
                     and entry.suffix.lower() == ".gguf"
-                    and not is_mmproj_filename(entry.name)
+                    and not hf_download.is_mmproj_filename(entry.name)
                 ):
                     yield entry
             except OSError:

--- a/backend/routes/models.py
+++ b/backend/routes/models.py
@@ -1,7 +1,9 @@
 """Model file API routes."""
 
-# Reserved subfolder: vision projectors live here and are applied via the mmproj
-# flag, so they must never appear in the launch model list.
+from backend.services.hf_download import is_mmproj_filename
+
+
+# Keep the legacy projector folder hidden for existing installations.
 MMPROJ_DIR_NAME = "mmproj"
 
 
@@ -36,7 +38,11 @@ def _iter_gguf_files(models_dir):
                     if is_root and entry.name.lower() == MMPROJ_DIR_NAME:
                         continue
                     stack.append((entry, False))
-                elif entry.is_file() and entry.suffix.lower() == ".gguf":
+                elif (
+                    entry.is_file()
+                    and entry.suffix.lower() == ".gguf"
+                    and not is_mmproj_filename(entry.name)
+                ):
                     yield entry
             except OSError:
                 # A broken or unreadable link is simply not a model.

--- a/backend/services/hf_download.py
+++ b/backend/services/hf_download.py
@@ -76,7 +76,7 @@ def is_mmproj_filename(filename: Any) -> bool:
 
 
 def slugify_repo_id(repo_id: str) -> str:
-    """Folder name for a repo's downloads, under models/ and models/mmproj/.
+    """Folder name for a repo's downloads under models/.
 
     Not injective: only "/" is substituted, so "owner/my_model" and
     "owner_my/model" both slugify to "owner_my_model" and share a folder. Left
@@ -300,18 +300,13 @@ def start_hf_model_download(
     model_dest = ctx.paths.models / repo_folder / model_basename
     mmproj_dest = None
     if mmproj_file:
-        mmproj_dest = (
-            ctx.paths.models
-            / "mmproj"
-            / repo_folder
-            / pathlib.PurePosixPath(mmproj_file).name
-        )
+        mmproj_dest = model_dest.parent / pathlib.PurePosixPath(mmproj_file).name
 
     existing = []
     if model_dest.exists():
         existing.append(model_name)
     if mmproj_dest and mmproj_dest.exists():
-        existing.append(f"mmproj/{repo_folder}/{mmproj_dest.name}")
+        existing.append(f"{repo_folder}/{mmproj_dest.name}")
     if existing and not overwrite:
         raise FileExistsError(f"Already exists: {', '.join(existing)}")
 
@@ -330,8 +325,6 @@ def start_hf_model_download(
             destinations.append(mmproj_dest)
         try:
             model_dest.parent.mkdir(parents=True, exist_ok=True)
-            if mmproj_dest:
-                mmproj_dest.parent.mkdir(parents=True, exist_ok=True)
             total = get_hf_file_size(repo_id, model_file, revision, token)
             if mmproj_file:
                 total += get_hf_file_size(repo_id, mmproj_file, revision, token)

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -546,7 +546,7 @@ footer {
 
     <div class="row">
         <div class="node ghost"><div class="t">llama/</div><div class="d">Installed binaries + grammars</div></div>
-        <div class="node ghost"><div class="t">models/</div><div class="d">GGUF weights, <code>mmproj/</code> for projectors</div></div>
+        <div class="node ghost"><div class="t">models/</div><div class="d">GGUF weights and colocated projectors</div></div>
         <div class="node ghost"><div class="t">presets/</div><div class="d">Saved launch configurations (JSON)</div></div>
         <div class="node ghost"><div class="t">config.json</div><div class="d">Installed version, backend, remembered target</div></div>
         <div class="node ghost"><div class="t">tools/</div><div class="d">Auto-downloaded <code>cloudflared</code></div></div>
@@ -1167,7 +1167,7 @@ flagCore.setFlagValue("temperature", 0.5);
         <tbody>
         <tr><td class="mono">config.json</td><td>Installed version, active backend, release tag, remembered external target <em>(address only — never a key)</em></td></tr>
         <tr><td class="mono">presets/*.json</td><td>Saved launch configurations, plus <code>.preset-created-times</code></td></tr>
-        <tr><td class="mono">models/</td><td>GGUF weights in any subfolder; <code>models/mmproj/</code> reserved for projectors</td></tr>
+        <tr><td class="mono">models/</td><td>GGUF weights in any subfolder; downloaded projectors live beside their models</td></tr>
         <tr><td class="mono">llama/bin/</td><td>Installed binaries; <code>llama/custom/</code> for a user-supplied build</td></tr>
         <tr><td class="mono">tools/cloudflared/</td><td>Auto-downloaded tunnel binary</td></tr>
         </tbody>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ Please give a brief summary of changes made to the program, include the date the
 ## 2026-08-07
 
 - Hugging Face companion mmproj downloads now land beside their model in `models/<repo>/` instead of under `models/mmproj/<repo>/`. Projector filenames and the legacy top-level `models/mmproj/` folder stay out of the launch-model list.
+- Aligned `backend/routes/models.py` with the module-import style used by the other route modules (behavior unchanged).
 
 ## 2026-08-06
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 Please give a brief summary of changes made to the program, include the date the changes were made.
 
+## 2026-08-07
+
+- Hugging Face companion mmproj downloads now land beside their model in `models/<repo>/` instead of under `models/mmproj/<repo>/`. Projector filenames and the legacy top-level `models/mmproj/` folder stay out of the launch-model list.
+
 ## 2026-08-06
 
 - Fixed the server stats bar KV-usage cell, which was stuck at `--%` on current llama.cpp: upstream removed `llamacpp:kv_cache_usage_ratio` from `/metrics`, and the `/slots` fallback expected `next_token` as an array while current builds return it as an object. `getSlotStats()` (`ui/js/app.js`) now accepts both shapes and uses `n_prompt_tokens` (prompt + generated tokens, including accepted MTP draft tokens) as the numerator instead of generated-only `n_decoded`.

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -36,7 +36,7 @@
 | `tests/` | Frontend (Node/Playwright) + backend (unittest) tests |
 | `docs/` | Documentation: todo, flag audit, architecture, bugtracker |
 | `llama/` | Downloaded `llama.cpp` binaries at runtime |
-| `models/` | User model files (.gguf), in any subfolder; `models/mmproj/` is reserved for projectors |
+| `models/` | User model files (.gguf), in any subfolder; downloaded projectors live beside their models |
 | `presets/` | Saved launcher preset JSON files |
 | `tools/` | Auto-downloaded `cloudflared` binary |
 | `scripts/` | `create_windows_shortcuts.ps1` |
@@ -645,7 +645,7 @@ Chat sidebar has sliders for temperature, top-p, top-k, min-p, repeat-penalty, a
 
 ### Download Layout
 
-- Models land in `models/<slug>/<file>.gguf`, projectors in `models/mmproj/<slug>/<file>.gguf`, where `<slug>` is `slugify_repo_id(repo_id)`.
+- Models and their projectors land together in `models/<slug>/`, where `<slug>` is `slugify_repo_id(repo_id)`. The legacy top-level `models/mmproj/` folder remains excluded from model discovery.
 - `model_name` in the status payload is the `models/`-relative path (`<slug>/<file>.gguf`), so it matches `/api/models` and `applyPresetModel()` can select it directly.
 - The slug is not injective: only `/` is substituted, so `owner/my_model` and `owner_my/model` share a folder. Accepted deliberately — an injective scheme would rename every existing download folder, and a shared folder is harmless because files keep their own names and a same-name clash hits the overwrite prompt below.
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -46,10 +46,10 @@ npm run test:frontend
 Runs the Playwright smoke test for browser-level shared-state sync. This is also the only suite that can cover the Configure sampler preset panel, because `renderFlags()` destroys and rebuilds it — the `<select>` an assertion reads is a different element than the one that was clicked, which a `node:vm` harness cannot reproduce.
 
 ```powershell
-python -m unittest discover tests -v
+.venv\Scripts\python.exe -m unittest discover tests -v
 ```
 
-Runs the backend unittest suite. No install needed — `unittest` is in the standard library.
+Runs the backend unittest suite. Use the project venv, not the system Python: HF download tests need runtime deps like `huggingface_hub`, and a system interpreter errors with misleading "require the huggingface_hub package" failures.
 
 ```powershell
 .venv\Scripts\python.exe -m pytest tests/backend -q

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -234,11 +234,16 @@ class ExtractedRouteTests(unittest.TestCase):
                 ["vendor/nested.gguf"],
             )
 
-    def test_models_route_skips_reserved_mmproj_folder_only_at_top_level(self):
+    def test_models_route_skips_projectors_and_legacy_mmproj_folder(self):
         with tempfile.TemporaryDirectory() as tmp:
             ctx = make_context(tmp)
             ctx.paths.models.mkdir(parents=True)
-            for rel in ("mmproj/proj.gguf", "vendor/mmproj/nested.gguf", "mmproj-extra/other.gguf"):
+            for rel in (
+                "mmproj/proj.gguf",
+                "vendor/mmproj-model.gguf",
+                "vendor/mmproj/nested.gguf",
+                "mmproj-extra/other.gguf",
+            ):
                 path = ctx.paths.models / rel
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_bytes(b"x" * 16)

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -3004,7 +3004,7 @@ class StartHfModelDownloadPathTests(unittest.TestCase):
             mmproj_path = pathlib.Path(snap["mmproj_path"])
             self.assertEqual(
                 mmproj_path,
-                ctx.paths.models / "mmproj" / "owner_model" / "mmproj-model.gguf",
+                ctx.paths.models / "owner_model" / "mmproj-model.gguf",
             )
             self.assertTrue(mmproj_path.is_file())
 


### PR DESCRIPTION
Multimodal projector files downloaded from Hugging Face now land in the same repo folder as their model (`models/<repo>/`) instead of under a separate `models/mmproj/<repo>/` hierarchy. The legacy top-level `models/mmproj/` folder remains excluded from model discovery. Projector filename patterns are also filtered from the launch-model list regardless of folder location. Updated tests and documentation accordingly.