### PR TITLE
Preserve and reactivate official backends alongside custom installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,9 +256,9 @@ Quick Launch, Configure, and Chat samplers share one state. Loading a full app p
 
 ### Custom pre-compiled binaries
 
-1. Put binaries (and needed `.dll` / `.so` / `.dylib`) in `llama/custom/bin/` (`llama-server`, `llama-cli`, optionally `llama-bench`, `llama-perplexity`, etc.). The directory is created if you click **Activate Custom**.
+1. Put binaries (and needed `.dll` / `.so` / `.dylib`) in `llama/custom/bin/` (`llama-server`, `llama-cli`, optionally `llama-bench`, `llama-perplexity`, etc.). Fresh installs create this directory automatically; **Activate Custom** also creates it if needed.
 2. In **Install**, choose **Custom (User-Provided)** → **Activate Custom**.
-3. Switch back by installing any official backend.
+3. Switch back by selecting the preserved official backend and clicking **Activate Existing**; no download is required.
 
 `llama/custom/` is preserved when removing official llama.cpp files.
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -17,6 +17,7 @@ from backend.config import (
     GUI_PORT,
     LLAMA_BIN_DIR,
     LLAMA_CUSTOM_BIN_DIR,
+    LLAMA_CUSTOM_GRAMMARS_DIR,
     LLAMA_GRAMMARS_DIR,
     LLAMA_HOST,
     LLAMA_PORT,
@@ -978,6 +979,8 @@ def main():
         PRESETS_DIR,
         LLAMA_BIN_DIR,
         LLAMA_GRAMMARS_DIR,
+        LLAMA_CUSTOM_BIN_DIR,
+        LLAMA_CUSTOM_GRAMMARS_DIR,
     ]:
         d.mkdir(parents=True, exist_ok=True)
 

--- a/backend/routes/install.py
+++ b/backend/routes/install.py
@@ -1,5 +1,6 @@
 """Routes for llama.cpp install/update management."""
 
+import sys
 import threading
 import urllib.parse
 
@@ -70,7 +71,8 @@ def start_install(request, response, ctx):
     body = request.body or {}
     tag = body.get("tag")
     backend = body.get("backend")
-    if not tag or not backend:
+    activate_existing = body.get("activate_existing") is True
+    if not backend or (not activate_existing and not tag):
         response.error("tag and backend required", 400)
         return
     if backend == "custom":
@@ -82,6 +84,22 @@ def start_install(request, response, ctx):
     claim_error = _claim_install_slot(ctx)
     if claim_error is not None:
         response.error(*claim_error)
+        return
+
+    if activate_existing:
+        try:
+            result = llama_manager.activate_official_backend(ctx, backend)
+            if result.get("ok"):
+                response.json(result)
+            else:
+                response.error(
+                    result.get("error") or "Could not activate existing backend", 400
+                )
+        except Exception as exc:
+            print(f"[install] activate existing backend failed: {exc}", file=sys.stderr)
+            response.error(sanitize_error(exc, 500), 500)
+        finally:
+            process_manager.release_install_slot(ctx)
         return
 
     def _install(tag, backend):

--- a/backend/routes/status.py
+++ b/backend/routes/status.py
@@ -6,6 +6,7 @@ import sys
 from ..http import sanitize_error
 from ..config import LLAMA_HOST, LLAMA_PORT
 from ..services import external_server
+from ..services import llama_manager
 from ..services import model_dir
 from ..services import process_manager
 
@@ -34,6 +35,7 @@ def get_status(request, response, ctx):
         process_status = process_manager.get_process_status_snapshot(ctx)
         model_dir_info = model_dir.get_models_dir_info(ctx)
         backend_specs = services.backend_specs
+        official_install = llama_manager.get_official_install_status(ctx, cfg)
         try:
             api_target = dict(services.get_llama_api_target())
         except Exception as exc:
@@ -46,6 +48,7 @@ def get_status(request, response, ctx):
                 "config_stale": config_stale,
                 "version": cfg.get("tag"),
                 "backend": cfg.get("backend"),
