### PR TITLE
Compact sidebar runtime controls

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 Please give a brief summary of changes made to the program, include the date the changes were made.
 
+## 2026-08-12
+
+- Reworked the left sidebar into a compact persistent runtime dock: Launch/Stop and the danger-styled Python shutdown control remain reachable without scrolling, memory usage is an expandable stacked GPU/RAM estimate, the Model Switcher remains intact in a shorter panel, and a narrow icon-only theme control leaves more room for the adjacent build version.
+
 ## 2026-08-11
 
 - Updated the official Windows and Linux AMD install options to llama.cpp's ROCm 7.14 release assets, first available in `b10356`, while retaining the architecture-specific Lemonade ROCm options. Release choices are now filtered to builds that actually contain the selected backend asset.

--- a/tests/frontend/flag_sync_smoke.cjs
+++ b/tests/frontend/flag_sync_smoke.cjs
@@ -1436,10 +1436,16 @@ async function main() {
         assert.equal(pageErrors.length, 0, pageErrors.join("\n"));
 
         await selectSection(page, "quick-launch");
+        await page.setViewportSize({ width: 1346, height: 674 });
         const initialSidebarSlider = await page.evaluate(() => {
+            const sidebar = document.querySelector("#sidebar");
+            const nav = document.querySelector(".sidebar-nav");
             const panel = document.querySelector("#sidebar-model-switcher");
             const theme = document.querySelector(".theme-menu");
             const slider = document.querySelector("#sidebar-model-switcher-slider");
+            const actionsBox = document.querySelector(".sidebar-runtime-actions").getBoundingClientRect();
+            const memoryBox = document.querySelector("#sidebar-memory-estimate").getBoundingClientRect();
+            const sidebarBox = sidebar.getBoundingClientRect();
             const panelBox = panel.getBoundingClientRect();
             const themeBox = theme.getBoundingClientRect();
             return {
@@ -1449,12 +1455,19 @@ async function main() {
                 themeTop: themeBox.top,
                 footerBottom: document.querySelector(".sidebar-footer").getBoundingClientRect().bottom,
                 viewportHeight: window.innerHeight,
+                actionsContained: actionsBox.right <= sidebarBox.right,
+                memoryContained: memoryBox.right <= sidebarBox.right,
+                navFits: nav.scrollHeight <= nav.clientHeight,
             };
         });
         assert.equal(initialSidebarSlider.disabled, "true");
         assert.equal(initialSidebarSlider.value, "0");
         assert.ok(initialSidebarSlider.panelBottom <= initialSidebarSlider.themeTop, "model and theme switchers must not overlap");
         assert.ok(initialSidebarSlider.footerBottom <= initialSidebarSlider.viewportHeight, "sidebar footer must remain in the viewport");
+        assert.equal(initialSidebarSlider.actionsContained, true, "runtime buttons must stay inside the sidebar");
+        assert.equal(initialSidebarSlider.memoryContained, true, "memory estimate must stay inside the sidebar");
+        assert.equal(initialSidebarSlider.navFits, true, "sidebar navigation should fit without scrolling at 1346x674");
+        await page.setViewportSize({ width: 1280, height: 720 });
 
         await page.evaluate(async () => {
             const entries = [

--- a/tests/frontend/model_switch_ui_unit.cjs
+++ b/tests/frontend/model_switch_ui_unit.cjs
@@ -117,6 +117,12 @@ assert.ok(
     indexHtml.indexOf('id="sidebar-model-switcher"') < indexHtml.indexOf('class="theme-menu"'),
     "the compact model slider should sit above the theme menu"
 );
+const sidebarFooterMarkup = indexHtml.match(/<div class="sidebar-footer">[\s\S]*?<\/aside>/)?.[0] || "";
+assert.match(sidebarFooterMarkup, /class="sidebar-runtime-controls"/, "runtime controls should stay in the fixed sidebar footer");
+assert.match(sidebarFooterMarkup, /<details class="sidebar-memory-estimate"/, "memory details should collapse natively");
+assert.match(sidebarFooterMarkup, /class="sidebar-meta-row"[\s\S]*?class="theme-menu"[\s\S]*?id="version-badge"/, "theme and version should share one row");
+assert.match(styleSource, /\.sidebar-runtime-controls\s*{[^}]*min-width:\s*0/, "runtime controls must be allowed to shrink inside the sidebar");
+assert.match(styleSource, /\.sidebar-memory-reading\s*{[^}]*grid-template-columns:\s*30px/, "GPU and RAM values should use stacked rows");
 const sidebarSwitcherMarkup = indexHtml.match(/<section class="sidebar-model-switcher"[\s\S]*?<\/section>/)?.[0] || "";
 assert.doesNotMatch(sidebarSwitcherMarkup, /<svg/, "the sidebar switch thumb should not contain an icon");
 assert.match(source, /sidebarThumb\.addEventListener\("pointerdown", handleSidebarPointerDown\)/);

--- a/ui/css/style.css
+++ b/ui/css/style.css
@@ -167,9 +167,16 @@ body.chat-focus-mode .sidebar {
 .sidebar-runtime-controls {
     display: grid;
     gap: var(--space-2);
-    margin: var(--space-3) var(--space-1) 0;
-    padding: var(--space-3) var(--space-2) 0;
-    border-top: 1px solid var(--border);
+    width: 100%;
+    min-width: 0;
+}
+
+.sidebar-runtime-actions {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 36px;
+    gap: var(--space-2);
+    width: 100%;
+    min-width: 0;
 }
 
 .sidebar-runtime-btn {
@@ -182,78 +189,151 @@ body.chat-focus-mode .sidebar {
     flex: 0 0 auto;
 }
 
+.sidebar-runtime-power {
+    width: 36px;
+    min-height: 36px;
+}
+
+.sidebar-runtime-actions .sidebar-runtime-power {
+    justify-content: center;
+    padding: 0;
+}
+
+.sidebar-runtime-actions > .sidebar-runtime-btn {
+    grid-column: 1;
+    grid-row: 1;
+}
+
+.sidebar-runtime-actions > .sidebar-runtime-power {
+    grid-column: 2;
+    grid-row: 1;
+}
+
 .sidebar-memory-estimate {
-    margin-top: var(--space-2);
-    padding: var(--space-3);
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     background: var(--bg-raised);
 }
 
-.sidebar-memory-head {
-    display: flex;
+.sidebar-memory-summary {
+    display: grid;
+    grid-template-columns: 10px minmax(0, 1fr) auto;
     align-items: center;
-    justify-content: space-between;
-    gap: var(--space-2);
-    font-size: 11px;
-    font-weight: 700;
+    gap: 2px var(--space-2);
+    min-height: 50px;
+    padding: 6px var(--space-2);
+    color: var(--fg-muted);
+    cursor: pointer;
+    list-style: none;
+    white-space: nowrap;
+}
+
+.sidebar-memory-summary::-webkit-details-marker {
+    display: none;
+}
+
+.sidebar-memory-summary::before {
+    content: "›";
+    grid-column: 1;
+    grid-row: 1 / span 3;
+    color: var(--fg-faint);
+    font-size: 13px;
+    line-height: 1;
+    transition: transform var(--ease-fast);
+}
+
+.sidebar-memory-estimate[open] .sidebar-memory-summary::before {
+    transform: rotate(90deg);
+}
+
+.sidebar-memory-title {
+    grid-column: 2;
+    grid-row: 1;
     color: var(--fg);
+    font-size: 10px;
+    font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.4px;
 }
 
-.sidebar-memory-state {
-    color: var(--fg-faint);
+.sidebar-memory-reading {
+    grid-column: 2 / 4;
+    display: grid;
+    grid-template-columns: 30px minmax(0, 1fr);
+    align-items: baseline;
+    gap: var(--space-1);
+    min-width: 0;
+}
+
+.sidebar-memory-reading:nth-of-type(2) { grid-row: 2; }
+.sidebar-memory-reading:nth-of-type(3) { grid-row: 3; }
+
+.sidebar-memory-reading strong {
+    overflow: hidden;
+    color: var(--fg-bright);
     font-size: 10px;
+    text-overflow: ellipsis;
+}
+
+.sidebar-memory-state {
+    grid-column: 3;
+    grid-row: 1;
+    color: var(--fg-faint);
+    font-size: 9px;
     font-weight: 600;
-    text-transform: none;
-    letter-spacing: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .sidebar-memory-state.is-error { color: var(--red); }
 .sidebar-memory-state.is-ready { color: var(--green); }
 
-.sidebar-memory-grid {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: var(--space-2);
-    margin-top: var(--space-3);
-}
-
-.sidebar-memory-grid > div {
-    display: grid;
-    gap: 2px;
-}
-
 .sidebar-memory-label {
     color: var(--fg-muted);
-    font-size: 10px;
-}
-
-.sidebar-memory-grid strong {
-    color: var(--fg-bright);
-    font-size: 16px;
-    font-weight: 700;
+    font-size: 9px;
 }
 
 .sidebar-memory-detail {
-    margin-top: var(--space-2);
+    padding: 0 var(--space-3) var(--space-3);
+    border-top: 1px solid var(--border);
     color: var(--fg-muted);
     font-size: 10px;
     line-height: 1.35;
     white-space: pre-line;
 }
 
+.sidebar-memory-estimate[open] .sidebar-memory-detail {
+    padding-top: var(--space-2);
+}
+
 .sidebar-footer {
-    padding: var(--space-3);
+    padding: var(--space-2) var(--space-3);
     border-top: 1px solid var(--border);
     display: flex;
     flex-direction: column;
+    gap: 6px;
+}
+
+.sidebar-meta-row {
+    display: grid;
+    grid-template-columns: 48px minmax(0, 1fr);
+    align-items: center;
     gap: var(--space-2);
 }
 
+.sidebar-meta-row .badge {
+    display: block;
+    max-width: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .sidebar-model-switcher {
-    padding: 9px 10px 8px;
+    padding: 8px 10px;
     border: 1px solid var(--accent-border);
     border-radius: var(--radius-sm);
     background: linear-gradient(180deg, var(--accent-subtle), var(--bg-raised));
@@ -273,7 +353,7 @@ body.chat-focus-mode .sidebar {
     grid-template-columns: 14px minmax(0, 1fr) 14px;
     align-items: center;
     gap: 7px;
-    margin-top: 7px;
+    margin-top: 6px;
 }
 
 .sidebar-model-switcher-slot {
@@ -356,27 +436,23 @@ body.chat-focus-mode .sidebar {
 }
 
 .sidebar-model-switcher-status {
-    min-height: 11px;
-    margin-top: 5px;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
     overflow: hidden;
-    color: var(--fg-faint);
-    font-size: 8px;
-    font-weight: 700;
-    letter-spacing: 0.5px;
-    line-height: 1.35;
-    text-align: center;
-    text-overflow: ellipsis;
-    text-transform: uppercase;
+    clip: rect(0, 0, 0, 0);
     white-space: nowrap;
-}
-
-.sidebar-model-switcher[data-state="busy"] .sidebar-model-switcher-status {
-    color: var(--accent-text);
+    border: 0;
 }
 
 /* One trigger plus a pop-up list, so each new theme costs a row in the menu
    rather than a column in the sidebar. */
-.theme-menu { position: relative; }
+.theme-menu {
+    position: relative;
+    min-width: 0;
+}
 
 .theme-menu-trigger {
     display: flex;
@@ -396,6 +472,12 @@ body.chat-focus-mode .sidebar {
     transition: background var(--ease-fast), border-color var(--ease-fast), color var(--ease-fast);
 }
 
+.sidebar-meta-row .theme-menu-trigger {
+    justify-content: space-between;
+    gap: var(--space-1);
+    padding: var(--space-2);
+}
+
 .theme-menu-trigger:hover { color: var(--fg); background: var(--bg-hover); }
 
 .theme-menu-trigger[aria-expanded="true"] {
@@ -404,12 +486,15 @@ body.chat-focus-mode .sidebar {
 }
 
 .theme-menu-current {
-    flex: 1;
-    min-width: 0;
-    text-align: left;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
     overflow: hidden;
-    text-overflow: ellipsis;
+    clip: rect(0, 0, 0, 0);
     white-space: nowrap;
+    border: 0;
 }
 
 .theme-menu-chevron { transition: transform var(--ease-fast); }
@@ -428,6 +513,11 @@ body.chat-focus-mode .sidebar {
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-lg);
     z-index: 40;
+}
+
+.sidebar-meta-row .theme-menu-list {
+    right: auto;
+    width: calc(var(--sidebar-w) - 2 * var(--space-3));
 }
 
 .theme-menu-list[hidden] { display: none; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -100,40 +100,39 @@
                 Presets
             </button>
 
-            <div class="sidebar-runtime-controls" aria-label="Runtime controls">
-                <button id="btn-sidebar-launch" class="btn btn-primary sidebar-runtime-btn" type="button">
-                    <span class="icon icon-sm"><svg viewBox="0 0 24 24"><polygon points="5 3 19 12 5 21 5 3"/></svg></span>
-                    Launch
-                </button>
-                <button id="btn-sidebar-stop" class="btn btn-danger sidebar-runtime-btn hidden" type="button">
-                    <span class="icon icon-sm"><svg viewBox="0 0 24 24"><rect x="6" y="6" width="12" height="12"/></svg></span>
-                    Stop
-                </button>
-                <button id="btn-sidebar-stop-app" class="btn btn-danger btn-ghost sidebar-runtime-btn" type="button">
-                    <span class="icon icon-sm"><svg viewBox="0 0 24 24"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></span>
-                    Stop Python Server
-                </button>
-                <div class="sidebar-memory-estimate" id="sidebar-memory-estimate">
-                    <div class="sidebar-memory-head">
-                        <span>Memory Estimate</span>
-                        <span class="sidebar-memory-state" id="memory-estimate-state">Idle</span>
-                    </div>
-                    <div class="sidebar-memory-grid">
-                        <div>
-                            <span class="sidebar-memory-label">GPU / Accelerator</span>
-                            <strong id="memory-estimate-accelerator">--</strong>
-                        </div>
-                        <div>
-                            <span class="sidebar-memory-label">RAM</span>
-                            <strong id="memory-estimate-ram">--</strong>
-                        </div>
-                    </div>
-                    <div class="sidebar-memory-detail" id="memory-estimate-detail">Select a model to estimate.</div>
-                </div>
-            </div>
         </nav>
 
         <div class="sidebar-footer">
+            <div class="sidebar-runtime-controls" aria-label="Runtime controls">
+                <div class="sidebar-runtime-actions">
+                    <button id="btn-sidebar-launch" class="btn btn-primary sidebar-runtime-btn" type="button">
+                        <span class="icon icon-sm"><svg viewBox="0 0 24 24"><polygon points="5 3 19 12 5 21 5 3"/></svg></span>
+                        Launch
+                    </button>
+                    <button id="btn-sidebar-stop" class="btn btn-danger sidebar-runtime-btn hidden" type="button">
+                        <span class="icon icon-sm"><svg viewBox="0 0 24 24"><rect x="6" y="6" width="12" height="12"/></svg></span>
+                        Stop
+                    </button>
+                    <button id="btn-sidebar-stop-app" class="btn btn-danger sidebar-runtime-power" type="button" aria-label="Stop Python Server" title="Stop Python Server">
+                        <span class="icon icon-sm"><svg viewBox="0 0 24 24"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg></span>
+                    </button>
+                </div>
+                <details class="sidebar-memory-estimate" id="sidebar-memory-estimate">
+                    <summary class="sidebar-memory-summary">
+                        <span class="sidebar-memory-title">Memory</span>
+                        <span class="sidebar-memory-reading">
+                            <span class="sidebar-memory-label">GPU</span>
+                            <strong id="memory-estimate-accelerator">--</strong>
+                        </span>
+                        <span class="sidebar-memory-reading">
+                            <span class="sidebar-memory-label">RAM</span>
+                            <strong id="memory-estimate-ram">--</strong>
+                        </span>
+                        <span class="sidebar-memory-state" id="memory-estimate-state">Idle</span>
+                    </summary>
+                    <div class="sidebar-memory-detail" id="memory-estimate-detail">Select a model to estimate.</div>
+                </details>
+            </div>
             <section class="sidebar-model-switcher" id="sidebar-model-switcher" aria-labelledby="sidebar-model-switcher-label">
                 <div class="sidebar-model-switcher-heading" id="sidebar-model-switcher-label">Model Switcher</div>
                 <div class="sidebar-model-switcher-control">
@@ -160,19 +159,21 @@
             </section>
             <!-- The list is built by theme-ui.js from its THEMES registry, so
                  adding a theme needs no markup change here. -->
-            <div class="theme-menu" id="theme-menu">
-                <button class="theme-menu-trigger" id="theme-menu-trigger" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="theme-menu-list" title="Change theme">
-                    <span class="theme-menu-swatch" id="theme-menu-current-swatch" aria-hidden="true"></span>
-                    <span class="theme-menu-current" id="theme-menu-current">Theme</span>
-                    <span class="icon icon-sm theme-menu-chevron" aria-hidden="true"><svg viewBox="0 0 24 24"><polyline points="6 9 12 15 18 9"/></svg></span>
-                </button>
-                <ul class="theme-menu-list" id="theme-menu-list" role="menu" aria-label="Theme" hidden></ul>
+            <div class="sidebar-meta-row">
+                <div class="theme-menu" id="theme-menu">
+                    <button class="theme-menu-trigger" id="theme-menu-trigger" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="theme-menu-list" title="Change theme">
+                        <span class="theme-menu-swatch" id="theme-menu-current-swatch" aria-hidden="true"></span>
+                        <span class="theme-menu-current" id="theme-menu-current">Theme</span>
+                        <span class="icon icon-sm theme-menu-chevron" aria-hidden="true"><svg viewBox="0 0 24 24"><polyline points="6 9 12 15 18 9"/></svg></span>
+                    </button>
+                    <ul class="theme-menu-list" id="theme-menu-list" role="menu" aria-label="Theme" hidden></ul>
+                </div>
+                <span id="version-badge" class="badge badge-neutral" title="llama.cpp version">Not Installed</span>
             </div>
             <div class="sidebar-status" id="sidebar-status" style="display:none;">
                 <span class="status-dot"></span>
                 <span id="sidebar-status-text">Running</span>
             </div>
-            <span id="version-badge" class="badge badge-neutral">Not Installed</span>
         </div>
     </aside>
 


### PR DESCRIPTION
- Reworked the left sidebar into a compact persistent runtime dock: Launch/Stop and the danger-styled Python shutdown control remain reachable without scrolling, memory usage is an expandable stacked GPU/RAM estimate, the Model Switcher remains intact in a shorter panel, and a narrow icon-only theme control leaves more room for the adjacent build version.