### PR TITLE
Add manual stable-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Create stable release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: stable-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Require main branch
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_REF -ne "refs/heads/main") {
+              throw "Stable releases must be run from the main branch."
+          }
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install Python dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Run backend tests
+        run: python -m unittest discover tests -v
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium
+
+      - name: Run frontend tests
+        run: npm test
+
+      - name: Verify and calculate release version
+        id: version
+        shell: pwsh
+        run: |
+          git fetch origin main --prune --prune-tags --tags
+          if ($LASTEXITCODE -ne 0) {
+              exit $LASTEXITCODE
+          }
+          $remoteMain = (git rev-parse origin/main).Trim()
+          if ($remoteMain -ne $env:GITHUB_SHA) {
+              throw "main advanced while this workflow was running. Run it again to release the new tip."
+          }
+
+          $version = python scripts/next_calver.py
+          if ($LASTEXITCODE -ne 0) {
+              exit $LASTEXITCODE
+          }
+          $version = $version.Trim()
+          if ($version -notmatch '^\d{2}\.\d{2}\.\d+$') {
+              throw "Calculated an invalid release version: $version"
+          }
+          "version=$version" >> $env:GITHUB_OUTPUT
+          "tag=v$version" >> $env:GITHUB_OUTPUT
+
+      - name: Build release package
+        shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: .\release.ps1 -Version $env:RELEASE_VERSION
+
+      - name: Publish GitHub release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          $asset = "releases/Llama-GUI-$env:RELEASE_VERSION.zip"
+          gh release create $env:RELEASE_TAG $asset `
+              --target $env:GITHUB_SHA `
+              --title "Llama GUI $env:RELEASE_VERSION" `
+              --generate-notes `
+              --latest `
+              --fail-on-no-commits

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ Please give a brief summary of changes made to the program, include the date the
 
 ## 2026-08-12
 
+- Added a manual GitHub Actions stable-release workflow that tests the current `main` tip, calculates the next UTC CalVer version, packages the app, generates release notes, and publishes the tagged archive while Nightly commits continue to bake untagged.
 - Removed the stale `-mv` / Vocoder Model server control and its unused file-picker purpose because current llama.cpp builds no longer accept that flag.
 - Added a Stable/Nightly selector for Llama GUI app updates. Stable keeps targeting the newest tagged release; Nightly safely fast-forwards to the latest commit on the configured release branch while retaining dirty-tree, divergence, dependency-install, and restart protections.
 - Reworked the left sidebar into a compact persistent runtime dock: Launch/Stop and the danger-styled Python shutdown control remain reachable without scrolling, memory usage is an expandable stacked GPU/RAM estimate, the Model Switcher remains intact in a shorter panel, and a narrow icon-only theme control leaves more room for the adjacent build version.

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -34,6 +34,7 @@
 | `ui/js/flags/` | Ordered pure-data modules for flag definitions |
 | `ui/templates/` | 15 bundled Jinja chat template files |
 | `tests/` | Frontend (Node/Playwright) + backend (unittest) tests |
+| `.github/workflows/` | Continuous integration and the manual stable-release workflow |
 | `docs/` | Documentation: todo, flag audit, architecture, bugtracker |
 | `llama/` | Downloaded `llama.cpp` binaries at runtime |
 | `models/` | User model files (.gguf), in any subfolder; downloaded projectors live beside their models |
@@ -702,6 +703,12 @@ The Stable channel targets the newest qualifying tag. The Nightly channel skips 
 - Version sort, not date sort. The tags are lightweight, so `--sort=-creatordate` would compare commit dates and misplace a hotfix tagged onto an older commit. Version sort orders `v1.6.3 < v1.6.3b < v1.6.4 < v1.6.10`.
 - The glob drops non-version tags such as `Summer-2026`; the regex drops prerelease tags such as `v1.6.3-rc1` and `v1.6.3-beta`. A single-letter revision suffix (`v1.6.3b`) is a normal release and is kept.
 - `--prune-tags` is required alongside `--prune`; without it a tag deleted upstream stays local and can still be picked as newest.
+
+### Publishing a Stable Release
+
+`.github/workflows/release.yml` provides the manual **Create stable release** action. It can run only from `main`, executes the backend and frontend suites, confirms that the tested commit is still the current `origin/main` tip, calculates the next UTC `YY.MM.Micro` version with `scripts/next_calver.py`, builds the existing `release.ps1` archive, and publishes it with generated GitHub release notes. Workflow concurrency prevents two release runs from publishing the same Micro version.
+
+Nightly remains the bake-in channel for untagged `main` commits. Publishing the tag promotes that exact commit to Stable; it does not create a separate nightly artifact.
 
 ### Status States
 

--- a/docs/software-versioning-policy.md
+++ b/docs/software-versioning-policy.md
@@ -1,0 +1,57 @@
+# Software Versioning Policy: Calendar Versioning (CalVer)
+
+## 1. Core principle
+
+Llama GUI uses Calendar Versioning (CalVer). A version communicates when a stable release was published rather than the size or type of its internal changes. The project aims to preserve backwards compatibility; any unavoidable compatibility impact must still be called out in the release notes.
+
+## 2. Version and tag format
+
+Stable releases use `YY.MM.Micro`, and their Git tags add a leading `v`:
+
+```text
+Version: 26.08.0
+Tag:     v26.08.0
+         |  |  |
+         |  |  +-- Micro: sequential release number within the month
+         |  +----- Month: two digits, zero-padded
+         +-------- Year: last two digits
+```
+
+- `YY`: Last two digits of the UTC release year.
+- `MM`: Two-digit UTC release month.
+- `Micro`: Starts at `0` for the first stable release of the month and increases by one for each later release that month.
+
+Release dates are calculated in UTC so a release near a month boundary has one unambiguous version.
+
+## 3. Release channels
+
+- **Nightly** follows every commit on `main`, including commits that have not been released yet. Nightly commits do not receive versions or consume Micro numbers.
+- **Stable** follows the newest qualifying `vYY.MM.Micro` tag reachable from `main`.
+
+Changes may remain available through Nightly for any desired testing period. When they are ready for Stable, the maintainer runs the manual **Create stable release** GitHub Actions workflow from `main`. The workflow tests the exact `main` commit, calculates the next CalVer version, builds the release archive, creates the tag, and publishes the GitHub Release.
+
+If `main` advances while the workflow is testing, the release stops and must be run again. Failures before the final publish step do not create a tag and therefore do not consume a version number. If GitHub creates a tag or partial release but its asset upload fails, repair or remove that partial release before running the workflow again.
+
+## 4. When to increment
+
+### First release of a month
+
+Reset Micro to `0`:
+
+- `v26.07.2` followed by the first August 2026 release becomes `v26.08.0`.
+
+### Additional releases in the same month
+
+Increase the highest existing Micro number by one regardless of whether the release contains features, maintenance changes, or an emergency fix:
+
+- `v26.08.0` becomes `v26.08.1`, then `v26.08.2`.
+
+Only canonical `vYY.MM.Micro` tags participate in this calculation. Nightly commits, prereleases, old-style letter suffixes, and unrelated tags are ignored.
+
+## 5. Examples
+
+| UTC release date | Change type | Version | Tag |
+| --- | --- | --- | --- |
+| August 12, 2026 | First release of the month | `26.08.0` | `v26.08.0` |
+| August 20, 2026 | Feature or fix | `26.08.1` | `v26.08.1` |
+| September 2, 2026 | First release of the next month | `26.09.0` | `v26.09.0` |

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -111,6 +111,7 @@ Backend tests use Python `unittest` and mostly exercise route/service logic with
 - `test_services.py`: service-level helpers for install specs, runtime validation, process/auth and active-runtime lifecycle, generation-bound health/stop behavior, downloads, file picker behavior, chat/search helpers, external-server registration (local-only validation, header-safe API keys, key never published or persisted, llama.cpp-aware probe identification, remembered-address round-tripping, unattended restore rules, runtime precedence), and HF validation.
 - `test_extracted_routes.py`: extracted route handlers and larger service flows, including preset secret scrubbing, launch preflight, active-runtime status, health/readiness, process launch/auth parsing, authoritative metrics/slots/chat targets, external chat-target registration and restore, HF download, tunnel, app update, and lifecycle routes.
 - `test_docs_sync.py`: documentation drift. Reads the live `API_ROUTER` and asserts the Route Modules table in `docs/directory.md` and the API surface table in `docs/architecture.html` list exactly the registered endpoints, in both directions, plus the stated endpoint count. Adding a route without documenting it fails here.
+- `test_release_version.py`: deterministic CalVer calculation for the first release of a month, later Micro increments, and ignored noncanonical tags.
 
 Run backend tests after changes under `backend/`, route behavior changes, service helper changes, process management changes, install/update changes, or security-sensitive validation changes.
 

--- a/scripts/next_calver.py
+++ b/scripts/next_calver.py
@@ -1,0 +1,26 @@
+"""Print the next UTC YY.MM.Micro version from this repository's tags."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from datetime import date, datetime, timezone
+from typing import Iterable, Optional
+
+
+def next_calver(tags: Iterable[str], today: Optional[date] = None) -> str:
+    today = today or datetime.now(timezone.utc).date()
+    prefix = today.strftime("%y.%m")
+    pattern = re.compile(rf"^v{re.escape(prefix)}\.(\d+)$")
+    micros = [int(match.group(1)) for tag in tags if (match := pattern.fullmatch(tag.strip()))]
+    return f"{prefix}.{max(micros, default=-1) + 1}"
+
+
+if __name__ == "__main__":
+    result = subprocess.run(
+        ["git", "tag", "--list"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    print(next_calver(result.stdout.splitlines()))

--- a/tests/backend/test_release_version.py
+++ b/tests/backend/test_release_version.py
@@ -1,0 +1,17 @@
+import unittest
+from datetime import date
+
+from scripts.next_calver import next_calver
+
+
+class CalVerTests(unittest.TestCase):
+    def test_first_release_of_month_starts_at_zero(self):
+        self.assertEqual(next_calver(["v2.0.6"], date(2026, 8, 12)), "26.08.0")
+
+    def test_next_release_uses_highest_micro(self):
+        tags = ["v26.08.2", "v26.08.0", "v26.07.9", "v26.08.1-rc1", "Summer-2026"]
+        self.assertEqual(next_calver(tags, date(2026, 8, 20)), "26.08.3")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Added a manual GitHub Actions stable-release workflow that tests the current `main` tip, calculates the next UTC CalVer version, packages the app, generates release notes, and publishes the tagged archive while Nightly commits continue to bake untagged.
