### PR TITLE
Beta merge

### DIFF
--- a/backend/routes/git_update.py
+++ b/backend/routes/git_update.py
@@ -1,19 +1,32 @@
 """Routes for app update management."""
 
+import urllib.parse
+
 from ..http import sanitize_error
 from ..services import git_update
 
 
 def get_status(request, response, ctx):
     try:
-        response.json(git_update.get_app_update_status(ctx, fetch=True))
+        query = urllib.parse.parse_qs(request.query)
+        channel = git_update.normalize_update_channel(
+            query.get("channel", ["stable"])[0]
+        )
+        response.json(
+            git_update.get_app_update_status(ctx, fetch=True, channel=channel)
+        )
+    except ValueError as e:
+        response.error(str(e), 400)
     except Exception as e:
         response.error(sanitize_error(e, 500), 500)
 
 
 def start_update(request, response, ctx):
     try:
-        result = git_update.update_app_from_git(ctx)
+        channel = git_update.normalize_update_channel(
+            (request.body or {}).get("channel", "stable")
+        )
+        result = git_update.update_app_from_git(ctx, channel=channel)
         if result.get("error"):
             response.error(
                 result.get("error", "App update failed"),
@@ -22,5 +35,7 @@ def start_update(request, response, ctx):
             )
         else:
             response.json(result)
+    except ValueError as e:
+        response.error(str(e), 400)
     except Exception as e:
         response.error(sanitize_error(e, 500), 500)