+                "official_install": official_install,
                 "executables": exes,
                 "runtime_files": [path.name for path in runtime_files],
                 "runtime_files_label": "Runtime libraries",

--- a/backend/services/llama_manager.py
+++ b/backend/services/llama_manager.py
@@ -510,6 +510,12 @@ def activate_custom_backend(ctx: AppContext) -> dict[str, Any]:
 
         with ctx.state.config_lock:
             cfg = dict(ctx.services.load_config())
+            if cfg.get("backend") and cfg.get("backend") != "custom" and cfg.get("tag"):
+                cfg["official_install"] = {
+                    "backend": cfg["backend"],
+                    "tag": cfg["tag"],
+                    "version": cfg.get("version") or cfg["tag"],
+                }
             cfg["version"] = "custom"
             cfg["backend"] = "custom"
             cfg["tag"] = "custom"
@@ -526,6 +532,100 @@ def activate_custom_backend(ctx: AppContext) -> dict[str, Any]:
     except Exception as e:
         print(f"[llama_manager] activate_custom_backend failed: {e}", file=sys.stderr)
         return {"ok": False, "error": str(e)}
+
+
+def get_official_install_status(
+    ctx: AppContext, cfg: Optional[Mapping[str, Any]] = None
+) -> dict[str, Any]:
+    cfg = cfg or ctx.services.load_config()
+    stored = cfg.get("official_install")
+    stored = stored if isinstance(stored, Mapping) else {}
+
+    backend = stored.get("backend")
+    tag = stored.get("tag")
+    version = stored.get("version")
+    if cfg.get("backend") and cfg.get("backend") != "custom" and cfg.get("tag"):
+        backend = cfg.get("backend")
+        tag = cfg.get("tag")
+        version = cfg.get("version") or tag
+
+    current_platform = ctx.services.current_platform or sys.platform
+    if current_platform == "unknown":
+        current_platform = sys.platform
+    files_present = all(
+        (ctx.paths.llama_bin / ctx.services.get_tool_filename(tool)).is_file()
+        and (
+            current_platform == "win32"
+            or os.access(
+                ctx.paths.llama_bin / ctx.services.get_tool_filename(tool), os.X_OK
+            )
+        )
+        for tool in ("llama-cli", "llama-server")
+    )
+    return {
+        "backend": str(backend).strip() if backend else None,
+        "tag": str(tag).strip() if tag else None,
+        "version": str(version).strip() if version else None,
+        "files_present": files_present,
+    }
+
+
+def _probe_official_build(ctx: AppContext) -> tuple[bool, Optional[str]]:
+    executable = ctx.paths.llama_bin / ctx.services.get_tool_filename("llama-cli")
+    try:
+        result = subprocess.run(
+            [str(executable), "--version"],
+            cwd=ctx.paths.llama_bin,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False, None
+    if result.returncode != 0:
+        return False, None
+    match = re.search(r"\bbuild\s+(\d+)\b", result.stdout + "\n" + result.stderr, re.I)
+    return True, f"b{match.group(1)}" if match else None
+
+
+def activate_official_backend(ctx: AppContext, backend: str) -> dict[str, Any]:
+    cfg = dict(ctx.services.load_config())
+    official = get_official_install_status(ctx, cfg)
+    if not official["files_present"]:
+        return {
+            "ok": False,
+            "error": "Existing official llama.cpp files were not found.",
+        }
+    if official["backend"] and official["backend"] != backend:
+        return {
+            "ok": False,
+            "error": f"The existing official installation is {official['backend']}, not {backend}.",
+        }
+
+    runtime_ok, detected_tag = _probe_official_build(ctx)
+    if not runtime_ok:
+        return {
+            "ok": False,
+            "error": "The existing official llama.cpp runtime could not be started.",
+        }
+
+    tag = official["tag"] or detected_tag
+    if not tag:
+        return {
+            "ok": False,
+            "error": "Could not determine the version of the existing official installation.",
+        }
+
+    version = official["version"] or tag
+    record = {"backend": backend, "tag": tag, "version": version}
+    with ctx.state.config_lock:
+        cfg = dict(ctx.services.load_config())
+        cfg.update({"backend": backend, "tag": tag, "version": version})
+        cfg["official_install"] = record
+        ctx.services.save_config(cfg)
+    ctx.state.clear_runtime_health_cache()
+    return {"ok": True, **record}
 
 
 def _validate_custom_runtime_dependencies(
@@ -958,8 +1058,18 @@ def install_release(
 
         with ctx.state.config_lock:
             config_data = dict(ctx.services.load_config())
+            version = release.get("name", tag)
             config_data.update(
-                {"version": release.get("name", tag), "backend": backend, "tag": tag}
+                {
+                    "version": version,
+                    "backend": backend,
+                    "tag": tag,
+                    "official_install": {
+                        "backend": backend,
+                        "tag": tag,
+                        "version": version,
+                    },
+                }
             )
             ctx.services.save_config(config_data)
         ctx.state.clear_runtime_health_cache()

--- a/backend/services/process_manager.py
+++ b/backend/services/process_manager.py
@@ -1487,6 +1487,7 @@ def remove_llama_files(ctx: AppContext) -> int:
     with ctx.state.config_lock:
         config_data = _load_config_safe(ctx)
         config_data.update({"version": None, "backend": None, "tag": None})
+        config_data.pop("official_install", None)
         ctx.services.save_config(config_data)
     ctx.state.clear_runtime_health_cache()
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,8 @@
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
 ## 2026-08-25
-
+- Preserved one downloaded official backend alongside a custom backend, allowing the Install tab to reactivate its existing `llama/bin` files without downloading them again; activation verifies that `llama-cli` can start, and legacy custom configurations recover its installed build tag from `--version`.
+- Fresh installs now create `llama/custom/bin` and `llama/custom/grammars` automatically.
 - Added an Experimental Configure accordion below Advanced with an off-by-default Adaptive Draft Size checkbox that emits the fork-only `--spec-draft-adaptive` flag.
 - Added a Multimodal Projector Device control directly below `-mm` in Model; it emits the new `--mmproj-device DEVICE` argument introduced in llama.cpp b10541 and included in v0.2.0.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,21 @@
+# TODO
+
+## Investigate the `llama-cli` conversation flag
+
+- The Configure tab defines **Conversation Mode** as the CLI-only `-cnv` flag.
+- It is visible only after selecting **llama-cli (Interactive Chat)** and expanding **Conversation & Chat**, so it is easy to overlook during normal `llama-server` use.
+- The installed llama.cpp build `b10630` advertises neither `-cnv` nor `--conversation` and rejects both as invalid arguments.
+
+### Upstream context
+
+- On December 10, 2025, [llama.cpp PR #17824](https://github.com/ggml-org/llama.cpp/pull/17824) replaced the old completion-oriented `llama-cli` with a server-backed chat CLI and renamed the old implementation `llama-completion`.
+- Current `llama-cli` enters an interactive chat loop unconditionally in [`tools/cli/cli-context.cpp`](https://github.com/ggml-org/llama.cpp/blob/master/tools/cli/cli-context.cpp) and sends requests through `/v1/chat/completions`; it has no raw-completion mode.
+- `-cnv` and `-no-cnv` remain argument options for `llama-completion`, where they control `COMMON_CONVERSATION_MODE`, but are registered for `LLAMA_EXAMPLE_COMPLETION` rather than `LLAMA_EXAMPLE_CLI`.
+- Current `llama-cli` supports `-st` / `--single-turn`, which exits after one chat response. This is not equivalent to disabling conversation formatting.
+- Upstream documentation is inconsistent: [`tools/cli/README.md`](https://github.com/ggml-org/llama.cpp/blob/master/tools/cli/README.md) still documents `-cnv` and `-no-cnv`, while [issue #27214](https://github.com/ggml-org/llama.cpp/issues/27214) reports that `-no-cnv` can be accepted without changing behavior, leaving scripted callers waiting at the chat prompt.
+
+### Later decision
+
+- Remove **Conversation Mode** from current `llama-cli`, or gate it to pre-PR-#17824 builds if those builds must remain supported.
+- If Llama GUI later adds `llama-completion` as a tool, expose `-cnv` / `-no-cnv` there instead.
+- Keep `-st` as the supported current `llama-cli` control for a single-response session.

--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,8 @@ echo "Upgrading pip..."
 echo "Installing Python dependencies from requirements.txt..."
 "$VENV_PYTHON" -m pip install -r requirements.txt
 
+mkdir -p llama/custom/bin llama/custom/grammars
+
 echo
 echo "Install complete."
 echo "Start the app with ./mac_linux_start.sh or ./mac_linux_silent_start.sh"

--- a/release.ps1
+++ b/release.ps1
@@ -85,6 +85,8 @@ foreach ($item in $items) {
 
 $placeholderDirs = @(
     "llama\bin",
+    "llama\custom\bin",
+    "llama\custom\grammars",
     "llama\dll",
     "llama\grammars",
     "models",

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -1828,7 +1828,12 @@ class ExtractedRouteTests(unittest.TestCase):
                 "api_key_required": False,
             }
             ctx.services.load_config = lambda: {
-                "external_chat_target": remembered_target
+                "external_chat_target": remembered_target,
+                "official_install": {
+                    "backend": "cpu",
+                    "tag": "b1",
+                    "version": "b1",
+                },
             }
             saved = []
             ctx.services.save_config = saved.append
@@ -3950,6 +3955,40 @@ class InstallRouteTests(unittest.TestCase):
         self.assertEqual(response.status, 200)
         self.assertEqual(len(response.payload), 1)
         self.assertEqual(response.payload[0]["tag"], "b1")
+
+    def test_install_can_activate_existing_backend_without_starting_download(self):
+        response = DummyResponse()
+        activated = {
+            "ok": True,
+            "backend": "cpu",
+            "tag": "b1",
+            "version": "b1",
+        }
+        with (
+            mock.patch.object(
+                llama_manager, "activate_official_backend", return_value=activated
+            ) as activate,
+            mock.patch.object(install.threading, "Thread") as thread,
+            mock.patch.object(llama_manager, "install_release") as download,
+        ):
+            install.start_install(
+                Request(
+                    "POST",
+                    "/api/install",
+                    "",
+                    {},
+                    body={"backend": "cpu", "activate_existing": True},
+                ),
+                response,
+                self.ctx,
+            )
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.payload, activated)
+        activate.assert_called_once_with(self.ctx, "cpu")
+        thread.assert_not_called()
+        download.assert_not_called()
+        self.assertFalse(self.ctx.state.install_in_progress)
 
     def test_install_get_releases_caps_response_at_thirty(self):
         fake_releases = [

--- a/tests/backend/test_server_baseline.py
+++ b/tests/backend/test_server_baseline.py
@@ -788,6 +788,19 @@ class ReleaseManifestTests(unittest.TestCase):
         self.assertIn("assets", shortcut_script)
         self.assertIn("assets", items, "create_windows_shortcuts.ps1 reads assets\\Llama-GUI.ico")
 
+    def test_fresh_installs_create_custom_backend_directories(self):
+        root, _items = self._release_items()
+        windows_installer = (root / "windows_install.bat").read_text(
+            encoding="utf-8", errors="replace"
+        )
+        unix_installer = (root / "install.sh").read_text(encoding="utf-8")
+        release_script = (root / "release.ps1").read_text(encoding="utf-8")
+
+        for directory in ("llama\\custom\\bin", "llama\\custom\\grammars"):
+            self.assertIn(directory, windows_installer)
+            self.assertIn(f'"{directory}"', release_script)
+        self.assertIn("mkdir -p llama/custom/bin llama/custom/grammars", unix_installer)
+
 
 class ImportSmokeTests(unittest.TestCase):
     def test_server_py_is_compatibility_entrypoint(self):

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -539,6 +539,137 @@ class ActivateCustomBackendTests(unittest.TestCase):
                 {"tag": "custom", "backend": "custom", "version": "custom"}
             )
 
+    def test_preserves_official_install_when_custom_is_activated(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            ctx.services.llama_tools = ["llama-cli", "llama-server"]
+            ctx.services.current_platform = "win32"
+            ctx.services.get_tool_filename = lambda tool: f"{tool}.exe"
+            ctx.services.load_config = lambda: {
+                "tag": "b10502",
+                "backend": "vulkan",
+                "version": "Build 10502",
+            }
+            ctx.services.save_config = mock.Mock()
+            ctx.paths.llama_custom_bin.mkdir(parents=True)
+            for tool in ("llama-cli", "llama-server"):
+                (ctx.paths.llama_custom_bin / f"{tool}.exe").write_text("")
+
+            result = llama_manager.activate_custom_backend(ctx)
+
+            self.assertTrue(result["ok"])
+            ctx.services.save_config.assert_called_once_with(
+                {
+                    "tag": "custom",
+                    "backend": "custom",
+                    "version": "custom",
+                    "official_install": {
+                        "backend": "vulkan",
+                        "tag": "b10502",
+                        "version": "Build 10502",
+                    },
+                }
+            )
+
+    def test_activates_preserved_official_install_without_downloading(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            ctx.services.current_platform = "win32"
+            ctx.services.get_tool_filename = lambda tool: f"{tool}.exe"
+            store = {
+                "backend": "custom",
+                "tag": "custom",
+                "version": "custom",
+                "official_install": {
+                    "backend": "vulkan",
+                    "tag": "b10502",
+                    "version": "Build 10502",
+                },
+            }
+            ctx.services.load_config = lambda: dict(store)
+            ctx.services.save_config = lambda cfg: (store.clear(), store.update(cfg))
+            ctx.paths.llama_bin.mkdir(parents=True)
+            for tool in ("llama-cli", "llama-server"):
+                (ctx.paths.llama_bin / f"{tool}.exe").write_text("")
+
+            completed = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="version: 0.1.2-dev (build 10502, commit abc)",
+                stderr="",
+            )
+            with mock.patch.object(llama_manager.subprocess, "run", return_value=completed):
+                result = llama_manager.activate_official_backend(ctx, "vulkan")
+
+            self.assertEqual(
+                result,
+                {
+                    "ok": True,
+                    "backend": "vulkan",
+                    "tag": "b10502",
+                    "version": "Build 10502",
+                },
+            )
+            self.assertEqual(store["backend"], "vulkan")
+            self.assertEqual(store["tag"], "b10502")
+
+    def test_rejects_preserved_official_install_when_binary_cannot_start(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            ctx.services.current_platform = "win32"
+            ctx.services.get_tool_filename = lambda tool: f"{tool}.exe"
+            store = {
+                "backend": "custom",
+                "tag": "custom",
+                "version": "custom",
+                "official_install": {
+                    "backend": "vulkan",
+                    "tag": "b10502",
+                    "version": "Build 10502",
+                },
+            }
+            ctx.services.load_config = lambda: dict(store)
+            ctx.services.save_config = mock.Mock()
+            ctx.paths.llama_bin.mkdir(parents=True)
+            for tool in ("llama-cli", "llama-server"):
+                (ctx.paths.llama_bin / f"{tool}.exe").write_text("")
+
+            completed = subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="missing runtime library"
+            )
+            with mock.patch.object(llama_manager.subprocess, "run", return_value=completed):
+                result = llama_manager.activate_official_backend(ctx, "vulkan")
+
+            self.assertFalse(result["ok"])
+            self.assertIn("could not be started", result["error"])
+            ctx.services.save_config.assert_not_called()
+            self.assertEqual(store["backend"], "custom")
+
+    def test_legacy_official_install_recovers_tag_from_binary_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            ctx.services.current_platform = "win32"
+            ctx.services.get_tool_filename = lambda tool: f"{tool}.exe"
+            store = {"backend": "custom", "tag": "custom", "version": "custom"}
+            ctx.services.load_config = lambda: dict(store)
+            ctx.services.save_config = lambda cfg: (store.clear(), store.update(cfg))
+            ctx.paths.llama_bin.mkdir(parents=True)
+            for tool in ("llama-cli", "llama-server"):
+                (ctx.paths.llama_bin / f"{tool}.exe").write_text("")
+
+            completed = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="version: 0.1.2-dev (build 10502, commit abc)",
+                stderr="",
+            )
+            with mock.patch.object(llama_manager.subprocess, "run", return_value=completed):
+                result = llama_manager.activate_official_backend(ctx, "vulkan")
+
+            self.assertTrue(result["ok"])
+            self.assertEqual(result["tag"], "b10502")
+            self.assertEqual(store["official_install"]["backend"], "vulkan")
+
     def test_rejects_non_executable_core_tools_on_unix(self):
         with tempfile.TemporaryDirectory() as tmp:
             ctx = make_service_context(tmp)
@@ -1366,6 +1497,11 @@ class LlamaManagerDownloadTests(unittest.TestCase):
                         "version": "Build 1234",
                         "backend": "cpu",
                         "tag": "b1234",
+                        "official_install": {
+                            "backend": "cpu",
+                            "tag": "b1234",
+                            "version": "Build 1234",
+                        },
                     }
                 ],
             )
@@ -2011,7 +2147,18 @@ class LlamaManagerDownloadTests(unittest.TestCase):
             )
             self.assertEqual(
                 saved_configs,
-                [{"version": "b1294", "backend": "lemonade-rocm-gfx110X", "tag": "b1294"}],
+                [
+                    {
+                        "version": "b1294",
+                        "backend": "lemonade-rocm-gfx110X",
+                        "tag": "b1294",
+                        "official_install": {
+                            "backend": "lemonade-rocm-gfx110X",
+                            "tag": "b1294",
+                            "version": "b1294",
+                        },
+                    }
+                ],
             )
             self.assertEqual(ctx.state.download_progress.snapshot()["status"], "done")
             self.assertIn("SHA256 digest metadata is missing", stderr.getvalue())

--- a/tests/frontend/manager_releases_unit.cjs
+++ b/tests/frontend/manager_releases_unit.cjs
@@ -197,6 +197,12 @@ vm.runInContext(source, context, { filename: "ui/js/manager.js" });
             "llama-cli": true,
             "llama-server": true,
         },
+        official_install: {
+            backend: "vulkan",
+            tag: "b10502",
+            version: "b10502",
+            files_present: true,
+        },
     };
     context.updateStatusUI(customStatus);
     assert.equal(backendSelect.value, "custom");
