### PR TITLE
Page through releases to find compatible backend assets

### DIFF
--- a/backend/routes/install.py
+++ b/backend/routes/install.py
@@ -9,6 +9,10 @@ from ..services import process_manager
 
 
 RELEASE_RESPONSE_LIMIT = 30
+RELEASE_PAGE_SIZE = 100
+# Bound lookback so a renamed or discontinued asset cannot exhaust GitHub's
+# unauthenticated API quota. Three pages covers roughly 300 nightly builds.
+RELEASE_PAGE_LIMIT = 3
 
 
 def _claim_install_slot(ctx):
@@ -29,23 +33,30 @@ def get_releases(request, response, ctx):
             spec = ctx.services.backend_specs.get(backend)
             if spec is not None:
                 repo_api = llama_manager.resolve_repo_api(spec, ctx)
-        releases = llama_manager.get_releases(ctx, repo_api)
         result = []
-        for r in releases:
-            if spec and spec.get("asset"):
-                expected_asset = spec["asset"].format(tag=r["tag_name"])
-                if not any(a.get("name") == expected_asset for a in r["assets"]):
-                    continue
-            result.append(
-                {
-                    "tag": r["tag_name"],
-                    "name": r.get("name", r["tag_name"]),
-                    "published": r["published_at"],
-                    "assets": [a["name"] for a in r["assets"]],
-                }
+        page = 1
+        while page <= RELEASE_PAGE_LIMIT:
+            releases = llama_manager.get_releases(
+                ctx, repo_api, page=page, per_page=RELEASE_PAGE_SIZE
             )
-            if len(result) == RELEASE_RESPONSE_LIMIT:
+            for r in releases:
+                if spec and spec.get("asset"):
+                    expected_asset = spec["asset"].format(tag=r["tag_name"])
+                    if not any(a.get("name") == expected_asset for a in r["assets"]):
+                        continue
+                result.append(
+                    {
+                        "tag": r["tag_name"],
+                        "name": r.get("name", r["tag_name"]),
+                        "published": r["published_at"],
+                        "assets": [a["name"] for a in r["assets"]],
+                    }
+                )
+                if len(result) == RELEASE_RESPONSE_LIMIT:
+                    break
+            if result or len(releases) < RELEASE_PAGE_SIZE:
                 break
+            page += 1
         response.json(result)
     except Exception as e:
         response.error(sanitize_error(e, 500), 500)

--- a/backend/services/llama_manager.py
+++ b/backend/services/llama_manager.py
@@ -13,6 +13,7 @@ import sys
 import tarfile
 import tempfile
 import time
+import urllib.parse
 import urllib.request
 import zipfile
 from typing import Any, Callable, Iterable, Mapping, Optional
@@ -182,8 +183,22 @@ def build_backend_specs(current_platform: str, current_arch: str) -> dict[str, A
     return with_custom({})
 
 
-def get_releases(ctx: AppContext, repo_api: Optional[str] = None) -> list[dict[str, Any]]:
+def get_releases(
+    ctx: AppContext,
+    repo_api: Optional[str] = None,
+    *,
+    page: Optional[int] = None,
+    per_page: Optional[int] = None,
+) -> list[dict[str, Any]]:
     api_url = repo_api or ctx.config.github_api
+    pagination = {
+        key: value
+        for key, value in (("page", page), ("per_page", per_page))
+        if value is not None
+    }
+    if pagination:
+        separator = "&" if "?" in api_url else "?"
+        api_url = f"{api_url}{separator}{urllib.parse.urlencode(pagination)}"
     req = urllib.request.Request(
         api_url,
         headers={"Accept": "application/vnd.github+json"},

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
+## 2026-08-22
+
+- Fixed backend-filtered llama.cpp release discovery stopping at GitHub's first page: the Install version list now checks up to three 100-release pages until it finds compatible assets, so Linux ROCm builds remain selectable after gaps in upstream publishing without exhausting GitHub's API quota when an asset is discontinued.
+
 ## 2026-08-19
 
 - Migrated reasoning effort to llama.cpp's native support (upstream PR #26941, first release b10434). The server-wide Default Reasoning Effort control now emits the native `--reasoning-effort LEVEL` launch flag on builds b10434+, gated by the installed build tag from `/api/status`; the custom backend and older installs keep the previous merged `--chat-template-kwargs` path, and Preserve Thinking returns to its own kwargs object on native builds. Chat requests now send the effort level as top-level `reasoning_effort` (final precedence over the server default on new builds) while keeping the `chat_template_kwargs` fallback for older servers. Added a `GET /api/llama/props` proxy (mirroring the slots proxy) and a Chat sidebar hint when the loaded template reports `chat_template_caps.supports_reasoning_effort: false` — the control stays enabled because the capability is boolean-only. Capability probes retry after transient failures and ignore stale model generations.

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -3995,6 +3995,45 @@ class InstallRouteTests(unittest.TestCase):
 
         self.assertEqual([release["tag"] for release in response.payload], ["b10356"])
 
+    def test_install_get_releases_pages_past_incompatible_release_window(self):
+        self.ctx.services.backend_specs["rocm"] = {
+            "label": "ROCm 7.14 (AMD, Official)",
+            "asset": "llama-{tag}-bin-ubuntu-rocm-7.14-x64.tar.gz",
+        }
+        first_page = [
+            {
+                "tag_name": f"b{i}",
+                "name": f"b{i}",
+                "published_at": "2026-08-22T00:00:00Z",
+                "assets": [{"name": f"llama-b{i}-bin-win-rocm-7.14-x64.zip"}],
+            }
+            for i in range(100)
+        ]
+        compatible = {
+            "tag_name": "b10375",
+            "name": "b10375",
+            "published_at": "2026-08-12T12:18:24Z",
+            "assets": [
+                {"name": "llama-b10375-bin-ubuntu-rocm-7.14-x64.tar.gz"}
+            ],
+        }
+        response = DummyResponse()
+        with mock.patch.object(
+            llama_manager, "get_releases", side_effect=[first_page, [compatible]]
+        ) as get_releases:
+            install.get_releases(
+                Request("GET", "/api/releases", "backend=rocm", {}), response, self.ctx
+            )
+
+        self.assertEqual([release["tag"] for release in response.payload], ["b10375"])
+        self.assertEqual(
+            get_releases.call_args_list,
+            [
+                mock.call(self.ctx, self.ctx.config.github_api, page=1, per_page=100),
+                mock.call(self.ctx, self.ctx.config.github_api, page=2, per_page=100),
+            ],
+        )
+
     def test_install_get_releases_error_returns_500(self):
         response = DummyResponse()
         with mock.patch.object(
@@ -4320,7 +4359,12 @@ class InstallRouteTests(unittest.TestCase):
                 self.ctx,
             )
         self.assertEqual(response.status, 200)
-        gr.assert_called_once_with(self.ctx, llama_manager.LEMONADE_ROCM_REPO_API)
+        gr.assert_called_once_with(
+            self.ctx,
+            llama_manager.LEMONADE_ROCM_REPO_API,
+            page=1,
+            per_page=100,
+        )
 
     def test_get_releases_without_backend_param_uses_default(self):
         response = DummyResponse()
@@ -4330,7 +4374,7 @@ class InstallRouteTests(unittest.TestCase):
                 response,
                 self.ctx,
             )
-        gr.assert_called_once_with(self.ctx, None)
+        gr.assert_called_once_with(self.ctx, None, page=1, per_page=100)
 
     def test_get_releases_ignores_unknown_backend(self):
         response = DummyResponse()
@@ -4340,7 +4384,7 @@ class InstallRouteTests(unittest.TestCase):
                 response,
                 self.ctx,
             )
-        gr.assert_called_once_with(self.ctx, None)
+        gr.assert_called_once_with(self.ctx, None, page=1, per_page=100)
 
     def test_get_releases_returns_empty_for_custom_backend(self):
         response = DummyResponse()

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -634,7 +634,6 @@ class ResolveRepoApiTests(unittest.TestCase):
                 llama_manager.resolve_repo_api(spec, ctx), ctx.config.github_api
             )
 
