### PR TITLE
Add CPU FFN layer offload control

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,9 @@
 
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
+## 2026-08-27
+- Added the new llama.cpp `-ncffn` / `--n-cpu-ffn` control for keeping dense FFN weights from the first N model layers on CPU.
+
 ## 2026-08-25
 - Preserved one downloaded official backend alongside a custom backend, allowing the Install tab to reactivate its existing `llama/bin` files without downloading them again; activation verifies that `llama-cli` can start, and legacy custom configurations recover its installed build tag from `--version`.
 - Fresh installs now create `llama/custom/bin` and `llama/custom/grammars` automatically.

--- a/tests/frontend/flag_definitions_unit.cjs
+++ b/tests/frontend/flag_definitions_unit.cjs
@@ -245,6 +245,12 @@ assert.equal(current.categories[advancedCategoryIndex + 1].id, "experimental");
 const mmprojFlagIndex = current.flags.findIndex((flag) => flag.id === "mmproj");
 assert.equal(current.flags[mmprojFlagIndex + 1].id, "mmproj_device");
 
+const nCpuFfn = current.flags.find((flag) => flag.id === "n_cpu_ffn");
+assert.equal(nCpuFfn.flag, "-ncffn");
+assert.equal(nCpuFfn.type, "int");
+assert.equal(nCpuFfn.min, 0);
+assert.equal(nCpuFfn.tool, "both");
+
 {
     const jinja = current.flags.find((flag) => flag.id === "jinja");
     assert.equal(jinja.default, true);

--- a/ui/js/flags/definitions.js
+++ b/ui/js/flags/definitions.js
@@ -553,6 +553,16 @@ const FLAGS = [
 		min: 0,
 	},
 	{
+		id: "n_cpu_ffn",
+		flag: "-ncffn",
+		category: "gpu",
+		type: "int",
+		label: "CPU FFN Layers",
+		desc: "Keep dense FFN weights of first N layers in CPU",
+		tool: "both",
+		min: 0,
+	},
+	{
 		id: "mmproj_offload",
 		flag: "--mmproj-offload",
 		false_flag: "--no-mmproj-offload",


### PR DESCRIPTION
## Summary

- Add the llama.cpp `-ncffn` / `--n-cpu-ffn` flag to the GPU settings.
- Support configuring the number of initial dense FFN layers kept on CPU for both tools.
- Add flag definition coverage and document the change in the changelog.

## Testing

- Updated frontend flag definition unit tests to validate the new integer flag and metadata.
- Not run (not requested)