### PR TITLE
Add preset archive/restore feature

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -952,6 +952,7 @@ API_ROUTER = (
     .add("POST", "/api/presets", presets_routes.save_preset)
     .add("POST", "/api/presets/shortcut", presets_routes.export_preset_shortcut)
     .add("POST", "/api/presets/rename", presets_routes.rename_preset)
+    .add("POST", "/api/presets/archive", presets_routes.archive_presets)
     .add("POST", "/api/open-folder", lifecycle_routes.post_open_folder)
     .add("POST", "/api/select-file", file_picker_routes.select_file)
     .add_prefix("DELETE", "/api/presets/", presets_routes.delete_preset, "name")

--- a/backend/routes/presets.py
+++ b/backend/routes/presets.py
@@ -6,6 +6,8 @@ import sys
 import time
 import urllib.parse
 
+from ..http import sanitize_error
+
 
 _PRESET_CREATED_TIMES_FILE = ".preset-created-times"
 _PRESET_ARCHIVED_FILE = ".preset-archived"
@@ -140,16 +142,7 @@ def _load_preset_archived(presets_dir):
 
 def _save_preset_archived(presets_dir, archived_names):
     metadata_file = presets_dir / _PRESET_ARCHIVED_FILE
-    try:
-        metadata_file.write_text(
-            json.dumps(sorted(archived_names), indent=2),
-            encoding="utf-8",
-        )
-    except OSError as exc:
-        print(
-            f"[presets] failed to save archive metadata: {type(exc).__name__}: {exc}",
-            file=sys.stderr,
-        )
+    _write_preset_json(metadata_file, sorted(archived_names))
 
 
 def _initial_preset_created_time(stat_result):
@@ -224,49 +217,56 @@ def build_preset_shortcut_script(root_dir, preset_name, gui_host="127.0.0.1", gu
 def list_presets(request, response, ctx):
     presets = []
     presets_dir = ctx.paths.presets
-    if presets_dir.exists():
-        created_times = _load_preset_created_times(presets_dir)
-        archived_names = _load_preset_archived(presets_dir)
-        existing_names = set()
-        metadata_changed = False
-        for path in sorted(presets_dir.glob("*.json")):
-            try:
-                with open(path, "r", encoding="utf-8") as preset_file:
-                    data = json.load(preset_file)
-                if is_preset_bundle(data):
-                    continue
-                stat_result = path.stat()
-                data, removed_sensitive_values = sanitize_preset_data(data)
-                if removed_sensitive_values:
-                    _write_preset_json(path, data)
-                existing_names.add(path.name)
-                created = created_times.get(path.name)
-                if not _is_valid_timestamp(created):
-                    created = _initial_preset_created_time(stat_result)
-                    created_times[path.name] = created
-                    metadata_changed = True
-                presets.append({
-                    "name": path.stem,
-                    "data": data,
-                    "created": created,
-                    "modified": path.stat().st_mtime,
-                    "archived": path.name in archived_names,
-                })
-            except (json.JSONDecodeError, OSError) as exc:
-                print(
-                    f"[presets] skipping unreadable preset {path.name}: {type(exc).__name__}: {exc}",
-                    file=sys.stderr,
-                )
-        stale_names = set(created_times) - existing_names
-        if stale_names:
-            for name in stale_names:
-                del created_times[name]
-            metadata_changed = True
-        if metadata_changed:
-            _save_preset_created_times(presets_dir, created_times)
-        stale_archived = archived_names - existing_names
-        if stale_archived:
-            _save_preset_archived(presets_dir, archived_names - stale_archived)
+    with ctx.state.preset_lock:
+        if presets_dir.exists():
+            created_times = _load_preset_created_times(presets_dir)
+            archived_names = _load_preset_archived(presets_dir)
+            existing_names = set()
+            metadata_changed = False
+            for path in sorted(presets_dir.glob("*.json")):
+                try:
+                    with open(path, "r", encoding="utf-8") as preset_file:
+                        data = json.load(preset_file)
+                    if is_preset_bundle(data):
+                        continue
+                    stat_result = path.stat()
+                    data, removed_sensitive_values = sanitize_preset_data(data)
+                    if removed_sensitive_values:
+                        _write_preset_json(path, data)
+                    existing_names.add(path.name)
+                    created = created_times.get(path.name)
+                    if not _is_valid_timestamp(created):
+                        created = _initial_preset_created_time(stat_result)
+                        created_times[path.name] = created
+                        metadata_changed = True
+                    presets.append({
+                        "name": path.stem,
+                        "data": data,
+                        "created": created,
+                        "modified": path.stat().st_mtime,
+                        "archived": path.name in archived_names,
+                    })
+                except (json.JSONDecodeError, OSError) as exc:
+                    print(
+                        f"[presets] skipping unreadable preset {path.name}: {type(exc).__name__}: {exc}",
+                        file=sys.stderr,
+                    )
+            stale_names = set(created_times) - existing_names
+            if stale_names:
+                for name in stale_names:
+                    del created_times[name]
+                metadata_changed = True
+            if metadata_changed:
+                _save_preset_created_times(presets_dir, created_times)
+            stale_archived = archived_names - existing_names
+            if stale_archived:
+                try:
+                    _save_preset_archived(presets_dir, archived_names - stale_archived)
+                except OSError as exc:
+                    print(
+                        f"[presets] failed to clean archive metadata: {type(exc).__name__}: {exc}",
+                        file=sys.stderr,
+                    )
     response.json(presets)
 
 
@@ -285,29 +285,31 @@ def save_preset(request, response, ctx):
         return
 
     presets_dir = ctx.paths.presets
-    presets_dir.mkdir(parents=True, exist_ok=True)
     safe_name = sanitize_preset_name(name)
     if not safe_name:
         response.error("Invalid preset name", 400)
         return
-    preset_file = get_preset_file_path(presets_dir, safe_name)
-    if preset_file is None:
-        response.error("Invalid preset name", 400)
-        return
-    if body.get("overwrite", True) is False and preset_file.exists():
-        response.error("A preset with that name already exists", 409)
-        return
 
-    created_times = _load_preset_created_times(presets_dir)
-    if not _is_valid_timestamp(created_times.get(preset_file.name)):
-        if preset_file.exists():
-            created_times[preset_file.name] = _initial_preset_created_time(preset_file.stat())
-        else:
-            created_times[preset_file.name] = time.time()
+    with ctx.state.preset_lock:
+        presets_dir.mkdir(parents=True, exist_ok=True)
+        preset_file = get_preset_file_path(presets_dir, safe_name)
+        if preset_file is None:
+            response.error("Invalid preset name", 400)
+            return
+        if body.get("overwrite", True) is False and preset_file.exists():
+            response.error("A preset with that name already exists", 409)
+            return
 
-    data, _ = sanitize_preset_data(data)
-    _write_preset_json(preset_file, data)
-    _save_preset_created_times(presets_dir, created_times)
+        created_times = _load_preset_created_times(presets_dir)
+        if not _is_valid_timestamp(created_times.get(preset_file.name)):
+            if preset_file.exists():
+                created_times[preset_file.name] = _initial_preset_created_time(preset_file.stat())
+            else:
+                created_times[preset_file.name] = time.time()
+
+        data, _ = sanitize_preset_data(data)
+        _write_preset_json(preset_file, data)
+        _save_preset_created_times(presets_dir, created_times)
     response.json({"saved": True, "name": safe_name})
 
 
@@ -333,34 +335,40 @@ def rename_preset(request, response, ctx):
         return
 
     presets_dir = ctx.paths.presets
-    preset_file = get_preset_file_path(presets_dir, safe_name)
-    # validation only: the resolved path is unusable as a rename target because
-    # Windows collapses its casing onto any existing file
-    validated_target = get_preset_file_path(presets_dir, safe_new_name)
-    if preset_file is None or validated_target is None:
-        response.error("Invalid preset name", 400)
-        return
-    if not preset_file.exists():
-        response.error("Preset not found", 404)
-        return
-    if safe_name == safe_new_name:
-        response.json({"renamed": True, "name": safe_new_name})
-        return
+    with ctx.state.preset_lock:
+        preset_file = get_preset_file_path(presets_dir, safe_name)
+        # validation only: the resolved path is unusable as a rename target because
+        # Windows collapses its casing onto any existing file
+        validated_target = get_preset_file_path(presets_dir, safe_new_name)
+        if preset_file is None or validated_target is None:
+            response.error("Invalid preset name", 400)
+            return
+        if not preset_file.exists():
+            response.error("Preset not found", 404)
+            return
+        if safe_name == safe_new_name:
+            response.json({"renamed": True, "name": safe_new_name})
+            return
 
-    # On Windows both Path equality and resolve() are case-insensitive, so a case-only
-    # rename would collapse onto the source and silently do nothing. Rename against the
-    # requested spelling instead, inside the parent get_preset_file_path already validated.
-    renamed_file = preset_file.parent / f"{safe_new_name}.json"
-    if renamed_file.exists() and not _is_same_file(renamed_file, preset_file):
-        response.error("A preset with that name already exists", 409)
-        return
+        # On Windows both Path equality and resolve() are case-insensitive, so a case-only
+        # rename would collapse onto the source and silently do nothing. Rename against the
+        # requested spelling instead, inside the parent get_preset_file_path already validated.
+        renamed_file = preset_file.parent / f"{safe_new_name}.json"
+        if renamed_file.exists() and not _is_same_file(renamed_file, preset_file):
+            response.error("A preset with that name already exists", 409)
+            return
 
-    preset_file.rename(renamed_file)
-    created_times = _load_preset_created_times(presets_dir)
-    if preset_file.name in created_times:
-        # carry the original creation time so "Date added" sorting survives a rename
-        created_times[renamed_file.name] = created_times.pop(preset_file.name)
-        _save_preset_created_times(presets_dir, created_times)
+        preset_file.rename(renamed_file)
+        created_times = _load_preset_created_times(presets_dir)
+        if preset_file.name in created_times:
+            # carry the original creation time so "Date added" sorting survives a rename
+            created_times[renamed_file.name] = created_times.pop(preset_file.name)
+            _save_preset_created_times(presets_dir, created_times)
+        archived_names = _load_preset_archived(presets_dir)
+        if preset_file.name in archived_names:
+            archived_names.remove(preset_file.name)
+            archived_names.add(renamed_file.name)
+            _save_preset_archived(presets_dir, archived_names)
     response.json({"renamed": True, "name": safe_new_name})
 
 
@@ -401,50 +409,59 @@ def delete_preset(request, response, ctx):
     if not safe_name:
         response.error("Invalid preset name", 400)
         return
-    preset_file = get_preset_file_path(ctx.paths.presets, safe_name)
-    if preset_file is None:
-        response.error("Invalid preset name", 400)
-        return
-    if preset_file.exists():
-        preset_file.unlink()
-        created_times = _load_preset_created_times(ctx.paths.presets)
-        if preset_file.name in created_times:
-            del created_times[preset_file.name]
-            _save_preset_created_times(ctx.paths.presets, created_times)
-        archived_names = _load_preset_archived(ctx.paths.presets)
-        if preset_file.name in archived_names:
-            archived_names.discard(preset_file.name)
-            _save_preset_archived(ctx.paths.presets, archived_names)
-        response.json({"deleted": True})
-    else:
-        response.error("Preset not found", 404)
+    with ctx.state.preset_lock:
+        preset_file = get_preset_file_path(ctx.paths.presets, safe_name)
+        if preset_file is None:
+            response.error("Invalid preset name", 400)
+            return
+        if preset_file.exists():
+            preset_file.unlink()
+            created_times = _load_preset_created_times(ctx.paths.presets)
+            if preset_file.name in created_times:
+                del created_times[preset_file.name]
+                _save_preset_created_times(ctx.paths.presets, created_times)
+            archived_names = _load_preset_archived(ctx.paths.presets)
+            if preset_file.name in archived_names:
+                archived_names.discard(preset_file.name)
+                _save_preset_archived(ctx.paths.presets, archived_names)
+            response.json({"deleted": True})
+        else:
+            response.error("Preset not found", 404)
 
 
 def archive_presets(request, response, ctx):
     body = request.body or {}
     names = body.get("names")
-    archived = bool(body.get("archived"))
     if not isinstance(names, list) or not names:
         response.error("names list required", 400)
         return
+    archived = body.get("archived")
+    if not isinstance(archived, bool):
+        response.error("archived boolean required", 400)
+        return
 
     presets_dir = ctx.paths.presets
-    file_names = []
-    for name in names:
-        safe_name = sanitize_preset_name(name)
-        preset_file = get_preset_file_path(presets_dir, safe_name) if safe_name else None
-        if preset_file is None:
-            response.error("Invalid preset name", 400)
-            return
-        if not preset_file.exists():
-            response.error("Preset not found", 404)
-            return
-        file_names.append(preset_file.name)
+    try:
+        with ctx.state.preset_lock:
+            file_names = []
+            for name in names:
+                safe_name = sanitize_preset_name(name)
+                preset_file = get_preset_file_path(presets_dir, safe_name) if safe_name else None
+                if preset_file is None:
+                    response.error("Invalid preset name", 400)
+                    return
+                if not preset_file.exists():
+                    response.error("Preset not found", 404)
+                    return
+                file_names.append(preset_file.name)
 
-    archived_names = _load_preset_archived(presets_dir)
-    if archived:
-        archived_names.update(file_names)
-    else:
-        archived_names.difference_update(file_names)
-    _save_preset_archived(presets_dir, archived_names)
+            archived_names = _load_preset_archived(presets_dir)
+            if archived:
+                archived_names.update(file_names)
+            else:
+                archived_names.difference_update(file_names)
+            _save_preset_archived(presets_dir, archived_names)
+    except OSError as exc:
+        response.error(sanitize_error(exc, 500), 500)
+        return
     response.json({"archived": archived, "count": len(file_names)})

--- a/backend/routes/presets.py
+++ b/backend/routes/presets.py
@@ -8,6 +8,7 @@ import urllib.parse
 
 
 _PRESET_CREATED_TIMES_FILE = ".preset-created-times"
+_PRESET_ARCHIVED_FILE = ".preset-archived"
 _SENSITIVE_PRESET_KEYS = {"api_key"}
 _SENSITIVE_CUSTOM_ARG_RE = re.compile(r"(?<![A-Za-z0-9_-])--api-key(?=$|[=\s])")
 
@@ -120,6 +121,37 @@ def _save_preset_created_times(presets_dir, created_times):
         )
 
 
+def _load_preset_archived(presets_dir):
+    metadata_file = presets_dir / _PRESET_ARCHIVED_FILE
+    try:
+        data = json.loads(metadata_file.read_text(encoding="utf-8"))
+        if not isinstance(data, list):
+            return set()
+        return {str(name) for name in data}
+    except FileNotFoundError:
+        return set()
+    except (json.JSONDecodeError, OSError) as exc:
+        print(
+            f"[presets] failed to read archive metadata: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return set()
+
+
+def _save_preset_archived(presets_dir, archived_names):
+    metadata_file = presets_dir / _PRESET_ARCHIVED_FILE
+    try:
+        metadata_file.write_text(
+            json.dumps(sorted(archived_names), indent=2),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        print(
+            f"[presets] failed to save archive metadata: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+
+
 def _initial_preset_created_time(stat_result):
     birth_time = getattr(stat_result, "st_birthtime", None)
     if _is_valid_timestamp(birth_time):
@@ -194,6 +226,7 @@ def list_presets(request, response, ctx):
     presets_dir = ctx.paths.presets
     if presets_dir.exists():
         created_times = _load_preset_created_times(presets_dir)
+        archived_names = _load_preset_archived(presets_dir)
         existing_names = set()
         metadata_changed = False
         for path in sorted(presets_dir.glob("*.json")):
@@ -217,6 +250,7 @@ def list_presets(request, response, ctx):
                     "data": data,
                     "created": created,
                     "modified": path.stat().st_mtime,
+                    "archived": path.name in archived_names,
                 })
             except (json.JSONDecodeError, OSError) as exc:
                 print(
@@ -230,6 +264,9 @@ def list_presets(request, response, ctx):
             metadata_changed = True
         if metadata_changed:
             _save_preset_created_times(presets_dir, created_times)
+        stale_archived = archived_names - existing_names
+        if stale_archived:
+            _save_preset_archived(presets_dir, archived_names - stale_archived)
     response.json(presets)
 
 
@@ -374,6 +411,40 @@ def delete_preset(request, response, ctx):
         if preset_file.name in created_times:
             del created_times[preset_file.name]
             _save_preset_created_times(ctx.paths.presets, created_times)
+        archived_names = _load_preset_archived(ctx.paths.presets)
+        if preset_file.name in archived_names:
+            archived_names.discard(preset_file.name)
+            _save_preset_archived(ctx.paths.presets, archived_names)
         response.json({"deleted": True})
     else:
         response.error("Preset not found", 404)
+
+
+def archive_presets(request, response, ctx):
+    body = request.body or {}
+    names = body.get("names")
+    archived = bool(body.get("archived"))
+    if not isinstance(names, list) or not names:
+        response.error("names list required", 400)
+        return
+
+    presets_dir = ctx.paths.presets
+    file_names = []
+    for name in names:
+        safe_name = sanitize_preset_name(name)
+        preset_file = get_preset_file_path(presets_dir, safe_name) if safe_name else None
+        if preset_file is None:
+            response.error("Invalid preset name", 400)
+            return
+        if not preset_file.exists():
+            response.error("Preset not found", 404)
+            return
+        file_names.append(preset_file.name)
+
+    archived_names = _load_preset_archived(presets_dir)
+    if archived:
+        archived_names.update(file_names)
+    else:
+        archived_names.difference_update(file_names)
+    _save_preset_archived(presets_dir, archived_names)
+    response.json({"archived": archived, "count": len(file_names)})

--- a/backend/state.py
+++ b/backend/state.py
@@ -83,6 +83,7 @@ class AtomicDict:
 class ServerState:
     process: Any = None
     process_lock: threading.Lock = field(default_factory=threading.Lock)
+    preset_lock: threading.Lock = field(default_factory=threading.Lock)
     output_buffer: list[str] = field(default_factory=list)
     output_buffer_lock: threading.Lock = field(default_factory=threading.Lock)
     output_buffer_start: int = 0

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1125,6 +1125,7 @@ flagCore.setFlagValue("temperature", 0.5);
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/remote-tunnel/stop</td><td>Stop the tunnel</td></tr>
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/presets</td><td>Save a preset</td></tr>
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/presets/rename</td><td>Rename, carrying the created-time entry</td></tr>
+<tr><td><span class="verb post">POST</span></td><td class="mono">/api/presets/archive</td><td>Bulk archive or restore presets (library visibility only)</td></tr>
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/presets/shortcut</td><td>Export a Windows shortcut</td></tr>
 <tr><td><span class="verb del">DELETE</span></td><td class="mono">/api/presets/&lt;name&gt;</td><td>Delete a preset (prefix route)</td></tr>
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/app-update</td><td>Fast-forward to the selected update target and reinstall deps</td></tr>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ Please give a brief summary of changes made to the program, include the date the
 
 ## 2026-08-12
 
+- Added preset archiving to the Presets tab: per-row, detail-panel, and bulk Archive/Restore controls move presets out of the main list into a 📦 Archived view without touching their files, so rename, delete, export, and `?preset=` shortcuts keep working. Archive state lives in a `.preset-archived` metadata file beside the presets and is exposed via a new `POST /api/presets/archive` route and an `archived` flag on `GET /api/presets`.
 - Added a manual GitHub Actions stable-release workflow that tests the current `main` tip, calculates the next UTC CalVer version, packages the app, generates release notes, and publishes the tagged archive while Nightly commits continue to bake untagged.
 - Removed the stale `-mv` / Vocoder Model server control and its unused file-picker purpose because current llama.cpp builds no longer accept that flag.
 - Added a Stable/Nightly selector for Llama GUI app updates. Stable keeps targeting the newest tagged release; Nightly safely fast-forwards to the latest commit on the configured release branch while retaining dirty-tree, divergence, dependency-install, and restart protections.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@ Please give a brief summary of changes made to the program, include the date the
 
 ## 2026-08-12
 
-- Added preset archiving to the Presets tab: per-row, detail-panel, and bulk Archive/Restore controls move presets out of the main list into a 📦 Archived view without touching their files, so rename, delete, export, and `?preset=` shortcuts keep working. Archive state lives in a `.preset-archived` metadata file beside the presets and is exposed via a new `POST /api/presets/archive` route and an `archived` flag on `GET /api/presets`.
+- Added preset archiving to the Presets tab: per-row, detail-panel, and bulk Archive/Restore controls move presets out of the main list into a 📦 Archived view without touching their files, so rename, delete, export, and `?preset=` shortcuts keep working. Archive state lives in an atomically written `.preset-archived` metadata file beside the presets, stays linked through renames, serializes concurrent changes, and is exposed via a validated `POST /api/presets/archive` route and an `archived` flag on `GET /api/presets`.
 - Added a manual GitHub Actions stable-release workflow that tests the current `main` tip, calculates the next UTC CalVer version, packages the app, generates release notes, and publishes the tagged archive while Nightly commits continue to bake untagged.
 - Removed the stale `-mv` / Vocoder Model server control and its unused file-picker purpose because current llama.cpp builds no longer accept that flag.
 - Added a Stable/Nightly selector for Llama GUI app updates. Stable keeps targeting the newest tagged release; Nightly safely fast-forwards to the latest commit on the configured release branch while retaining dirty-tree, divergence, dependency-install, and restart protections.

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -79,7 +79,7 @@
 
 ### Route Modules (`backend/routes/`)
 
-`API_ROUTER` at the bottom of `backend/app.py` is the authoritative registry: 42 exact routes plus one prefix route, 43 endpoints total. Keep this table in sync with it — a route that is registered but undocumented here is the drift that is hardest to notice.
+`API_ROUTER` at the bottom of `backend/app.py` is the authoritative registry: 43 exact routes plus one prefix route, 44 endpoints total. Keep this table in sync with it — a route that is registered but undocumented here is the drift that is hardest to notice.
 
 | Route | Endpoints |
 |-------|-----------|
@@ -90,7 +90,7 @@
 | `install.py` | `GET /api/releases`, `GET /api/download-progress`, `POST /api/install`, `POST /api/update`, `POST /api/activate-custom` |
 | `metrics.py` | `GET /api/llama/metrics`, `GET /api/llama/slots` — Prometheus proxy |
 | `models.py` | `GET /api/models` — list GGUF files recursively as `models/`-relative names |
-| `presets.py` | `GET /api/presets`, `POST /api/presets` (save), `POST /api/presets/rename`, `POST /api/presets/shortcut` (Windows shortcut export), `DELETE /api/presets/<name>` (prefix route) |
+| `presets.py` | `GET /api/presets`, `POST /api/presets` (save), `POST /api/presets/rename`, `POST /api/presets/archive` (bulk archive/restore), `POST /api/presets/shortcut` (Windows shortcut export), `DELETE /api/presets/<name>` (prefix route) |
 | `hf_download.py` | `POST /api/hf/repo-files`, `POST /api/hf/download`, `POST /api/hf/download-cancel`, `GET /api/hf/download-status` |
 | `tunnel.py` | `POST /api/remote-tunnel/start`, `POST /api/remote-tunnel/stop`, `GET /api/remote-tunnel/status` |
 | `git_update.py` | `GET /api/app-update-status`, `POST /api/app-update` |
@@ -176,7 +176,7 @@ The frontend loads scripts in a strict dependency order via `ui/index.html`:
 | `ui/js/flag-core.js` | `window.LlamaGui.flagCore` | Shared frontend flag state and launch-argument core. Owns `currentTool`, selected model, `flagValues`, shared setters, custom launch args parsing, preset apply/collect helpers, `getLaunchArgs()`, and command preview generation |
 | `ui/js/config-flags-ui.js` | `window.LlamaGui.configFlagsUi` | Configure tab flag rendering, search/filtering, expand/collapse state, type-specific flag input builders, input restoration, and high-risk `multi_enum` warnings |
 | `ui/js/manager.js` | `window.LlamaGui.manager` | GitHub release fetching, backend selection, installation progress UI, app update (git status/pull/restart), the shared `fetchJson()` utility, accepted-status observer wiring for runtime reconciliation, and the shared known-model-name cache (`getKnownModelNames()`) populated by `refreshModels()` |
-| `ui/js/presets.js` | `window.LlamaGui.presets` | Preset normalization, validation, saving, loading, updating, deleting, duplicating, renaming, exporting, and importing; group-by-model library rendering with search across names, models, tools and overridden flags; favorites, warning and bulk-selection filters; the detail panel and library summary; missing-model detection; and roving arrow-key focus |
+| `ui/js/presets.js` | `window.LlamaGui.presets` | Preset normalization, validation, saving, loading, updating, deleting, duplicating, renaming, exporting, and importing; group-by-model library rendering with search across names, models, tools and overridden flags; favorites, warning and bulk-selection filters; an archive view that hides unused presets until restored; the detail panel and library summary; missing-model detection; and roving arrow-key focus |
 | `ui/js/searchable-select.js` | `window.LlamaGui.searchableSelect` | Searchable combobox wrapper that visually replaces a native `<select>` (button + popup with search) while keeping the select in the DOM as the source of truth for options, value, and change events |
 | `ui/js/model-switch-ui.js` | `window.LlamaGui.modelSwitchUi` | Versioned two-slot saved-preset references, strict storage normalization, duplicate detection, session-only fallback, accessible Quick Launch card state/rendering, and the drag-to-confirm sidebar shortcut wired through injected preset/runtime dependencies |
 | `ui/js/app-data.js` | (data) | `QUICK_PROFILES`, `BUILTIN_SAMPLER_PRESETS`, `CHAT_SAMPLER_SLIDER_MAP` |

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -465,6 +465,108 @@ class ExtractedRouteTests(unittest.TestCase):
             )
             self.assertEqual(empty_response.status, 400)
 
+            for archived in (None, 0, 1, "false"):
+                with self.subTest(archived=archived):
+                    invalid_response = DummyResponse()
+                    presets.archive_presets(
+                        Request(
+                            "POST",
+                            "/api/presets/archive",
+                            "",
+                            {},
+                            body={"names": ["Shelve"], "archived": archived},
+                        ),
+                        invalid_response,
+                        ctx,
+                    )
+                    self.assertEqual(invalid_response.status, 400)
+
+    def test_presets_archive_route_reports_metadata_write_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            presets.save_preset(
+                Request("POST", "/api/presets", "", {}, body={"name": "Shelve", "data": {}}),
+                DummyResponse(),
+                ctx,
+            )
+            response = DummyResponse()
+            stderr = io.StringIO()
+
+            with mock.patch.object(
+                presets, "_write_preset_json", side_effect=OSError("disk full")
+            ), contextlib.redirect_stderr(stderr):
+                presets.archive_presets(
+                    Request(
+                        "POST",
+                        "/api/presets/archive",
+                        "",
+                        {},
+                        body={"names": ["Shelve"], "archived": True},
+                    ),
+                    response,
+                    ctx,
+                )
+
+            self.assertEqual(response.status, 500)
+            self.assertEqual(response.payload["error"], "Internal server error")
+            self.assertIn("disk full", stderr.getvalue())
+
+    def test_presets_archive_route_serializes_concurrent_updates(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            for name in ("First", "Second"):
+                presets.save_preset(
+                    Request("POST", "/api/presets", "", {}, body={"name": name, "data": {}}),
+                    DummyResponse(),
+                    ctx,
+                )
+
+            real_load = presets._load_preset_archived
+            load_count = 0
+            load_count_lock = threading.Lock()
+            both_loaded = threading.Event()
+            errors = []
+
+            def slow_load(presets_dir):
+                nonlocal load_count
+                archived_names = real_load(presets_dir)
+                with load_count_lock:
+                    load_count += 1
+                    if load_count == 2:
+                        both_loaded.set()
+                both_loaded.wait(0.15)
+                return archived_names
+
+            def archive(name):
+                try:
+                    presets.archive_presets(
+                        Request(
+                            "POST",
+                            "/api/presets/archive",
+                            "",
+                            {},
+                            body={"names": [name], "archived": True},
+                        ),
+                        DummyResponse(),
+                        ctx,
+                    )
+                except Exception as exc:
+                    errors.append(exc)
+
+            with mock.patch.object(presets, "_load_preset_archived", side_effect=slow_load):
+                threads = [threading.Thread(target=archive, args=(name,)) for name in ("First", "Second")]
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join(2)
+
+            self.assertFalse(errors)
+            self.assertFalse(any(thread.is_alive() for thread in threads))
+            self.assertEqual(
+                json.loads((ctx.paths.presets / ".preset-archived").read_text(encoding="utf-8")),
+                ["First.json", "Second.json"],
+            )
+
     def test_delete_preset_clears_archive_metadata(self):
         with tempfile.TemporaryDirectory() as tmp:
             ctx = make_context(tmp)
@@ -560,6 +662,17 @@ class ExtractedRouteTests(unittest.TestCase):
             list_response = DummyResponse()
             presets.list_presets(Request("GET", "/api/presets", "", {}), list_response, ctx)
             created = list_response.payload[0]["created"]
+            presets.archive_presets(
+                Request(
+                    "POST",
+                    "/api/presets/archive",
+                    "",
+                    {},
+                    body={"names": ["Original"], "archived": True},
+                ),
+                DummyResponse(),
+                ctx,
+            )
 
             response = DummyResponse()
             presets.rename_preset(
@@ -578,9 +691,14 @@ class ExtractedRouteTests(unittest.TestCase):
             self.assertEqual(renamed_list.payload[0]["name"], "Renamed")
             self.assertEqual(renamed_list.payload[0]["data"], {"temperature": 0.7})
             self.assertEqual(renamed_list.payload[0]["created"], created)
+            self.assertTrue(renamed_list.payload[0]["archived"])
             self.assertEqual(
                 json.loads((ctx.paths.presets / ".preset-created-times").read_text(encoding="utf-8")),
                 {"Renamed.json": created},
+            )
+            self.assertEqual(
+                json.loads((ctx.paths.presets / ".preset-archived").read_text(encoding="utf-8")),
+                ["Renamed.json"],
             )
 
     def test_rename_preset_applies_a_case_only_change(self):

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -415,6 +415,81 @@ class ExtractedRouteTests(unittest.TestCase):
                 {},
             )
 
+    def test_presets_archive_route_flags_restores_and_validates(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            for name in ("Keep", "Shelve"):
+                presets.save_preset(
+                    Request("POST", "/api/presets", "", {}, body={"name": name, "data": {"temperature": 0.5}}),
+                    DummyResponse(),
+                    ctx,
+                )
+
+            archive_response = DummyResponse()
+            presets.archive_presets(
+                Request("POST", "/api/presets/archive", "", {}, body={"names": ["Shelve"], "archived": True}),
+                archive_response,
+                ctx,
+            )
+            self.assertEqual(archive_response.payload, {"archived": True, "count": 1})
+
+            list_response = DummyResponse()
+            presets.list_presets(Request("GET", "/api/presets", "", {}), list_response, ctx)
+            flags = {entry["name"]: entry["archived"] for entry in list_response.payload}
+            self.assertEqual(flags, {"Keep": False, "Shelve": True})
+
+            restore_response = DummyResponse()
+            presets.archive_presets(
+                Request("POST", "/api/presets/archive", "", {}, body={"names": ["Shelve"], "archived": False}),
+                restore_response,
+                ctx,
+            )
+            self.assertEqual(restore_response.payload, {"archived": False, "count": 1})
+            list_response = DummyResponse()
+            presets.list_presets(Request("GET", "/api/presets", "", {}), list_response, ctx)
+            self.assertFalse(any(entry["archived"] for entry in list_response.payload))
+
+            missing_response = DummyResponse()
+            presets.archive_presets(
+                Request("POST", "/api/presets/archive", "", {}, body={"names": ["Missing"], "archived": True}),
+                missing_response,
+                ctx,
+            )
+            self.assertEqual(missing_response.status, 404)
+
+            empty_response = DummyResponse()
+            presets.archive_presets(
+                Request("POST", "/api/presets/archive", "", {}, body={"names": [], "archived": True}),
+                empty_response,
+                ctx,
+            )
+            self.assertEqual(empty_response.status, 400)
+
+    def test_delete_preset_clears_archive_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            presets.save_preset(
+                Request("POST", "/api/presets", "", {}, body={"name": "Shelve", "data": {"temperature": 0.5}}),
+                DummyResponse(),
+                ctx,
+            )
+            presets.archive_presets(
+                Request("POST", "/api/presets/archive", "", {}, body={"names": ["Shelve"], "archived": True}),
+                DummyResponse(),
+                ctx,
+            )
+
+            presets.delete_preset(
+                Request("DELETE", "/api/presets/Shelve", "", {}, params={"name": "Shelve"}),
+                DummyResponse(),
+                ctx,
+            )
+
+            self.assertEqual(
+                json.loads((ctx.paths.presets / ".preset-archived").read_text(encoding="utf-8")),
+                [],
+            )
+
     def test_list_presets_reads_utf8_explicitly(self):
         with tempfile.TemporaryDirectory() as tmp:
             ctx = make_context(tmp)

--- a/tests/frontend/flag_sync_smoke.cjs
+++ b/tests/frontend/flag_sync_smoke.cjs
@@ -1705,8 +1705,8 @@ async function main() {
         assert.equal(state.tabbable, 1, "still exactly one item in the tab order after moving");
         assert.equal(
             state.tabbableDescendants,
-            3,
-            "only the focused row's checkbox, favorite, and Load button stay tabbable"
+            4,
+            "only the focused row's checkbox, favorite, archive, and Load button stay tabbable"
         );
 
         // Enter selects without collapsing the roving state.

--- a/tests/frontend/presets_unit.cjs
+++ b/tests/frontend/presets_unit.cjs
@@ -990,7 +990,60 @@ async function testPresetLoadFailureClearsAuxiliaryState() {
     assert.equal(elements.get("presets-count-line").textContent, "0 presets · 0 models");
 }
 
-testPresetLoadFailureClearsAuxiliaryState()
+// --- Archive view ------------------------------------------------------------
+// Archived presets stay in the library (still loadable by name or shortcut)
+// but are hidden from the main list; the archive view shows only them.
+{
+    const ctx = createModelContext(new Set(["kept.gguf"]));
+    ctx.__presets = [
+        { name: "daily", archived: false, data: { model: "kept.gguf", flags: {} } },
+        { name: "shelved", archived: true, data: { model: "kept.gguf", flags: {} } },
+    ];
+    // joined before compare: a vm-context array is not host Array, so
+    // deepStrictEqual would fail on the prototype even with equal contents
+    const visibleNames = () => vm.runInContext("getVisiblePresetEntries().map((e) => e.name).join(',')", ctx);
+
+    vm.runInContext("currentPresetGroups = buildPresetGroups(__presets)", ctx);
+    assert.equal(visibleNames(), "daily", "archived presets are hidden from the main list");
+    assert.equal(vm.runInContext("getPresetLibrarySummary().filtered", ctx), false);
+
+    vm.runInContext("presetArchiveViewActive = true; currentPresetGroups = buildPresetGroups(__presets)", ctx);
+    assert.equal(visibleNames(), "shelved", "the archive view shows only archived presets");
+    assert.equal(
+        vm.runInContext("getPresetLibrarySummary().filtered", ctx),
+        true,
+        "the archive view reports itself as filtered so the summary stays scoped"
+    );
+
+    vm.runInContext("presetArchiveViewActive = false", ctx);
+}
+
+async function testSetPresetArchivedPostsBatchPayload() {
+    const ctx = createModelContext(new Set(["kept.gguf"]));
+    const calls = [];
+    ctx.fetchJson = async (url, options) => {
+        calls.push({ url, body: JSON.parse(options.body) });
+        return { archived: options ? JSON.parse(options.body).archived : true, count: 1 };
+    };
+    vm.runInContext("selectedPresetNames = new Set(['shelved'])", ctx);
+
+    await vm.runInContext("setPresetArchived(['shelved'], true)", ctx);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "/api/presets/archive");
+    assert.deepEqual(calls[0].body, { names: ["shelved"], archived: true });
+    assert.equal(
+        vm.runInContext("selectedPresetNames.size", ctx),
+        0,
+        "presets moved to the archive leave the current view, so they must leave the selection"
+    );
+
+    await vm.runInContext("setPresetArchived('solo', false)", ctx);
+    assert.deepEqual(calls[1].body, { names: ["solo"], archived: false }, "a bare name is wrapped into a batch");
+}
+
+testSetPresetArchivedPostsBatchPayload()
+    .then(() => testPresetLoadFailureClearsAuxiliaryState())
     .then(() => console.log("presets unit tests passed"))
     .catch((error) => {
         console.error(error);

--- a/ui/css/style.css
+++ b/ui/css/style.css
@@ -2558,6 +2558,7 @@ input[type="range"].sampler-range::-moz-range-thumb {
 .presets-filters {
     display: flex;
     flex: none;
+    flex-wrap: wrap;
     align-items: center;
     gap: 6px;
     padding: 9px var(--space-3);
@@ -2575,6 +2576,8 @@ input[type="range"].sampler-range::-moz-range-thumb {
     border: 1px solid var(--border-strong);
     cursor: pointer;
     transition: all var(--ease-fast);
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .preset-chip:hover {
@@ -2837,6 +2840,27 @@ input[type="range"].sampler-range::-moz-range-thumb {
 .preset-row-favorite.active {
     color: var(--favorite);
     background: var(--favorite-subtle);
+}
+
+.preset-row-archive {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: 0;
+    border-radius: var(--radius-xs);
+    background: transparent;
+    color: var(--fg-faint);
+    cursor: pointer;
+}
+
+.preset-row-archive:hover,
+.preset-row-archive:focus-visible {
+    color: var(--accent-text);
+    background: var(--accent-subtle);
 }
 
 .preset-row-warn {

--- a/ui/index.html
+++ b/ui/index.html
@@ -1353,6 +1353,7 @@
                         <button id="preset-filter-all" class="preset-chip active" type="button">All</button>
                         <button id="preset-filter-warnings" class="preset-chip preset-chip-warn" type="button">&#9888; Warnings</button>
                         <button id="preset-favorites-first" class="preset-chip preset-chip-favorite active" type="button" aria-pressed="true" title="Keep favorite presets and model groups above other results">&#9733; Favorites first</button>
+                        <button id="preset-archive-view" class="preset-chip" type="button" aria-pressed="false" title="Show presets hidden from the main list by archiving">&#128230; Archived</button>
                         <span id="presets-count-line" class="presets-count-line"></span>
                     </div>
                     <div id="presets-list" class="presets-browser-list"></div>
@@ -1366,6 +1367,8 @@
                         <button id="btn-presets-unfavorite-selected" class="presets-icon-btn" type="button" title="Remove selected presets from favorites" aria-label="Remove selected presets from favorites">
                             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" aria-hidden="true"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01z"/></svg>
                         </button>
+                        <button id="btn-presets-archive-selected" class="btn btn-sm" type="button" title="Move selected presets to the archive">Archive</button>
+                        <button id="btn-presets-restore-selected" class="btn btn-sm" type="button" title="Restore selected presets from the archive">Restore</button>
                         <button id="btn-presets-export-selected" class="btn btn-sm" type="button" title="Export selected presets as a JSON file">Export</button>
                         <button id="btn-presets-delete-selected" class="btn btn-sm btn-danger" type="button">Delete</button>
                     </div>

--- a/ui/js/presets.js
+++ b/ui/js/presets.js
@@ -352,6 +352,8 @@ let presetSearchQuery = "";
 let presetWarningFilterActive = false;
 let presetSortMode = loadPresetSortMode();
 let presetFavoritesMode = loadPresetFavoritesMode();
+let presetArchiveViewActive = false;
+let presetArchivedCount = 0;
 let currentPresetGroups = [];
 let selectedPresetName = "";
 let selectedPresetNames = new Set();
@@ -629,6 +631,7 @@ function buildPresetGroups(presets) {
             created: typeof preset.created === "number" ? preset.created * 1000 : 0,
             lastUsed: getPresetLastUsed(preset.name),
             favorite: isPresetFavorite(preset.name),
+            archived: preset.archived === true,
         };
         // Built once here, not once per entry per keystroke in the filter below.
         entry.searchText = buildPresetSearchText(entry);
@@ -658,6 +661,7 @@ function buildPresetGroups(presets) {
             .filter((entry) => !query || getPresetSearchText(entry).includes(query))
             .filter((entry) => !presetWarningFilterActive || entry.warnings.length > 0)
             .filter((entry) => presetFavoritesMode !== "only" || entry.favorite)
+            .filter((entry) => (presetArchiveViewActive ? entry.archived : !entry.archived))
             .sort(compareEntries);
         return {
             ...group,
@@ -769,6 +773,8 @@ const PRESET_ICON_CHEVRON = '<svg width="11" height="11" viewBox="0 0 24 24" fil
 const PRESET_ICON_EMPTY = '<svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path d="M20 7h-9"/><path d="M14 17H5"/><circle cx="17" cy="17" r="3"/><circle cx="7" cy="7" r="3"/></svg>';
 const PRESET_ICON_STAR = '<svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01z"/></svg>';
 const PRESET_ICON_STAR_OUTLINE = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" aria-hidden="true"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01z"/></svg>';
+const PRESET_ICON_ARCHIVE = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="4" width="18" height="4" rx="1"/><path d="M5 8v11a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V8"/><path d="M10 12h4"/></svg>';
+const PRESET_ICON_RESTORE = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="4" width="18" height="4" rx="1"/><path d="M5 8v11a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V8"/><path d="M12 16v-5"/><path d="m9.5 13.5 2.5-2.5 2.5 2.5"/></svg>';
 
 function createPresetIcon(svgMarkup) {
     const wrap = document.createElement("span");
@@ -808,7 +814,7 @@ function formatPresetTimestamp(ts) {
 }
 
 function isPresetFilterActive() {
-    return Boolean(presetSearchQuery.trim()) || presetWarningFilterActive || presetFavoritesMode === "only";
+    return Boolean(presetSearchQuery.trim()) || presetWarningFilterActive || presetFavoritesMode === "only" || presetArchiveViewActive;
 }
 
 // Describes the presets currently visible rather than every preset on disk, so
@@ -1017,6 +1023,14 @@ function renderPresetDetailPanel() {
         loadPresets();
     });
     actions.appendChild(favoriteBtn);
+    actions.appendChild(createPresetButton(
+        entry.archived ? "Restore" : "Archive",
+        "btn btn-sm",
+        () => setPresetArchived([entry.name], !entry.archived),
+        entry.archived
+            ? "Restore this preset from the archive back into the main list"
+            : "Move this preset to the archive to clean up the list; it can be restored any time"
+    ));
 
     const spacer = document.createElement("span");
     spacer.className = "preset-detail-actions-spacer";
@@ -1114,9 +1128,31 @@ function renderPresetBulkControls() {
     if (unfavoriteButton) {
         unfavoriteButton.disabled = selectedPresetNames.size === 0;
     }
+    const archiveButton = document.getElementById("btn-presets-archive-selected");
+    if (archiveButton) {
+        archiveButton.disabled = selectedPresetNames.size === 0;
+    }
+    const restoreButton = document.getElementById("btn-presets-restore-selected");
+    if (restoreButton) {
+        restoreButton.disabled = selectedPresetNames.size === 0;
+    }
     if (browser) {
         browser.classList.toggle("has-checked", selectedPresetNames.size > 0);
     }
+}
+
+function renderPresetArchiveChip() {
+    const chip = document.getElementById("preset-archive-view");
+    if (!chip) return;
+    const countText = presetArchivedCount > 0 ? ` (${presetArchivedCount})` : "";
+    chip.textContent = presetArchiveViewActive
+        ? `\uD83D\uDCE6 Viewing archive${countText}`
+        : `\uD83D\uDCE6 Archived${countText}`;
+    chip.title = presetArchiveViewActive
+        ? "Viewing archived presets. Click to return to the main list"
+        : "Show presets hidden from the main list by archiving";
+    chip.classList.toggle("active", presetArchiveViewActive);
+    chip.setAttribute("aria-pressed", String(presetArchiveViewActive));
 }
 
 function renderPresetCountLine() {
@@ -1249,6 +1285,18 @@ function renderPresetEntry(entry) {
         loadPresets();
     });
     el.appendChild(rowFavorite);
+
+    const rowArchive = document.createElement("button");
+    rowArchive.type = "button";
+    rowArchive.className = "preset-row-archive";
+    rowArchive.title = entry.archived ? "Restore from archive" : "Archive preset";
+    rowArchive.setAttribute("aria-label", `${entry.archived ? "Restore" : "Archive"} ${entry.name}`);
+    rowArchive.appendChild(createPresetIcon(entry.archived ? PRESET_ICON_RESTORE : PRESET_ICON_ARCHIVE));
+    rowArchive.addEventListener("click", (event) => {
+        event.stopPropagation();
+        setPresetArchived([entry.name], !entry.archived);
+    });
+    el.appendChild(rowArchive);
 
     el.appendChild(createPresetButton("Load", "btn btn-sm btn-primary preset-row-load", () => loadPreset(entry.name)));
     return el;
@@ -1426,11 +1474,13 @@ function renderPresetGroups(container, groups) {
         empty.className = "presets-empty";
         empty.textContent = presetSearchQuery
             ? "No presets match your search."
-            : presetWarningFilterActive
-                ? "No presets with warnings."
-                : presetFavoritesMode === "only"
-                    ? "No favorite presets yet. Star a preset to keep it here."
-                    : "No saved presets yet. Save the current configuration above or import a JSON preset file.";
+            : presetArchiveViewActive
+                ? "The archive is empty. Archive a preset to move it out of the main list."
+                : presetWarningFilterActive
+                    ? "No presets with warnings."
+                    : presetFavoritesMode === "only"
+                        ? "No favorite presets yet. Star a preset to keep it here."
+                        : "No saved presets yet. Save the current configuration above or import a JSON preset file.";
         container.appendChild(empty);
         renderPresetAuxiliaryPanels();
         return;
@@ -1439,7 +1489,8 @@ function renderPresetGroups(container, groups) {
     // when searching or filtering, force groups open so matches are visible
     const forceExpanded = Boolean(presetSearchQuery.trim())
         || presetWarningFilterActive
-        || presetFavoritesMode === "only";
+        || presetFavoritesMode === "only"
+        || presetArchiveViewActive;
 
     for (const group of groups) {
         const groupEl = document.createElement("section");
@@ -1568,6 +1619,8 @@ async function loadPresets() {
     try {
         const presets = await fetchPresetEntries();
         if (requestId !== loadPresetsRequestId) return;
+        presetArchivedCount = presets.filter((preset) => preset.archived === true).length;
+        renderPresetArchiveChip();
         prunePresetLocalState(new Set(presets.map((preset) => preset.name)));
         currentPresetGroups = buildPresetGroups(presets);
         const visibleEntries = getVisiblePresetEntries();
@@ -1676,6 +1729,26 @@ function initPresetLibraryControls() {
     const exportSelected = document.getElementById("btn-presets-export-selected");
     if (exportSelected) {
         exportSelected.addEventListener("click", exportSelectedPresets);
+    }
+
+    const archiveSelected = document.getElementById("btn-presets-archive-selected");
+    if (archiveSelected) {
+        archiveSelected.addEventListener("click", () => archiveSelectedPresets(true));
+    }
+
+    const restoreSelected = document.getElementById("btn-presets-restore-selected");
+    if (restoreSelected) {
+        restoreSelected.addEventListener("click", () => archiveSelectedPresets(false));
+    }
+
+    const archiveView = document.getElementById("preset-archive-view");
+    if (archiveView) {
+        renderPresetArchiveChip();
+        archiveView.addEventListener("click", () => {
+            presetArchiveViewActive = !presetArchiveViewActive;
+            renderPresetArchiveChip();
+            loadPresets();
+        });
     }
 
     const filterAll = document.getElementById("preset-filter-all");
@@ -1890,6 +1963,45 @@ async function deletePreset(name) {
         showPresetActionStatus("Failed to delete preset", "error", 3200);
         console.warn("Failed to delete preset", e);
     }
+}
+
+async function setPresetArchived(names, archived) {
+    const list = Array.isArray(names) ? names : [names];
+    if (list.length === 0) return;
+    try {
+        await fetchJson("/api/presets/archive", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ names: list, archived }),
+        });
+        for (const name of list) {
+            selectedPresetNames.delete(name);
+        }
+        if (list.includes(selectedPresetName)) {
+            selectedPresetName = "";
+        }
+        await loadPresets();
+        showPresetActionStatus(
+            `${archived ? "Archived" : "Restored"} ${list.length} preset${list.length === 1 ? "" : "s"}`,
+            "success"
+        );
+    } catch (e) {
+        showPresetActionStatus(
+            archived ? "Failed to archive presets" : "Failed to restore presets",
+            "error",
+            3200
+        );
+        console.warn("Failed to update preset archive state", e);
+    }
+}
+
+function archiveSelectedPresets(archived) {
+    const names = Array.from(selectedPresetNames);
+    if (names.length === 0) {
+        showPresetActionStatus("No presets selected", "error", 3200);
+        return;
+    }
+    setPresetArchived(names, archived);
 }
 
 async function favoriteSelectedPresets(favorite) {


### PR DESCRIPTION
- Added preset archiving to the Presets tab: per-row, detail-panel, and bulk Archive/Restore controls move presets out of the main list into a 📦 Archived view without touching their files, so rename, delete, export, and `?preset=` shortcuts keep working. Archive state lives in a `.preset-archived` metadata file beside the presets and is exposed via a new `POST /api/presets/archive` route and an `archived` flag on `GET /api/presets`.