-
 class NormalizeArchTests(unittest.TestCase):
     def test_amd64_maps_to_x64(self):
         from backend.app import normalize_arch
@@ -1684,7 +1683,7 @@ class LlamaManagerDownloadTests(unittest.TestCase):
             )
             ctx.services.save_config.assert_called_once()
 
-    def test_get_releases_uses_repo_api_when_provided(self):
+    def test_get_releases_uses_repo_api_and_pagination_when_provided(self):
         with tempfile.TemporaryDirectory() as tmp:
             ctx = make_service_context(tmp)
             payload = json.dumps([{"tag_name": "b1294", "assets": []}]).encode()
@@ -1693,12 +1692,17 @@ class LlamaManagerDownloadTests(unittest.TestCase):
             )
 
             result = llama_manager.get_releases(
-                ctx, llama_manager.LEMONADE_ROCM_REPO_API
+                ctx,
+                llama_manager.LEMONADE_ROCM_REPO_API + "?channel=nightly",
+                page=2,
+                per_page=100,
             )
 
             request = ctx.services.urlopen_with_ssl.call_args.args[0]
             self.assertEqual(
-                request.full_url, llama_manager.LEMONADE_ROCM_REPO_API
+                request.full_url,
+                llama_manager.LEMONADE_ROCM_REPO_API
+                + "?channel=nightly&page=2&per_page=100",
             )
             self.assertEqual(result[0]["tag_name"], "b1294")
 


### PR DESCRIPTION
- Fixed backend-filtered llama.cpp release discovery stopping at GitHub's first page: the Install version list now checks up to three 100-release pages until it finds compatible assets, so Linux ROCm builds remain selectable after gaps in upstream publishing without exhausting GitHub's API quota when an asset is discontinued.
