### PR TITLE
Add experimental adaptive speculative draft sizing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
+## 2026-08-25
+
+- Added an Experimental Configure accordion below Advanced with an off-by-default Adaptive Draft Size checkbox that emits the fork-only `--spec-draft-adaptive` flag.
+
 ## 2026-08-22
 
 - Added an independent Ngram Map K4V speculative-decoding submenu with lookup size, draft size, and minimum-hit controls; it stacks with draft and Ngram Mod modes through one shared `--spec-type`, shows llama.cpp defaults in each description, and migrates legacy presets.

--- a/docs/upstream-changes.md
+++ b/docs/upstream-changes.md
@@ -11,6 +11,13 @@ Track announced llama.cpp changes that may require coordinated Llama-GUI updates
 - **Remaining:** the dual paths stay until the supported binary floor makes them dead code — the legacy merged-kwargs launch path (`flag-core.js`) and the nested `chat_template_kwargs` copy in Chat requests (`chat-ui.js` `getChatThinkingParams`) can then be removed in one sweep.
 - **Upstream caution:** [ggml-org/llama.cpp#27023](https://github.com/ggml-org/llama.cpp/issues/27023) remains open and reports Low/High having no effect on some models in an earlier build. Smoke-test levels visibly before treating them as verified on a given model.
 
+### Fork-only acceptance-based draft sizing (`--spec-draft-adaptive`)
+
+- **Implementation:** [LaurentZuijdwijk/llama.cpp `common/arg.cpp`](https://github.com/LaurentZuijdwijk/llama.cpp/blob/master/common/arg.cpp#L3999-L4005).
+- **Status:** Implemented in that fork but absent from upstream `ggml-org/llama.cpp` as of 2026-08-25. It is a default-off boolean available to `llama-speculative`, `llama-server`, and `llama-cli`, with env `LLAMA_ARG_SPEC_DRAFT_ADAPTIVE`.
+- **Behavior:** Sizes each draft from measured acceptance instead of always drafting the `--spec-draft-n-max` token count. This is separate from the open upstream adaptive-MTP proposal tracked below.
+- **Local handling:** Llama-GUI exposes the checkbox in the temporary **Experimental** Configure category. When this exact feature merges upstream, re-verify its spelling and semantics, then move the control into **Speculative Decoding**.
+
 ### Adaptive MTP draft depth (`draft-mtp-adaptive`)
 
 - **Upstream:** [ggml-org/llama.cpp#27210](https://github.com/ggml-org/llama.cpp/pull/27210) (branch `stew675:adaptive-mtp`, 3 commits, head `77cd0e8`). The range `08ae079..77cd0e8` linked in tracking is the final commit: it gates the adaptive range validation on adaptive mode so plain `draft-mtp` no longer aborts when the effective `n_max` is below the default floor of 3 (e.g. `--spec-draft-n-max 2`), and improves the abort message when `n_max` was capped by the model's MTP layer count.
@@ -42,4 +49,4 @@ Track announced llama.cpp changes that may require coordinated Llama-GUI updates
 - **Recheck when:** Upstream changes the actual default or a bundled llama.cpp release includes that change.
 - **Local decision:** Either keep Llama-GUI's explicit 8080 default or change the frontend, backend target fallback, external-server form, tests, and documentation to 9931 together.
 
-Last checked: 2026-08-19.
+Last checked: 2026-08-25.

--- a/tests/frontend/flag_definitions_unit.cjs
+++ b/tests/frontend/flag_definitions_unit.cjs
@@ -239,6 +239,9 @@ assert.deepEqual(validateFlags(current.flags, current.categories), {
     ],
 });
 
+const advancedCategoryIndex = current.categories.findIndex((category) => category.id === "advanced");
+assert.equal(current.categories[advancedCategoryIndex + 1].id, "experimental");
+
 {
     const jinja = current.flags.find((flag) => flag.id === "jinja");
     assert.equal(jinja.default, true);

--- a/tests/frontend/launch_args_unit.cjs
+++ b/tests/frontend/launch_args_unit.cjs
@@ -57,6 +57,16 @@ function launchResult() {
 }
 
 {
+    assert.ok(!flatLaunchArgs().includes("--spec-draft-adaptive"));
+    vm.runInContext(
+        'window.LlamaGui.flagCore.setFlagValue("spec_draft_adaptive", true)',
+        context
+    );
+    assert.ok(flatLaunchArgs().includes("--spec-draft-adaptive"));
+    vm.runInContext("window.LlamaGui.flagCore.replaceFlagValues(getDefaultValues())", context);
+}
+
+{
     const recognizedModelArgs = [
         [["-m", "models/local.gguf"]],
         [["--model", "models/local.gguf"]],

--- a/ui/js/flags/categories.js
+++ b/ui/js/flags/categories.js
@@ -36,4 +36,5 @@ const FLAG_CATEGORIES = [
 	{ id: "grammar", name: "Grammar & Constraints", icon: "📝" },
 	{ id: "logging", name: "Logging", icon: "📋" },
 	{ id: "advanced", name: "Advanced", icon: "🔧" },
+	{ id: "experimental", name: "Experimental", icon: "🧪" },
 ];

--- a/ui/js/flags/definitions.js
+++ b/ui/js/flags/definitions.js
@@ -1926,4 +1926,16 @@ const FLAGS = [
 		tool: "both",
 		default: false,
 	},
+
+	// Experimental
+	{
+		id: "spec_draft_adaptive",
+		flag: "--spec-draft-adaptive",
+		category: "experimental",
+		type: "bool",
+		label: "Adaptive Draft Size",
+		desc: "Size each speculative draft from measured acceptance instead of always drafting --spec-draft-n-max tokens. Available in the LaurentZuijdwijk llama.cpp fork; upstream builds may reject this flag.",
+		tool: "both",
+		default: false,
+	},
 ];


### PR DESCRIPTION
## Summary

- Add an off-by-default Experimental Configure option for fork-only `--spec-draft-adaptive`.
- Ensure the flag is emitted through shared launch argument state.
- Document fork compatibility and upstream tracking.
- Add changelog and frontend coverage for category placement and launch arguments.

## Testing

- Added frontend unit coverage for flag definitions and launch argument generation.
- Not run (not requested).