### PR TITLE
Add multimodal projector device and experimental adaptive draft controls

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ Please give a brief summary of changes made to the program (excluding documentat
 ## 2026-08-25
 
 - Added an Experimental Configure accordion below Advanced with an off-by-default Adaptive Draft Size checkbox that emits the fork-only `--spec-draft-adaptive` flag.
+- Added a Multimodal Projector Device control directly below `-mm` in Model; it emits the new `--mmproj-device DEVICE` argument introduced in llama.cpp b10541 and included in v0.2.0.
 
 ## 2026-08-22
 

--- a/tests/frontend/flag_definitions_unit.cjs
+++ b/tests/frontend/flag_definitions_unit.cjs
@@ -242,6 +242,9 @@ assert.deepEqual(validateFlags(current.flags, current.categories), {
 const advancedCategoryIndex = current.categories.findIndex((category) => category.id === "advanced");
 assert.equal(current.categories[advancedCategoryIndex + 1].id, "experimental");
 
+const mmprojFlagIndex = current.flags.findIndex((flag) => flag.id === "mmproj");
+assert.equal(current.flags[mmprojFlagIndex + 1].id, "mmproj_device");
+
 {
     const jinja = current.flags.find((flag) => flag.id === "jinja");
     assert.equal(jinja.default, true);

--- a/tests/frontend/launch_args_unit.cjs
+++ b/tests/frontend/launch_args_unit.cjs
@@ -67,6 +67,17 @@ function launchResult() {
 }
 
 {
+    vm.runInContext(
+        'window.LlamaGui.flagCore.setFlagValue("mmproj_device", "Vulkan0")',
+        context
+    );
+    const args = flatLaunchArgs();
+    const flagIndex = args.indexOf("--mmproj-device");
+    assert.equal(args[flagIndex + 1], "Vulkan0");
+    vm.runInContext("window.LlamaGui.flagCore.replaceFlagValues(getDefaultValues())", context);
+}
+
+{
     const recognizedModelArgs = [
         [["-m", "models/local.gguf"]],
         [["--model", "models/local.gguf"]],

--- a/ui/js/flags/definitions.js
+++ b/ui/js/flags/definitions.js
@@ -56,6 +56,17 @@ const FLAGS = [
 		tool: "both",
 	},
 	{
+		id: "mmproj_device",
+		flag: "--mmproj-device",
+		category: "model",
+		type: "text",
+		label: "Multimodal Projector Device",
+		short_desc: "Choose which backend device runs the multimodal projector.",
+		desc: "Select one backend device for the multimodal projector, such as an iGPU while the main model stays on a dGPU. Use a name from --list-devices; only one device is accepted, and none disables projector offload. Short alias: -mmdev. Available in llama.cpp b10541 and v0.2.0+.",
+		tool: "both",
+		placeholder: "auto; none = don't offload",
+	},
+	{
 		id: "mmproj_url",
 		flag: "--mmproj-url",
 		category: "model",


### PR DESCRIPTION
## Summary

- Add `--mmproj-device` support for selecting the multimodal projector device.
- Update upstream tracking and changelog documentation.
- Add flag ordering and launch-argument coverage.

## Testing

- Added frontend unit coverage for flag definitions and generated launch arguments.