--- a/backend/services/file_picker.py
+++ b/backend/services/file_picker.py
@@ -106,7 +106,7 @@ def select_file_in_native_dialog(
 # `purpose` is the flag id (see getPathPickerRequest in ui/js/app.js). "model" has
 # no path flag today - the main model is a dropdown over models/ - but it is kept
 # here so a future model path flag gets the models/ folder and filter by default.
-MODEL_FILE_PURPOSES = frozenset({"model", "model_draft", "mmproj", "model_vocoder"})
+MODEL_FILE_PURPOSES = frozenset({"model", "model_draft", "mmproj"})
 
 
 def get_select_file_options(ctx: AppContext, purpose: Any, title: Any) -> tuple[str, Path, FileTypes]:

--- a/backend/services/git_update.py
+++ b/backend/services/git_update.py
@@ -24,6 +24,8 @@ RELEASE_TAG_GLOB = "refs/tags/v[0-9]*"
 # must never be handed to users as an automatic update.
 RELEASE_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+[a-z]?$")
 
+UPDATE_CHANNELS = {"stable", "nightly"}
+
 SAFE_DIRTY_PATH_PREFIXES = (
     "llama/",
     "models/",
@@ -183,6 +185,13 @@ def is_release_tag(tag):
     return bool(RELEASE_TAG_RE.match(str(tag or "").strip()))
 
 
+def normalize_update_channel(value):
+    channel = str(value or "stable").strip().lower()
+    if channel not in UPDATE_CHANNELS:
+        raise ValueError("Update channel must be 'stable' or 'nightly'.")
+    return channel
+
+
 def find_latest_release_tag(base_dir, upstream_ref):
     """Return the newest release tag reachable from ``upstream_ref``.
 
@@ -279,13 +288,14 @@ def create_windows_shortcuts(ctx: AppContext) -> dict[str, Any]:
     }
 
 
-def unavailable_status(reason, repo_url):
+def unavailable_status(reason, repo_url, update_channel):
     return {
         "available": False,
         "can_update": False,
         "state": "error",
         "reason": reason,
         "repo_url": repo_url,
+        "update_channel": update_channel,
     }
 
 
@@ -305,28 +315,38 @@ def error_status(reason, **fields):
     }
 
 
-def get_app_update_status(ctx: AppContext, fetch: bool = False) -> dict[str, Any]:
+def get_app_update_status(
+    ctx: AppContext,
+    fetch: bool = False,
+    channel: str = "stable",
+) -> dict[str, Any]:
     base_dir = ctx.paths.root
     repo_url = ctx.config.app_repo_url
+    update_channel = normalize_update_channel(channel)
 
     if not (base_dir / ".git").exists():
-        return unavailable_status("This folder is not a git repository.", repo_url)
+        return unavailable_status(
+            "This folder is not a git repository.", repo_url, update_channel
+        )
 
     git_version = run_git(["--version"], base_dir)
     if git_version.returncode != 0:
-        return unavailable_status("Git is not available on this system.", repo_url)
+        return unavailable_status(
+            "Git is not available on this system.", repo_url, update_channel
+        )
 
     branch_res = run_git(["rev-parse", "--abbrev-ref", "HEAD"], base_dir)
     if branch_res.returncode != 0:
         return error_status(
             (branch_res.stderr or "Unable to read current git branch").strip(),
             repo_url=repo_url,
+            update_channel=update_channel,
         )
     branch = branch_res.stdout.strip()
 
-    # Releases are cut from a single branch, so the comparison is always against
-    # that branch's tags. Using the checked-out branch instead would pin anyone
-    # on a development branch to whatever stale tag it happens to contain.
+    # Stable tags and nightly commits come from one configured branch. Using the
+    # checked-out branch instead would pin a development checkout to its own
+    # stale tags or commits.
     release_branch = (ctx.config.app_release_branch or "").strip() or branch
     upstream_ref = f"origin/{release_branch}"
 
@@ -338,6 +358,7 @@ def get_app_update_status(ctx: AppContext, fetch: bool = False) -> dict[str, Any
         "origin_url": origin_url,
         "branch": branch,
         "release_branch": release_branch,
+        "update_channel": update_channel,
     }
 
     dirty_res = run_git(["status", "--porcelain=v1", "-z"], base_dir)
@@ -379,42 +400,47 @@ def get_app_update_status(ctx: AppContext, fetch: bool = False) -> dict[str, Any
             **common,
         )
 
-    release_info = find_latest_release_tag(base_dir, upstream_ref)
-    if release_info["error"]:
-        return error_status(release_info["error"], **common)
+    release_tag = ""
+    target_ref = upstream_ref
+    if update_channel == "stable":
+        release_info = find_latest_release_tag(base_dir, upstream_ref)
+        if release_info["error"]:
+            return error_status(release_info["error"], **common)
 
-    release_tag = release_info["tag"]
-    if not release_tag:
-        return {
-            "available": True,
-            "can_update": False,
-            "reason": f"No tagged release was found on {upstream_ref}.",
-            **common,
-            "ahead": 0,
-            "behind": 0,
-            "state": "no_release",
-            "release_tag": "",
-        }
+        release_tag = release_info["tag"]
+        if not release_tag:
+            return {
+                "available": True,
+                "can_update": False,
+                "reason": f"No tagged release was found on {upstream_ref}.",
+                **common,
+                "ahead": 0,
+                "behind": 0,
+                "state": "no_release",
+                "release_tag": "",
+                "target_ref": "",
+            }
+        target_ref = f"refs/tags/{release_tag}"
 
-    release_ref = f"refs/tags/{release_tag}"
     behind_ahead_res = run_git(
-        ["rev-list", "--left-right", "--count", f"HEAD...{release_ref}"],
+        ["rev-list", "--left-right", "--count", f"HEAD...{target_ref}"],
         base_dir,
     )
     if behind_ahead_res.returncode != 0:
+        target_name = f"release {release_tag}" if release_tag else target_ref
         return error_status(
-            f"Unable to compare HEAD with release {release_tag}.",
+            f"Unable to compare HEAD with {target_name}.",
             **common,
             release_tag=release_tag,
+            target_ref=target_ref,
         )
 
     parts = behind_ahead_res.stdout.strip().split()
     ahead = int(parts[0]) if len(parts) > 0 else 0
     behind = int(parts[1]) if len(parts) > 1 else 0
 
-    # "behind" means the release is a strict descendant of HEAD, which is
-    # exactly the condition under which `merge --ff-only` can succeed. Commits
-    # made after the release (behind == 0) count as up to date.
+    # "behind" means the selected target is a strict descendant of HEAD, which
+    # is exactly the condition under which `merge --ff-only` can succeed.
     if behind > 0 and ahead > 0:
         state = "diverged"
     elif behind > 0:
@@ -432,12 +458,14 @@ def get_app_update_status(ctx: AppContext, fetch: bool = False) -> dict[str, Any
         "behind": behind,
         "state": state,
         "release_tag": release_tag,
+        "target_ref": target_ref,
     }
 
 
-def update_app_from_git(ctx: AppContext) -> dict[str, Any]:
+def update_app_from_git(ctx: AppContext, channel: str = "stable") -> dict[str, Any]:
     base_dir = ctx.paths.root
-    status = get_app_update_status(ctx, fetch=True)
+    update_channel = normalize_update_channel(channel)
+    status = get_app_update_status(ctx, fetch=True, channel=update_channel)
     if not status.get("available"):
         return {
             "updated": False,
@@ -460,7 +488,7 @@ def update_app_from_git(ctx: AppContext) -> dict[str, Any]:
         if state == "diverged":
             return {
                 "updated": False,
-                "error": "Branch has diverged from the latest release; manual merge/rebase required.",
+                "error": "Branch has diverged from the selected update target; manual merge/rebase required.",
                 "status": status,
             }
         return {
@@ -469,9 +497,10 @@ def update_app_from_git(ctx: AppContext) -> dict[str, Any]:
             "status": status,
         }
 
-    release_tag = status["release_tag"]
+    release_tag = status.get("release_tag", "")
+    target_ref = status["target_ref"]
     update_res = run_git(
-        ["merge", "--ff-only", f"refs/tags/{release_tag}"],
+        ["merge", "--ff-only", target_ref],
         base_dir,
     )
     if update_res.returncode != 0:
@@ -480,10 +509,11 @@ def update_app_from_git(ctx: AppContext) -> dict[str, Any]:
             "error": (
                 update_res.stderr or update_res.stdout or "git merge failed"
             ).strip(),
-            "status": get_app_update_status(ctx, fetch=False),
+            "status": get_app_update_status(ctx, fetch=False, channel=update_channel),
         }
 
     deps_res = install_python_dependencies(ctx)
+    target_name = release_tag or target_ref
     if deps_res.get("error"):
         shortcuts_res = create_windows_shortcuts(ctx)
         return {
@@ -494,8 +524,9 @@ def update_app_from_git(ctx: AppContext) -> dict[str, Any]:
             "shortcuts_error": shortcuts_res.get("error", ""),
             "shortcuts_message": shortcuts_res.get("message", ""),
             "release_tag": release_tag,
-            "message": (update_res.stdout or f"Updated to {release_tag}").strip(),
-            "status": get_app_update_status(ctx, fetch=False),
+            "update_channel": update_channel,
+            "message": (update_res.stdout or f"Updated to {target_name}").strip(),
+            "status": get_app_update_status(ctx, fetch=False, channel=update_channel),
         }
 
     shortcuts_res = create_windows_shortcuts(ctx)
@@ -507,6 +538,7 @@ def update_app_from_git(ctx: AppContext) -> dict[str, Any]:
         "shortcuts_error": shortcuts_res.get("error", ""),
         "shortcuts_message": shortcuts_res.get("message", ""),
         "release_tag": release_tag,
-        "message": (update_res.stdout or f"Updated to {release_tag}").strip(),
-        "status": get_app_update_status(ctx, fetch=False),
+        "update_channel": update_channel,
+        "message": (update_res.stdout or f"Updated to {target_name}").strip(),
+        "status": get_app_update_status(ctx, fetch=False, channel=update_channel),
     }

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -559,7 +559,7 @@ footer {
         <div class="node yellow"><div class="t">Hugging Face</div><div class="d">GGUF model downloads via <code>huggingface_hub</code></div></div>
         <div class="node yellow"><div class="t">DuckDuckGo / SearXNG</div><div class="d">Chat web search, zero-key</div></div>
         <div class="node yellow"><div class="t">Cloudflare</div><div class="d">Quick tunnel for remote access</div></div>
-        <div class="node yellow"><div class="t">git origin</div><div class="d">In-app app updates to the newest release tag</div></div>
+        <div class="node yellow"><div class="t">git origin</div><div class="d">Stable release or nightly main-branch app updates</div></div>
     </div>
 
     <div class="legend">
@@ -684,7 +684,7 @@ footer {
 <tr><td class="mono">presets.py</td><td class="mono">—</td><td>Preset CRUD on <code>presets/*.json</code>, rename with created-time carry, Windows shortcut export</td></tr>
 <tr><td class="mono">models.py</td><td class="mono">—</td><td>Recursive GGUF discovery under <code>models/</code>, returned as <code>models/</code>-relative names</td></tr>
 <tr><td class="mono">tunnel.py</td><td class="mono">tunnel.py</td><td>Download <code>cloudflared</code>, start/stop quick tunnel, poll for the public URL</td></tr>
-<tr><td class="mono">git_update.py</td><td class="mono">git_update.py</td><td>Fetch tags, classify dirty paths, fast-forward to the newest release tag, reinstall deps</td></tr>
+<tr><td class="mono">git_update.py</td><td class="mono">git_update.py</td><td>Fetch origin, classify dirty paths, fast-forward to a stable tag or nightly branch head, reinstall deps</td></tr>
 <tr><td class="mono">benchmarks.py</td><td class="mono">—</td><td>Ensure the official WikiText-2 raw test file exists for perplexity runs</td></tr>
 <tr><td class="mono">search.py</td><td class="mono">web_search.py</td><td>Standalone web-search endpoint</td></tr>
 <tr><td class="mono">lifecycle.py</td><td class="mono">lifecycle.py</td><td>Graceful shutdown, restart with port-availability polling, open a folder in the OS file manager</td></tr>
@@ -1054,17 +1054,18 @@ flagCore.setFlagValue("temperature", 0.5);
 
 <h3>Updating the app itself</h3>
 <p>
-    <code>GET /api/app-update-status?fetch=true</code> runs <code>git fetch origin --prune --prune-tags --tags</code>,
-    then finds the newest release tag reachable from <code>origin/main</code> —
-    <em>always the release branch, never the checked-out branch</em>, so a user on a development branch is still offered
-    the newest published release. Tags are selected by version sort, not date, because they are lightweight and a
+    <code>GET /api/app-update-status</code> runs <code>git fetch origin --prune --prune-tags --tags</code>.
+    The Stable channel finds the newest release tag reachable from <code>origin/main</code>; the Nightly channel targets
+    the latest <code>origin/main</code> commit directly —
+    <em>always the release branch, never the checked-out branch</em>, so a user on a development branch is still compared
+    with the selected Stable or Nightly target. Tags are selected by version sort, not date, because they are lightweight and a
     hotfix tagged onto an older commit would otherwise sort wrong.
 </p>
 <p>
     Dirty working-tree paths are classified: data and cache locations (<code>models/</code>, <code>presets/</code>,
     <code>llama/</code>, <code>config.json</code>, <code>__pycache__/</code>, log and backup suffixes) are
     <em>safe</em>; source changes are <em>blocking</em>. If the branch is behind and nothing blocks,
-    <code>POST /api/app-update</code> fast-forwards to the tag, reinstalls <code>requirements.txt</code>, restarts the
+    <code>POST /api/app-update</code> fast-forwards to the selected tag or branch head, reinstalls <code>requirements.txt</code>, restarts the
     server, and the page reloads with a cache-busting timestamp.
 </p>
 
@@ -1072,9 +1073,9 @@ flagCore.setFlagValue("temperature", 0.5);
 <table>
 <thead><tr><th class="mono">state</th><th>Meaning</th><th>Auto-update</th></tr></thead>
 <tbody>
-<tr><td class="mono">up_to_date</td><td>HEAD already contains the release tag, including local commits made after it</td><td>No</td></tr>
-<tr><td class="mono">behind</td><td>The release is a strict descendant of HEAD, so <code>merge --ff-only</code> can succeed</td><td>Yes, unless blocking changes exist</td></tr>
-<tr><td class="mono">diverged</td><td>HEAD and the release have both moved; manual merge or rebase required</td><td>No</td></tr>
+<tr><td class="mono">up_to_date</td><td>HEAD already contains the selected tag or branch head, including local commits made after it</td><td>No</td></tr>
+<tr><td class="mono">behind</td><td>The selected target is a strict descendant of HEAD, so <code>merge --ff-only</code> can succeed</td><td>Yes, unless blocking changes exist</td></tr>
+<tr><td class="mono">diverged</td><td>HEAD and the selected target have both moved; manual merge or rebase required</td><td>No</td></tr>
 <tr><td class="mono">no_release</td><td>No tag on the release branch matched the release pattern</td><td>No</td></tr>
 <tr><td class="mono">error</td><td>A git command failed or the upstream branch is missing; <code>reason</code> holds the detail</td><td>No</td></tr>
 </tbody>
@@ -1100,7 +1101,7 @@ flagCore.setFlagValue("temperature", 0.5);
 <tr><td><span class="verb get">GET</span></td><td class="mono">/api/remote-tunnel/status</td><td>Cloudflare tunnel status + URL</td></tr>
 <tr><td><span class="verb get">GET</span></td><td class="mono">/api/chat/target</td><td>Live and remembered external server</td></tr>
 <tr><td><span class="verb get">GET</span></td><td class="mono">/api/models</td><td>GGUF files under <code>models/</code></td></tr>
-<tr><td><span class="verb get">GET</span></td><td class="mono">/api/app-update-status</td><td>Git release-tag comparison</td></tr>
+<tr><td><span class="verb get">GET</span></td><td class="mono">/api/app-update-status</td><td>Stable-tag or nightly-branch Git comparison</td></tr>
 <tr><td><span class="verb get">GET</span></td><td class="mono">/api/presets</td><td>List saved presets</td></tr>
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/launch/preflight</td><td>Pre-launch checks and slot resolution</td></tr>
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/launch</td><td>Spawn the selected llama.cpp tool</td></tr>
@@ -1126,7 +1127,7 @@ flagCore.setFlagValue("temperature", 0.5);
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/presets/rename</td><td>Rename, carrying the created-time entry</td></tr>
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/presets/shortcut</td><td>Export a Windows shortcut</td></tr>
 <tr><td><span class="verb del">DELETE</span></td><td class="mono">/api/presets/&lt;name&gt;</td><td>Delete a preset (prefix route)</td></tr>
-<tr><td><span class="verb post">POST</span></td><td class="mono">/api/app-update</td><td>Fast-forward to the release tag and reinstall deps</td></tr>
+<tr><td><span class="verb post">POST</span></td><td class="mono">/api/app-update</td><td>Fast-forward to the selected update target and reinstall deps</td></tr>
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/shutdown</td><td>Graceful shutdown</td></tr>
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/restart</td><td>Restart, or exit 75 when supervised</td></tr>
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/open-folder</td><td>Open a folder in the OS file manager</td></tr>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ Please give a brief summary of changes made to the program, include the date the
 
 ## 2026-08-12
 
+- Added a Stable/Nightly selector for Llama GUI app updates. Stable keeps targeting the newest tagged release; Nightly safely fast-forwards to the latest commit on the configured release branch while retaining dirty-tree, divergence, dependency-install, and restart protections.
 - Reworked the left sidebar into a compact persistent runtime dock: Launch/Stop and the danger-styled Python shutdown control remain reachable without scrolling, memory usage is an expandable stacked GPU/RAM estimate, the Model Switcher remains intact in a shorter panel, and a narrow icon-only theme control leaves more room for the adjacent build version.
 
 ## 2026-08-11

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ Please give a brief summary of changes made to the program, include the date the
 
 ## 2026-08-12
 
+- Removed the stale `-mv` / Vocoder Model server control and its unused file-picker purpose because current llama.cpp builds no longer accept that flag.
 - Added a Stable/Nightly selector for Llama GUI app updates. Stable keeps targeting the newest tagged release; Nightly safely fast-forwards to the latest commit on the configured release branch while retaining dirty-tree, divergence, dependency-install, and restart protections.
 - Reworked the left sidebar into a compact persistent runtime dock: Launch/Stop and the danger-styled Python shutdown control remain reachable without scrolling, memory usage is an expandable stacked GPU/RAM estimate, the Model Switcher remains intact in a shorter panel, and a narrow icon-only theme control leaves more room for the adjacent build version.
 

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -903,7 +903,7 @@ Returns `{"selected": bool, "path": string}`.
 
 ### File Type Filters
 
-- Model files (purpose: model, model_draft, mmproj, model_vocoder): `*.gguf`, plus `*.*` as an escape hatch. `purpose` is the flag id; `model` has no path flag today (the main model is a dropdown over `models/`) and is listed so a future one gets the right folder and filter.
+- Model files (purpose: model, model_draft, mmproj): `*.gguf`, plus `*.*` as an escape hatch. `purpose` is the flag id; `model` has no path flag today (the main model is a dropdown over `models/`) and is listed so a future one gets the right folder and filter.
 - Other paths (grammar file, log file, etc.): `*.*`
 
 ---

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -685,15 +685,17 @@ Frontend tunnel controls, status rendering, URL rendering, copy wiring, start/st
 
 ### How It Works
 
-1. `GET /api/app-update-status` (with `fetch=true`) runs `git fetch origin --prune --prune-tags --tags`, then finds the newest release tag reachable from `origin/<release branch>`.
+1. The Install tab offers **Stable releases** and **Nightly** update channels. `GET /api/app-update-status` runs `git fetch origin --prune --prune-tags --tags`, then selects the newest release tag reachable from `origin/<release branch>` for Stable or the current `origin/<release branch>` head for Nightly.
 2. Dirty git paths are classified as "safe" (ignored directories, cache dirs, data suffixes) or "blocking" (source file changes).
-3. If the local branch is behind that tagged release and has no blocking changes, auto-update is available. Untagged commits after the latest release do not trigger an update.
-4. `POST /api/app-update` fast-forwards the current branch to the release tag, then reinstalls `requirements.txt` via pip.
+3. If the local branch is behind the selected target and has no blocking changes, auto-update is available. Untagged commits trigger an update only on the Nightly channel.
+4. `POST /api/app-update` fast-forwards the current branch to the selected target, then reinstalls `requirements.txt` via pip.
 5. After success, the server restarts and the frontend reloads with cache busting.
 
 ### Release Tag Selection
 
 The release branch is `APP_RELEASE_BRANCH` in `backend/config.py` (default `main`), exposed as `ServerConfig.app_release_branch`. Tags are always looked up on `origin/<release branch>`, never on the checked-out branch, so a user sitting on a development branch is still offered the newest published release.
+
+The Stable channel targets the newest qualifying tag. The Nightly channel skips tag selection and targets `origin/<release branch>` directly, so a fast-forward includes every unreleased commit currently on that branch. The API accepts `channel=nightly` on `GET /api/app-update-status` and `{ "channel": "nightly" }` on `POST /api/app-update`; omitted channels default to Stable.
 
 `find_latest_release_tag()` runs `git for-each-ref --merged=origin/<release branch> --sort=-v:refname 'refs/tags/v[0-9]*'` and keeps the first tag matching `RELEASE_TAG_RE` (`^v\d+\.\d+\.\d+[a-z]?$`).
 
@@ -707,19 +709,19 @@ The release branch is `APP_RELEASE_BRANCH` in `backend/config.py` (default `main
 
 | State | Meaning | Auto-update |
 | --- | --- | --- |
-| `up_to_date` | HEAD already contains the release tag (including local commits made after it) | No |
-| `behind` | The release is a strict descendant of HEAD, so `merge --ff-only` can succeed | Yes, unless blocking changes exist |
-| `diverged` | HEAD and the release have both moved; manual merge/rebase required | No |
+| `up_to_date` | HEAD already contains the selected tag or branch head (including local commits made after it) | No |
+| `behind` | The selected target is a strict descendant of HEAD, so `merge --ff-only` can succeed | Yes, unless blocking changes exist |
+| `diverged` | HEAD and the selected target have both moved; manual merge/rebase required | No |
 | `no_release` | No tag on the release branch matched the release pattern | No |
 | `error` | A git command failed or the upstream branch is missing; `reason` holds the detail | No |
 
-Every failure path sets `state: "error"` and a human-readable `reason`. The frontend keys off `state`, so a path without it would fall through to a generic message and the git error would be lost. `release_tag` and `release_branch` are included on all states past the initial git checks.
+Every failure path sets `state: "error"` and a human-readable `reason`. The frontend keys off `state`, so a path without it would fall through to a generic message and the git error would be lost. `update_channel` identifies the selected channel; successful comparisons also include `release_branch`, `target_ref`, and the Stable channel's `release_tag`.
 
 When `LLAMA_GUI_SUPERVISED=1`, restart requests exit cleanly with status `75` instead of spawning a detached replacement process. An external launcher or service manager can use that status to relaunch `python server.py`; ordinary shutdowns still exit with status `0`. Standalone launches retain the existing self-restart behavior.
 
 ### Dependency Installation
 
-`install_python_dependencies()` runs `pip install -r requirements.txt` and reports success/failure. It is an internal step of `POST /api/app-update`, called after the fast-forward to the release tag and before Windows shortcut creation — there is no standalone endpoint for it. A dependency failure does not fail the update: the response returns `updated: true` with `dependencies_installed: false` and a `dependency_error`.
+`install_python_dependencies()` runs `pip install -r requirements.txt` and reports success/failure. It is an internal step of `POST /api/app-update`, called after the fast-forward to the selected update target and before Windows shortcut creation — there is no standalone endpoint for it. A dependency failure does not fail the update: the response returns `updated: true` with `dependencies_installed: false` and a `dependency_error`.
 
 ### Safe Dirty Path Classification
 

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -4857,6 +4857,12 @@ class GitUpdateRouteTests(unittest.TestCase):
         self.assertEqual(result["safe_dirty_paths"], ["models/new.gguf"])
         self.assertEqual(result["blocking_dirty_paths"], ["models/server.py"])
 
+    def test_normalize_update_channel_validates_allowlist(self):
+        self.assertEqual(srv.normalize_update_channel(None), "stable")
+        self.assertEqual(srv.normalize_update_channel(" NIGHTLY "), "nightly")
+        with self.assertRaisesRegex(ValueError, "stable.*nightly"):
+            srv.normalize_update_channel("preview")
+
     # --- install_python_dependencies tests ---
 
     def test_install_deps_no_requirements(self):
@@ -5068,6 +5074,21 @@ class GitUpdateRouteTests(unittest.TestCase):
             call_log,
         )
 
+    def test_get_nightly_status_targets_latest_release_branch_commit(self):
+        call_log = []
+        with self.patched_git(counts="0\t5", call_log=call_log):
+            status = srv.get_app_update_status(self.ctx, channel="nightly")
+        self.assertEqual(status["update_channel"], "nightly")
+        self.assertEqual(status["target_ref"], "origin/main")
+        self.assertEqual(status["release_tag"], "")
+        self.assertEqual(status["behind"], 5)
+        self.assertTrue(status["can_update"])
+        self.assertEqual(self.git_calls(call_log, "tags"), [])
+        self.assertIn(
+            ["rev-list", "--left-right", "--count", "HEAD...origin/main"],
+            call_log,
+        )
+
     def test_get_status_with_blocking_changes(self):
         with self.patched_git(dirty=" M server.py\x00", counts="0\t2"):
             status = srv.get_app_update_status(self.ctx)
@@ -5158,6 +5179,18 @@ class GitUpdateRouteTests(unittest.TestCase):
         self.assertTrue(result["updated"])
         self.assertIn(["merge", "--ff-only", "refs/tags/v1.2.3"], call_log)
 
+    def test_update_nightly_fast_forwards_to_release_branch_head(self):
+        call_log = []
+        with (
+            self.patched_git(counts="0\t3", call_log=call_log),
+            self.patched_shortcuts(created=False),
+        ):
+            result = srv.update_app_from_git(self.ctx, channel="nightly")
+        self.assertTrue(result["updated"])
+        self.assertEqual(result["update_channel"], "nightly")
+        self.assertEqual(result["release_tag"], "")
+        self.assertIn(["merge", "--ff-only", "origin/main"], call_log)
+
     def test_update_release_success_keeps_shortcut_failure_nonfatal(self):
         with (
             self.patched_git(counts="0\t3", merge_stdout="Updating abc..def"),
@@ -5211,6 +5244,31 @@ class GitUpdateRouteTests(unittest.TestCase):
         self.assertFalse(response.payload["available"])
         self.assertEqual(response.payload["repo_url"], self.ctx.config.app_repo_url)
 
+    def test_app_update_status_route_passes_nightly_channel(self):
+        with mock.patch.object(
+            srv,
+            "get_app_update_status",
+            return_value={"available": True, "update_channel": "nightly"},
+        ) as mock_status:
+            response = DummyResponse()
+            git_update.get_status(
+                Request("GET", "/api/app-update-status", "channel=nightly", {}),
+                response,
+                self.ctx,
+            )
+        self.assertEqual(response.status, 200)
+        mock_status.assert_called_once_with(self.ctx, fetch=True, channel="nightly")
+
+    def test_app_update_status_route_rejects_unknown_channel(self):
+        response = DummyResponse()
+        git_update.get_status(
+            Request("GET", "/api/app-update-status", "channel=preview", {}),
+            response,
+            self.ctx,
+        )
+        self.assertEqual(response.status, 400)
+        self.assertIn("stable", response.payload["error"])
+
     def test_app_update_status_route_handles_error(self):
         with mock.patch.object(
             srv,
@@ -5255,6 +5313,42 @@ class GitUpdateRouteTests(unittest.TestCase):
             )
         self.assertEqual(response.status, 200)
         self.assertTrue(response.payload["updated"])
+
+    def test_app_update_route_passes_nightly_channel(self):
+        with mock.patch.object(srv, "update_app_from_git", return_value={
+            "updated": True,
+            "update_channel": "nightly",
+        }) as mock_update:
+            response = DummyResponse()
+            git_update.start_update(
+                Request(
+                    "POST",
+                    "/api/app-update",
+                    "",
+                    {},
+                    body={"channel": "nightly"},
+                ),
+                response,
+                self.ctx,
+            )
+        self.assertEqual(response.status, 200)
+        mock_update.assert_called_once_with(self.ctx, channel="nightly")
+
+    def test_app_update_route_rejects_unknown_channel(self):
+        response = DummyResponse()
+        git_update.start_update(
+            Request(
+                "POST",
+                "/api/app-update",
+                "",
+                {},
+                body={"channel": "preview"},
+            ),
+            response,
+            self.ctx,
+        )
+        self.assertEqual(response.status, 400)
+        self.assertIn("nightly", response.payload["error"])
 
 
 class LifecycleTests(unittest.TestCase):

--- a/tests/frontend/manager_releases_unit.cjs
+++ b/tests/frontend/manager_releases_unit.cjs
@@ -84,8 +84,10 @@ const elements = new Map();
     "release-group",
     "custom-backend-info",
     "app-update-status",
+    "app-update-channel",
     "btn-update-app",
 ].forEach((id) => elements.set(id, makeElement()));
+elements.get("app-update-channel").value = "stable";
 
 const fetchCalls = [];
 const fetchPayload = [{ tag: "b1294", published: "2024-01-01T00:00:00Z", assets: [] }];
@@ -330,6 +332,50 @@ vm.runInContext(source, context, { filename: "ui/js/manager.js" });
     result = runClear("http://127.0.0.1:5240/?preset=Test");
     assert.equal(result.cleared, false, "a URL without appReload must not be rewritten");
     assert.deepEqual(result.replaced, [], "no history entry should be replaced when nothing changes");
+
+    const appUpdateChannel = elements.get("app-update-channel");
+    appUpdateChannel.value = "nightly";
+    let updateRequest;
+    context.fetch = async (url, options) => {
+        if (url === "/api/app-update-status?channel=nightly") {
+            return {
+                ok: true,
+                json: async () => ({
+                    available: true,
+                    can_update: true,
+                    state: "behind",
+                    update_channel: "nightly",
+                    release_branch: "main",
+                    branch: "main",
+                    behind: 4,
+                }),
+            };
+        }
+        assert.equal(url, "/api/app-update");
+        updateRequest = options;
+        return {
+            ok: true,
+            json: async () => ({
+                updated: false,
+                message: "Already up to date",
+                status: {
+                    available: true,
+                    can_update: false,
+                    state: "up_to_date",
+                    update_channel: "nightly",
+                    release_branch: "main",
+                    branch: "main",
+                },
+            }),
+        };
+    };
+    await context.window.LlamaGui.manager.checkAppUpdateStatus();
+    assert.match(elements.get("app-update-status").textContent, /latest nightly commit on origin\/main/);
+    vm.runInContext("confirmAction = async () => true", context);
+    await context.window.LlamaGui.manager.updateAppFromGitHub();
+    assert.deepEqual(JSON.parse(updateRequest.body), { channel: "nightly" });
+
+    appUpdateChannel.value = "stable";
 
     context.fetch = async (url) => {
         assert.equal(url, "/api/app-update-status");

--- a/ui/index.html
+++ b/ui/index.html
@@ -252,6 +252,14 @@
 
                 <div class="card">
                     <h3>Llama GUI App Updates</h3>
+                    <div class="form-group">
+                        <label class="form-label" for="app-update-channel">Update channel</label>
+                        <select id="app-update-channel">
+                            <option value="stable">Stable releases</option>
+                            <option value="nightly">Nightly — latest commit on main (may be unstable)</option>
+                        </select>
+                        <p class="help-text">Stable installs tagged releases. Nightly includes unreleased commits from the main branch.</p>
+                    </div>
                     <div id="app-update-status" class="status-box"></div>
                     <div class="form-row">
                         <button id="btn-check-app-update" class="btn" type="button">Check App Updates</button>

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -693,6 +693,7 @@ function initInstallButtons() {
     document.getElementById("btn-open-llama").addEventListener("click", () => openFolder("llama"));
     document.getElementById("btn-check-app-update").addEventListener("click", checkAppUpdateStatus);
     document.getElementById("btn-update-app").addEventListener("click", updateAppFromGitHub);
+    document.getElementById("app-update-channel").addEventListener("change", checkAppUpdateStatus);
     if (typeof checkAppUpdateStatus === "function") {
         checkAppUpdateStatus();
     }

--- a/ui/js/flags/definitions.js
+++ b/ui/js/flags/definitions.js
@@ -98,15 +98,6 @@ const FLAGS = [
 		min: 1,
 	},
 	{
-		id: "model_vocoder",
-		flag: "-mv",
-		category: "model",
-		type: "path",
-		label: "Vocoder Model",
-		desc: "Vocoder model for audio generation (server only)",
-		tool: "server",
-	},
-	{
 		id: "no_mmproj",
 		flag: "--no-mmproj",
 		category: "model",

--- a/ui/js/manager.js
+++ b/ui/js/manager.js
@@ -825,6 +825,22 @@ function showAppUpdateStatus(type, message) {
     }
 }
 
+function selectedAppUpdateChannel() {
+    const select = document.getElementById("app-update-channel");
+    return select && select.value === "nightly" ? "nightly" : "stable";
+}
+
+function appUpdateStatusChannel(status) {
+    return status && status.update_channel === "nightly" ? "nightly" : "stable";
+}
+
+function describeAppUpdateTarget(status) {
+    if (appUpdateStatusChannel(status) === "nightly") {
+        return `latest nightly commit on origin/${status.release_branch || "main"}`;
+    }
+    return status.release_tag ? `release ${status.release_tag}` : "latest release";
+}
+
 function describeAppUpdateStatus(status) {
     if (!status) return "Unable to determine app update status.";
     if (status.reason && !status.available) return status.reason;
@@ -840,7 +856,7 @@ function describeAppUpdateStatus(status) {
     const blockingPaths = formatPaths(status.blocking_dirty_paths);
     const safePaths = formatPaths(status.safe_dirty_paths);
     const branch = status.branch ? `branch ${status.branch}` : "current branch";
-    const release = status.release_tag ? `release ${status.release_tag}` : "latest release";
+    const target = describeAppUpdateTarget(status);
     const behindCount = status.behind || 0;
     const behindNote = behindCount
         ? ` You are ${behindCount} commit${behindCount === 1 ? "" : "s"} behind it.`
@@ -854,21 +870,21 @@ function describeAppUpdateStatus(status) {
     }
     if (status.state === "up_to_date") {
         const safeNote = safePaths ? ` Local app data is present and ignored for updates: ${safePaths}.` : "";
-        return `Llama GUI already includes the ${release} on ${branch}.${safeNote}`;
+        return `Llama GUI already includes the ${target} on ${branch}.${safeNote}`;
     }
     if (status.state === "behind") {
         if (status.has_blocking_changes) {
             const detail = blockingPaths ? ` Blocking paths: ${blockingPaths}.` : "";
-            return `${release} is available, but source changes must be committed or stashed first.${behindNote}${detail}`;
+            return `${target} is available, but source changes must be committed or stashed first.${behindNote}${detail}`;
         }
         if (status.dirty) {
             const detail = safePaths ? ` Safe local app data will be left alone: ${safePaths}.` : "";
-            return `${release} is available.${behindNote}${detail}`;
+            return `${target} is available.${behindNote}${detail}`;
         }
-        return `${release} is available.${behindNote}`;
+        return `${target} is available.${behindNote}`;
     }
     if (status.state === "diverged") {
-        return `Local branch and ${release} diverged; update manually with git.`;
+        return `Local branch and the ${target} diverged; update manually with git.`;
     }
     if (status.state === "no_release") {
         return status.reason || `No tagged release was found for ${branch}.`;
@@ -906,27 +922,40 @@ function renderAppUpdateStatus(status) {
     if (updateBtn && status) {
         updateBtn.disabled = !status.can_update;
         updateBtn.title = status.can_update
-            ? `Install ${status.release_tag ? `release ${status.release_tag}` : "latest release"}`
+            ? `Install ${describeAppUpdateTarget(status)}`
             : msg;
     }
 }
 
 async function checkAppUpdateStatus() {
+    const channel = selectedAppUpdateChannel();
+    const updateBtn = document.getElementById("btn-update-app");
+    if (updateBtn) updateBtn.disabled = true;
     showAppUpdateStatus("info", "Checking app update status...");
     try {
-        const status = await fetchJson("/api/app-update-status");
+        const url = channel === "nightly"
+            ? "/api/app-update-status?channel=nightly"
+            : "/api/app-update-status";
+        const status = await fetchJson(url);
+        if (selectedAppUpdateChannel() !== channel) return;
         renderAppUpdateStatus(status);
     } catch (e) {
+        if (selectedAppUpdateChannel() !== channel) return;
         showAppUpdateStatus("error", "Failed to check app updates: " + e.message);
     }
 }
 
 async function updateAppFromGitHub() {
+    const channel = selectedAppUpdateChannel();
     let status = latestAppUpdateStatus;
-    if (!status) {
+    if (!status || appUpdateStatusChannel(status) !== channel) {
         showAppUpdateStatus("info", "Checking app update status...");
         try {
-            status = await fetchJson("/api/app-update-status");
+            const url = channel === "nightly"
+                ? "/api/app-update-status?channel=nightly"
+                : "/api/app-update-status";
+            status = await fetchJson(url);
+            if (selectedAppUpdateChannel() !== channel) return;
         } catch (e) {
             showAppUpdateStatus("error", "Failed to check app updates: " + e.message);
             return;
@@ -939,14 +968,18 @@ async function updateAppFromGitHub() {
 
     const ok = await confirmAction(
         "Update Llama GUI",
-        `Install ${status.release_tag ? `release ${status.release_tag}` : "the latest release"} from GitHub now? Python dependencies from requirements.txt will be installed after the update. The app may need a restart after updating.`,
+        `Install the ${describeAppUpdateTarget(status)} from GitHub now? Python dependencies from requirements.txt will be installed after the update. The app may need a restart after updating.`,
         "Update"
     );
     if (!ok) return;
 
-    showAppUpdateStatus("info", `Installing ${status.release_tag ? `release ${status.release_tag}` : "the latest release"} from GitHub...`);
+    showAppUpdateStatus("info", `Installing the ${describeAppUpdateTarget(status)} from GitHub...`);
     try {
-        const result = await fetchJson("/api/app-update", { method: "POST" });
+        const result = await fetchJson("/api/app-update", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ channel }),
+        });
         if (result.updated) {
             if (result.dependency_error) {
                 showAppUpdateStatus("warning", "App updated, but dependency installation failed: " + result.dependency_error + " Restart Llama GUI after fixing dependencies.");


### PR DESCRIPTION
- Removed the stale `-mv` / Vocoder Model server control and its unused file-picker purpose because current llama.cpp builds no longer accept that flag.
- Added a Stable/Nightly selector for Llama GUI app updates. Stable keeps targeting the newest tagged release; Nightly safely fast-forwards to the latest commit on the configured release branch while retaining dirty-tree, divergence, dependency-install, and restart protections.