@@ -214,7 +220,9 @@ vm.runInContext(source, context, { filename: "ui/js/manager.js" });
         "vulkan",
         "pending install backend should survive status refresh while installed backend is still custom"
     );
-    assert.equal(elements.get("btn-install").textContent, "Install");
+    assert.equal(elements.get("btn-install").textContent, "Activate Existing");
+    assert.equal(context.canActivateOfficialBackend(customStatus, "vulkan"), true);
+    assert.equal(context.canActivateOfficialBackend(customStatus, "cpu"), false);
     assert.equal(
         elements.get("btn-update").disabled,
         true,

--- a/ui/index.html
+++ b/ui/index.html
@@ -208,7 +208,7 @@
                     </div>
 
                     <div class="form-group">
-                        <label class="form-label">Backend to install</label>
+                        <label class="form-label">Backend</label>
                         <select id="backend-select">
                             <option value="">Loading available backends...</option>
                         </select>

--- a/ui/js/manager.js
+++ b/ui/js/manager.js
@@ -43,6 +43,21 @@ function installedBackendIdFromStatus(status) {
     return normalizeBackendId(status && status.backend);
 }
 
+function canActivateOfficialBackend(status, backendId) {
+    const target = normalizeBackendId(backendId);
+    const official = status && status.official_install;
+    const recordedBackend = normalizeBackendId(official && official.backend);
+    return Boolean(
+        status
+        && status.backend === "custom"
+        && target
+        && target !== "custom"
+        && official
+        && official.files_present
+        && (!recordedBackend || recordedBackend === target)
+    );
+}
+
 function renderBackendOptions(status) {
     const backendSelect = document.getElementById("backend-select");
     if (!backendSelect) return;
@@ -108,6 +123,7 @@ function updateInstalledBackendSummary(status) {
 }
 
 function syncInstallActionButtons(status, selectedInstallBackend) {
+    const installBtn = document.getElementById("btn-install");
     const updateBtn = document.getElementById("btn-update");
     const repairBtn = document.getElementById("btn-repair");
     const installTarget = normalizeBackendId(selectedInstallBackend);
@@ -115,6 +131,14 @@ function syncInstallActionButtons(status, selectedInstallBackend) {
     const hasInstalledBackend = Boolean(status && status.installed && installedBackend);
     const hasStaleBackendConfig = Boolean(status && status.config_stale && installedBackend);
     const customTargetSelected = installTarget === "custom";
+    const canActivateExisting = canActivateOfficialBackend(status, installTarget);
+
+    if (installBtn && !customTargetSelected) {
+        installBtn.textContent = canActivateExisting ? "Activate Existing" : "Install";
+        installBtn.title = canActivateExisting
+            ? "Use the official llama.cpp files already installed in llama/bin"
+            : "Download and install the selected llama.cpp release";
+    }
 
     if (updateBtn) {
         const canUpdate = !customTargetSelected && hasInstalledBackend && installedBackend !== "custom";
@@ -248,6 +272,25 @@ async function activateCustomBackend() {
         showStatus("error", "Failed to activate custom backend: " + e.message);
     } finally {
         setInstallButtonsDisabled(false);
+    }
+}
+
+async function activateOfficialBackend(backend) {
+    setInstallButtonsDisabled(true);
+    showStatus("info", `Activating existing ${backend} backend...`);
+    try {
+        const result = await fetchJson("/api/install", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ backend, activate_existing: true }),
+        });
+        showStatus("success", `Existing ${result.tag} (${result.backend}) installation activated.`);
+        await checkStatus();
+    } catch (e) {
+        showStatus("error", "Failed to activate existing backend: " + e.message);
+    } finally {
+        setInstallButtonsDisabled(false);
+        syncInstallActionButtons(latestStatus, selectedBackendId());
     }
 }
 
@@ -505,8 +548,11 @@ async function installRelease() {
     if (backendEl && backendEl.value === "custom") {
         return activateCustomBackend();
     }
-    const tag = document.getElementById("release-select").value;
     const backend = backendEl ? backendEl.value : "";
+    if (canActivateOfficialBackend(latestStatus, backend)) {
+        return activateOfficialBackend(backend);
+    }
+    const tag = document.getElementById("release-select").value;
     if (!tag) {
         showStatus("error", "Select a version first");
         return;

--- a/windows_install.bat
+++ b/windows_install.bat
@@ -47,6 +47,11 @@ echo Installing Python dependencies from requirements.txt...
 call "%VENV_PYTHON%" -m pip install -r requirements.txt
 if errorlevel 1 goto :install_error
 
+if not exist "llama\custom\bin" mkdir "llama\custom\bin"
+if errorlevel 1 goto :install_error
+if not exist "llama\custom\grammars" mkdir "llama\custom\grammars"
+if errorlevel 1 goto :install_error
+
 where powershell >nul 2>&1
 if %ERRORLEVEL% EQU 0 (
     echo Creating desktop shortcut...


### PR DESCRIPTION
## Summary

- Preserve official backend metadata when switching to a custom backend.
- Allow existing official llama.cpp files to be reactivated without downloading again.
- Verify the existing runtime before activation and expose activation state in the Install UI.
- Create custom binary and grammar directories during fresh installs and releases.
- Add backend, route, UI, and release-layout coverage.

## Testing

Not run (not requested)