### PR TITLE
Fix finished HF download progress state

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 Please give a brief summary of changes made to the program, include the date the changes were made.
 
+## 2026-08-16
+
+- The Quick Launch Hugging Face progress bar now shows a finished state once a download completes: the bar fills solid green, the animated shimmer stops, and the label switches from "Downloading 100%" to "Download complete". The finished state also renders correctly when the page is reloaded after a completed download.
+
 ## 2026-08-15
 
 - Updated the Speculative Decoding "Draft GPU Layers" control to emit llama.cpp's canonical `--spec-draft-ngl` argument and clarified that it accepts an exact layer count, `auto`, or `all`.

--- a/tests/frontend/hf_download_ui_unit.cjs
+++ b/tests/frontend/hf_download_ui_unit.cjs
@@ -157,6 +157,19 @@ function addElement(elements, id, tagName = "div", value = "") {
     assert.equal(progress.classList.contains("hidden"), false);
     assert.equal(fill.style.width, "50%");
     assert.equal(text.textContent, "model.gguf 50% (1.0 MB / 2.0 MB)");
+
+    // The backend keeps reporting downloaded == total after finishing; the bar
+    // must switch to a finished state instead of sitting at "Downloading 100%".
+    ui.updateProgress({ status: "done", downloaded: 2097152, total: 2097152, current_file: "" });
+    assert.equal(progress.classList.contains("hidden"), false);
+    assert.equal(fill.classList.contains("done"), true);
+    assert.equal(fill.style.width, "100%");
+    assert.equal(text.textContent, "Download complete (2.0 MB)");
+
+    // A new download clears the finished styling again.
+    ui.updateProgress({ status: "downloading", downloaded: 524288, total: 2097152, current_file: "model.gguf" });
+    assert.equal(fill.classList.contains("done"), false);
+    assert.equal(fill.style.width, "25%");
 }
 
 {

--- a/ui/css/style.css
+++ b/ui/css/style.css
@@ -1596,6 +1596,11 @@ input[type="range"].sampler-range::-moz-range-thumb {
 #hf-download-progress { margin: var(--space-3) 0; }
 #hf-progress-text { font-size: 12px; color: var(--fg-muted); margin-top: var(--space-1); display: inline-block; }
 
+/* Finished HF download: solid green fill, shimmer stopped. Scoped to the HF
+   card — the Install tab bar shares .progress-fill and never gains .done. */
+#hf-download-progress .progress-fill.done { background: var(--green); }
+#hf-download-progress .progress-fill.done::after { content: none; }
+
 .quick-launch-status {
     display: none;
     margin-top: var(--space-3);

--- a/ui/js/hf-download-ui.js
+++ b/ui/js/hf-download-ui.js
@@ -59,8 +59,15 @@
         const status = String(prog.status || "");
         const active = ["starting", "downloading", "cancelling"].includes(status);
         wrap.classList.toggle("hidden", !active && status !== "done");
+        // The backend keeps reporting downloaded == total after finishing and
+        // clears current_file — without an explicit done branch the bar sits at
+        // "Downloading 100%" forever (and again on a reload of a finished run).
+        fill.classList.toggle("done", status === "done");
 
-        if (prog.total > 0) {
+        if (status === "done") {
+            fill.style.width = "100%";
+            text.textContent = `Download complete (${formatHfBytes(prog.total)})`;
+        } else if (prog.total > 0) {
             const pct = Math.min(100, Math.round((prog.downloaded / prog.total) * 100));
             fill.style.width = pct + "%";
             text.textContent = `${prog.current_file || "Downloading"} ${pct}% (${formatHfBytes(prog.downloaded)} / ${formatHfBytes(prog.total)})`;


### PR DESCRIPTION
The Quick Launch Hugging Face progress bar now recognizes a completed download even when the backend reports downloaded == total. It switches to a finished state with a solid green 100% fill, stops the shimmer, and shows the label 'Download complete' instead of 'Downloading 100%'. The finished state also persists correctly after a reload, and a new download resets the styling properly.

