### PR TITLE
- Corrected the README backend list: removed the non-existent macOS `…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Special thanks to ggml-org for [llama.cpp](https://github.com/ggml-org/llama.cpp
 - A supported OS/architecture for the prebuilt `llama.cpp` binaries you want
 
 Supported prebuilt backends (installer only offers matches for your OS/arch):
-- Windows: CPU, CUDA, Vulkan, SYCL, ROCm
-- macOS: Apple Silicon (`Metal`, optional `KleidiAI`) and Intel CPU
-- Linux: CPU, Vulkan, ROCm, OpenVINO (depends on architecture; some accelerators need vendor drivers)
+- Windows: CPU, CUDA, Vulkan, SYCL, ROCm, and more
+- macOS: Apple Silicon (`Metal`) and Intel CPU
+- Linux: CPU, Vulkan, ROCm, OpenVINO, Lemonade ROCm (depends on architecture; some accelerators need vendor drivers)
 
 ## Quick Start
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ Please give a brief summary of changes made to the program, include the date the
 - Added a manual GitHub Actions stable-release workflow that tests the current `main` tip, calculates the next UTC CalVer version, packages the app, generates release notes, and publishes the tagged archive while Nightly commits continue to bake untagged.
 - Removed the stale `-mv` / Vocoder Model server control and its unused file-picker purpose because current llama.cpp builds no longer accept that flag.
 - Added a Stable/Nightly selector for Llama GUI app updates. Stable keeps targeting the newest tagged release; Nightly safely fast-forwards to the latest commit on the configured release branch while retaining dirty-tree, divergence, dependency-install, and restart protections.
+- Corrected the README backend list: removed the non-existent macOS `KleidiAI` option and added Lemonade ROCm to the Linux list.
 - Reworked the left sidebar into a compact persistent runtime dock: Launch/Stop and the danger-styled Python shutdown control remain reachable without scrolling, memory usage is an expandable stacked GPU/RAM estimate, the Model Switcher remains intact in a shorter panel, and a narrow icon-only theme control leaves more room for the adjacent build version.
 
 ## 2026-08-11


### PR DESCRIPTION
Corrected the README backend list: removed the non-existent macOS `KleidiAI` option and added Lemonade ROCm to the Linux list.