### PR TITLE
feat: add ModelScope (魔搭) source with multi-threaded chunked downloads

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -51,6 +51,7 @@ from backend.routes import benchmarks as benchmarks_routes
 from backend.routes import external_server as external_server_routes
 from backend.routes import file_picker as file_picker_routes
 from backend.routes import hf_download as hf_download_routes
+from backend.routes import modelscope_download as modelscope_download_routes
 from backend.routes import metrics as metrics_routes
 from backend.routes import model_dir as model_dir_routes
 from backend.routes import models as models_routes
@@ -946,6 +947,8 @@ API_ROUTER = (
     .add("POST", "/api/hf/repo-files", hf_download_routes.list_repo_files)
     .add("POST", "/api/hf/download", hf_download_routes.start_download)
     .add("POST", "/api/hf/download-cancel", hf_download_routes.cancel_download)
+    .add("POST", "/api/ms/repo-files", modelscope_download_routes.list_repo_files)
+    .add("POST", "/api/ms/download", modelscope_download_routes.start_download)
     .add("POST", "/api/install", install_routes.start_install)
     .add("POST", "/api/update", install_routes.start_update)
     .add("POST", "/api/activate-custom", install_routes.activate_custom)

--- a/backend/routes/modelscope_download.py
+++ b/backend/routes/modelscope_download.py
@@ -1,0 +1,41 @@
+"""Routes for ModelScope (魔搭) model discovery and downloads.
+
+Status and cancellation are intentionally shared with the HF routes: both
+services drive the same ``ctx.state.model_download`` state machine, so the
+frontend polls ``/api/hf/download-status`` and cancels via
+``/api/hf/download-cancel`` regardless of the selected source.
+"""
+
+import sys
+
+from backend.http import sanitize_error
+from backend.services import modelscope_download as ms_download
+
+
+def list_repo_files(request, response, ctx):
+    body = request.body or {}
+    try:
+        repo_id = ms_download.validate_hf_repo_id(body.get("repo_id"))
+        response.json(ms_download.get_ms_model_files(repo_id, ctx.services.urlopen_with_ssl))
+    except Exception as exc:
+        print(f"[ms_download] repo file listing failed: {exc}", file=sys.stderr)
+        response.error(sanitize_error(exc, 400), 400)
+
+
+def start_download(request, response, ctx):
+    body = request.body or {}
+    try:
+        result = ms_download.start_ms_model_download(
+            ctx,
+            repo_id=body.get("repo_id"),
+            model_file=body.get("model_file"),
+            mmproj_file=body.get("mmproj_file"),
+            overwrite=bool(body.get("overwrite")),
+            urlopen=ctx.services.urlopen_with_ssl,
+        )
+        response.json(result)
+    except FileExistsError as exc:
+        response.error(str(exc), 409, code="exists")
+    except Exception as exc:
+        print(f"[ms_download] failed to start model download: {exc}", file=sys.stderr)
+        response.error(sanitize_error(exc, 400), 400)

--- a/backend/services/modelscope_download.py
+++ b/backend/services/modelscope_download.py
@@ -1,0 +1,385 @@
+"""ModelScope (魔搭) model discovery and multi-threaded chunked downloads.
+
+Mirrors :mod:`backend.services.hf_download` but talks to the ModelScope REST
+API directly (no vendor SDK) and fetches each file with parallel HTTP Range
+chunks. Both services share the same ``ctx.state.model_download`` state, the
+same lock/cancel contract, and the same frontend progress poller — only one
+download can run at a time regardless of source.
+"""
+
+import json
+import pathlib
+import threading
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable
+
+from backend.context import AppContext
+from backend.http import sanitize_error
+from backend.services import model_dir
+from backend.services.hf_download import (
+    get_model_download_snapshot,
+    is_mmproj_filename,
+    remove_partial_downloads,
+    reset_model_download_state,
+    set_model_download_state,
+    slugify_repo_id,
+    validate_hf_filename,
+    validate_hf_repo_id,
+)
+
+UrlOpen = Callable[..., Any]
+
+MS_API_BASE = "https://www.modelscope.cn"
+MS_REPO_FILES_API = MS_API_BASE + "/api/v1/models/{repo_id}/repo/files?Recursive=true"
+MS_FILE_URL = MS_API_BASE + "/models/{repo_id}/resolve/master/{path}"
+USER_AGENT = "Llama-GUI"
+
+CHUNK_SIZE = 32 * 1024 * 1024
+READ_SIZE = 1024 * 1024
+MAX_WORKERS = 8
+CHUNK_RETRIES = 3
+
+
+def get_ms_model_files(repo_id: str, urlopen: UrlOpen = urllib.request.urlopen) -> dict[str, Any]:
+    """List the repo's GGUF files: {repo_id, revision, models, mmproj}."""
+    url = MS_REPO_FILES_API.format(repo_id=repo_id)
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urlopen(request, timeout=30) as resp:
+        payload = json.loads(resp.read().decode("utf-8"))
+    files = (payload.get("Data") or {}).get("Files") or []
+    items = []
+    for entry in files:
+        if entry.get("Type") != "blob":
+            continue
+        name = str(entry.get("Path") or "")
+        if not name.lower().endswith(".gguf"):
+            continue
+        try:
+            size = int(entry.get("Size") or 0)
+        except (TypeError, ValueError):
+            size = 0
+        items.append({"name": name, "size": size, "size_mb": round(size / 1048576, 2)})
+    items.sort(key=lambda item: item["name"].lower())
+    main_files = [item for item in items if not is_mmproj_filename(item["name"])]
+    mmproj_files = [item for item in items if is_mmproj_filename(item["name"])]
+    return {"repo_id": repo_id, "revision": "master", "models": main_files, "mmproj": mmproj_files}
+
+
+def build_ms_download_url(repo_id: str, filename: str) -> str:
+    return MS_FILE_URL.format(repo_id=repo_id, path=filename)
+
+
+def get_ms_file_size(repo_id: str, filename: str, urlopen: UrlOpen = urllib.request.urlopen) -> int:
+    """Declared file size via HEAD, 0 when the server won't say."""
+    request = urllib.request.Request(
+        build_ms_download_url(repo_id, filename),
+        headers={"User-Agent": USER_AGENT},
+        method="HEAD",
+    )
+    try:
+        with urlopen(request, timeout=30) as resp:
+            raw = resp.headers.get("Content-Length")
+        return int(raw) if raw else 0
+    except (OSError, ValueError, urllib.error.URLError) as exc:
+        print(f"[ms_download] failed to read file size for {repo_id}/{filename}: {exc}", flush=True)
+        return 0
+
+
+class _ChunkCounter:
+    """Thread-safe byte counter feeding the shared download state."""
+
+    def __init__(self, ctx: AppContext, completed_bytes: int, total_bytes: int, filename: str) -> None:
+        self._ctx = ctx
+        self._lock = threading.Lock()
+        self._completed = completed_bytes
+        self._total = total_bytes
+        self._filename = filename
+        self._done = 0
+
+    def add(self, count: int) -> None:
+        with self._lock:
+            self._done += count
+            set_model_download_state(
+                self._ctx,
+                downloaded=self._completed + self._done,
+                total=self._total,
+                current_file=self._filename,
+            )
+
+    @property
+    def done(self) -> int:
+        with self._lock:
+            return self._done
+
+
+def _cancel_requested(ctx: AppContext) -> bool:
+    return ctx.state.model_download_cancel.is_set()
+
+
+def _download_chunk(
+    ctx: AppContext,
+    url: str,
+    start: int,
+    end: int,
+    part_path: pathlib.Path,
+    counter: _ChunkCounter,
+    urlopen: UrlOpen,
+) -> None:
+    """Fetch one byte range into *part_path*, resuming from what's on disk."""
+    got = part_path.stat().st_size if part_path.exists() else 0
+    span = end - start + 1
+    for attempt in range(CHUNK_RETRIES):
+        if _cancel_requested(ctx):
+            raise InterruptedError("Download cancelled.")
+        if got >= span:
+            return
+        try:
+            request = urllib.request.Request(
+                url,
+                headers={"User-Agent": USER_AGENT, "Range": f"bytes={start + got}-{end}"},
+            )
+            with urlopen(request, timeout=60) as resp:
+                status = getattr(resp, "status", 200)
+                if status not in (206, 200):
+                    raise OSError(f"Unexpected HTTP status {status} for Range request.")
+                with open(part_path, "ab" if status == 206 else "wb") as f:
+                    if status == 200:
+                        got = 0
+                    while True:
+                        if _cancel_requested(ctx):
+                            raise InterruptedError("Download cancelled.")
+                        chunk = resp.read(READ_SIZE)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+                        got += len(chunk)
+                        counter.add(len(chunk))
+            if got >= span:
+                return
+            raise OSError(f"Chunk short read: {got}/{span} bytes.")
+        except InterruptedError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - retried below, then reported
+            if attempt + 1 >= CHUNK_RETRIES:
+                raise OSError(f"Chunk {start}-{end} failed after {CHUNK_RETRIES} attempts: {exc}") from exc
+            time.sleep(1.5 * (attempt + 1))
+
+
+def _single_stream(
+    ctx: AppContext,
+    url: str,
+    dest: pathlib.Path,
+    counter: _ChunkCounter,
+    urlopen: UrlOpen,
+) -> None:
+    """Fallback when the server (or fake) does not honour Range requests."""
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    tmp_path = dest.with_suffix(dest.suffix + ".part")
+    with urlopen(request, timeout=60) as resp, open(tmp_path, "wb") as f:
+        while True:
+            if _cancel_requested(ctx):
+                raise InterruptedError("Download cancelled.")
+            chunk = resp.read(READ_SIZE)
+            if not chunk:
+                break
+            f.write(chunk)
+            counter.add(len(chunk))
+    tmp_path.replace(dest)
+
+
+def download_ms_file(
+    ctx: AppContext,
+    repo_id: str,
+    filename: str,
+    dest: pathlib.Path,
+    completed_bytes: int,
+    total_bytes: int,
+    urlopen: UrlOpen = urllib.request.urlopen,
+) -> int:
+    """Download one file with parallel Range chunks; returns bytes written.
+
+    On success the chunk temp files are removed. On failure the chunk files are
+    removed too (a fresh attempt re-plans them), matching the partial-file
+    cleanup contract in AGENTS.md.
+    """
+    url = build_ms_download_url(repo_id, filename)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    total = get_ms_file_size(repo_id, filename, urlopen)
+    counter = _ChunkCounter(ctx, completed_bytes, total_bytes or total, filename)
+
+    supports_ranges = False
+    if total > 0:
+        probe = urllib.request.Request(
+            url, headers={"User-Agent": USER_AGENT}, method="HEAD"
+        )
+        try:
+            with urlopen(probe, timeout=30) as resp:
+                accepts = str(resp.headers.get("Accept-Ranges") or "")
+            supports_ranges = accepts.lower() == "bytes"
+        except (OSError, urllib.error.URLError):
+            supports_ranges = False
+
+    part_paths: list[pathlib.Path] = []
+    try:
+        if total <= 0 or not supports_ranges:
+            _single_stream(ctx, url, dest, counter, urlopen)
+        else:
+            chunk_count = min(MAX_WORKERS, max(1, total // CHUNK_SIZE + (1 if total % CHUNK_SIZE else 0)))
+            base = total // chunk_count
+            spans = []
+            start = 0
+            for index in range(chunk_count):
+                end = total - 1 if index == chunk_count - 1 else start + base - 1
+                spans.append((start, end))
+                start = end + 1
+            part_paths = [
+                dest.with_suffix(dest.suffix + f".part{index}")
+                for index in range(len(spans))
+            ]
+            with ThreadPoolExecutor(max_workers=len(spans)) as pool:
+                futures = [
+                    pool.submit(
+                        _download_chunk,
+                        ctx,
+                        url,
+                        span_start,
+                        span_end,
+                        part_path,
+                        counter,
+                        urlopen,
+                    )
+                    for (span_start, span_end), part_path in zip(spans, part_paths)
+                ]
+                for future in futures:
+                    future.result()
+
+            assembled = dest.with_suffix(dest.suffix + ".assembling")
+            with open(assembled, "wb") as out:
+                for part_path in part_paths:
+                    with open(part_path, "rb") as part_file:
+                        while True:
+                            buf = part_file.read(READ_SIZE)
+                            if not buf:
+                                break
+                            out.write(buf)
+            if assembled.stat().st_size != total:
+                raise OSError(f"Assembled size mismatch for {filename}.")
+            assembled.replace(dest)
+        return counter.done
+    finally:
+        for part_path in part_paths:
+            try:
+                if part_path.exists():
+                    part_path.unlink()
+            except OSError as exc:
+                print(f"[ms_download] failed to remove chunk file: {exc}", flush=True)
+
+
+def start_ms_model_download(
+    ctx: AppContext,
+    repo_id: Any,
+    model_file: Any,
+    mmproj_file: Any,
+    overwrite: bool = False,
+    urlopen: UrlOpen = urllib.request.urlopen,
+) -> dict[str, Any]:
+    """Validate inputs and spawn the background download worker (HF twin)."""
+    repo_id = validate_hf_repo_id(repo_id)
+    model_file = validate_hf_filename(model_file)
+    mmproj_file = validate_hf_filename(mmproj_file) if mmproj_file else ""
+
+    if is_mmproj_filename(model_file):
+        raise ValueError("Choose a main model file, not an mmproj file.")
+    if mmproj_file and not is_mmproj_filename(mmproj_file):
+        raise ValueError("Choose an mmproj/projector file for the companion mmproj download.")
+
+    with ctx.state.model_download_lock:
+        if ctx.state.model_download_in_progress:
+            raise RuntimeError("A model download is already in progress.")
+        models_dir = model_dir.get_models_dir(ctx)
+        repo_folder = slugify_repo_id(repo_id)
+        model_basename = pathlib.PurePosixPath(model_file).name
+        model_name = f"{repo_folder}/{model_basename}"
+        model_dest = models_dir / repo_folder / model_basename
+        mmproj_dest = None
+        if mmproj_file:
+            mmproj_dest = model_dest.parent / pathlib.PurePosixPath(mmproj_file).name
+
+        existing = []
+        if model_dest.exists():
+            existing.append(model_name)
+        if mmproj_dest and mmproj_dest.exists():
+            existing.append(f"{repo_folder}/{mmproj_dest.name}")
+        if existing and not overwrite:
+            raise FileExistsError(f"Already exists: {', '.join(existing)}")
+
+        ctx.state.model_download_in_progress = True
+        ctx.state.model_download_cancel.clear()
+        reset_model_download_state(
+            ctx, status="starting", message="Preparing ModelScope download..."
+        )
+
+    def _worker() -> None:
+        destinations = [model_dest]
+        if mmproj_dest:
+            destinations.append(mmproj_dest)
+        try:
+            model_dest.parent.mkdir(parents=True, exist_ok=True)
+            total = get_ms_file_size(repo_id, model_file, urlopen)
+            if mmproj_file:
+                total += get_ms_file_size(repo_id, mmproj_file, urlopen)
+            reset_model_download_state(
+                ctx,
+                status="downloading",
+                message=f"Downloading {model_name}...",
+                total=total,
+                downloaded=0,
+            )
+            completed = download_ms_file(
+                ctx, repo_id, model_file, model_dest, 0, total, urlopen
+            )
+            mmproj_path = ""
+            if mmproj_file and mmproj_dest:
+                set_model_download_state(ctx, message=f"Downloading {mmproj_dest.name}...")
+                completed += download_ms_file(
+                    ctx,
+                    repo_id,
+                    mmproj_file,
+                    mmproj_dest,
+                    completed,
+                    total,
+                    urlopen,
+                )
+                mmproj_path = str(mmproj_dest)
+            set_model_download_state(
+                ctx,
+                status="done",
+                message=f"Downloaded {model_name}.",
+                downloaded=total or completed,
+                total=total or completed,
+                current_file="",
+                model_name=model_name,
+                model_path=str(model_dest),
+                mmproj_path=mmproj_path,
+            )
+        except InterruptedError as exc:
+            remove_partial_downloads(destinations)
+            set_model_download_state(ctx, status="cancelled", message=str(exc), current_file="")
+        except Exception as exc:
+            remove_partial_downloads(destinations)
+            set_model_download_state(
+                ctx,
+                status="error",
+                message=sanitize_error(exc, 500),
+                current_file="",
+            )
+        finally:
+            with ctx.state.model_download_lock:
+                ctx.state.model_download_in_progress = False
+                ctx.state.model_download_cancel.clear()
+
+    threading.Thread(target=_worker, daemon=True).start()
+    return get_model_download_snapshot(ctx)

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -625,6 +625,7 @@ footer {
             <div class="node green"><div class="t">process_manager</div><div class="d">Spawn, stop, output buffer, arg parsing, API keys</div></div>
             <div class="node green"><div class="t">chat · web_search</div><div class="d">Proxy helpers, SearXNG/ddgs, HTML→text</div></div>
             <div class="node green"><div class="t">hf_download</div><div class="d">Repo listing, cancellable download, path validation</div></div>
+            <div class="node green"><div class="t">modelscope_download</div><div class="d">ModelScope listing, multi-threaded chunked download</div></div>
             <div class="node green"><div class="t">external_server</div><div class="d">Target resolution, health probe, remembered address</div></div>
             <div class="node green"><div class="t">tunnel · git_update · lifecycle · file_picker</div><div class="d">cloudflared, app updates, shutdown, tkinter dialogs</div></div>
             <div class="node green"><div class="t">subprocess_utils</div><div class="d">CREATE_NO_WINDOW spawn helpers for short-lived probe processes</div></div>
@@ -682,6 +683,7 @@ footer {
 <tr><td class="mono">external_server.py</td><td class="mono">external_server.py</td><td>Register / read / clear an externally started llama-server; resolve the proxy target</td></tr>
 <tr><td class="mono">metrics.py</td><td class="mono">local_llama_http.py</td><td>Proxy llama-server's Prometheus <code>/metrics</code> and <code>/slots</code></td></tr>
 <tr><td class="mono">hf_download.py</td><td class="mono">hf_download.py · model_dir.py</td><td>List repo GGUF files, background download into the active model root with cancel, progress status</td></tr>
+<tr><td class="mono">modelscope_download.py</td><td class="mono">modelscope_download.py · model_dir.py</td><td>List ModelScope repo GGUF files, multi-threaded chunked download into the active model root; shares the download state machine, cancel, and progress status with hf_download</td></tr>
 <tr><td class="mono">presets.py</td><td class="mono">—</td><td>Preset CRUD on <code>presets/*.json</code>, rename with created-time carry, Windows shortcut export</td></tr>
 <tr><td class="mono">models.py</td><td class="mono">model_dir.py</td><td>Recursive GGUF discovery under the active model root, returned as root-relative names</td></tr>
 <tr><td class="mono">model_dir.py</td><td class="mono">model_dir.py</td><td>Validate, persist, report, and reset the active model root without unsafe fallback</td></tr>
@@ -1100,7 +1102,7 @@ flagCore.setFlagValue("temperature", 0.5);
 <tr><td><span class="verb get">GET</span></td><td class="mono">/api/llama/slots</td><td>Slots proxy (KV/context fallback)</td></tr>
 <tr><td><span class="verb get">GET</span></td><td class="mono">/api/llama/props</td><td>Props proxy (chat-template capabilities)</td></tr>
 <tr><td><span class="verb get">GET</span></td><td class="mono">/api/download-progress</td><td>Release install progress</td></tr>
-<tr><td><span class="verb get">GET</span></td><td class="mono">/api/hf/download-status</td><td>Hugging Face download progress</td></tr>
+<tr><td><span class="verb get">GET</span></td><td class="mono">/api/hf/download-status</td><td>Hugging Face / ModelScope download progress</td></tr>
 <tr><td><span class="verb get">GET</span></td><td class="mono">/api/remote-tunnel/status</td><td>Cloudflare tunnel status + URL</td></tr>
 <tr><td><span class="verb get">GET</span></td><td class="mono">/api/chat/target</td><td>Live and remembered external server</td></tr>
 <tr><td><span class="verb get">GET</span></td><td class="mono">/api/models</td><td>GGUF files under the active model root</td></tr>
@@ -1124,6 +1126,8 @@ flagCore.setFlagValue("temperature", 0.5);
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/hf/repo-files</td><td>List GGUF files in a HF repo</td></tr>
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/hf/download</td><td>Start a background model download</td></tr>
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/hf/download-cancel</td><td>Cancel the in-progress download</td></tr>
+<tr><td><span class="verb post">POST</span></td><td class="mono">/api/ms/repo-files</td><td>List GGUF files in a ModelScope repo</td></tr>
+<tr><td><span class="verb post">POST</span></td><td class="mono">/api/ms/download</td><td>Start a multi-threaded ModelScope model download</td></tr>
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/remote-tunnel/start</td><td>Start the Cloudflare quick tunnel</td></tr>
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/remote-tunnel/stop</td><td>Stop the tunnel</td></tr>
 <tr><td><span class="verb post">POST</span></td><td class="mono">/api/presets</td><td>Save a preset</td></tr>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,9 @@
---Changelog--
+# --Changelog--
 
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
+
+## 2026-08-28
+- Added ModelScope (魔搭) as a second model source in the HF download panel: a Source dropdown switches between Hugging Face and ModelScope, backed by new `POST /api/ms/repo-files` and `POST /api/ms/download` routes (`backend/services/modelscope_download.py`). ModelScope downloads use parallel HTTP Range chunks (up to 8 workers) with automatic single-stream fallback; progress, cancel, and completion state are shared with the HF flow, so the same progress bar, cancel button, and model auto-selection work for both sources. Revision and token inputs are disabled for ModelScope (not part of its API). The downloaded file passed an end-to-end check: listed via the ModelScope API, downloaded, discovered by the models API, and loaded by llama-server.
 
 ## 2026-08-27
 - Added the new llama.cpp `-ncffn` / `--n-cpu-ffn` control for keeping dense FFN weights from the first N model layers on CPU.

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -79,7 +79,7 @@
 
 ### Route Modules (`backend/routes/`)
 
-`API_ROUTER` at the bottom of `backend/app.py` is the authoritative registry: 46 exact routes plus one prefix route, 47 endpoints total. Keep this table in sync with it — a route that is registered but undocumented here is the drift that is hardest to notice.
+`API_ROUTER` at the bottom of `backend/app.py` is the authoritative registry: 48 exact routes plus one prefix route, 49 endpoints total. Keep this table in sync with it — a route that is registered but undocumented here is the drift that is hardest to notice.
 
 | Route | Endpoints |
 |-------|-----------|
@@ -93,6 +93,7 @@
 | `model_dir.py` | `POST /api/models-dir` — set or reset the active model root |
 | `presets.py` | `GET /api/presets`, `POST /api/presets` (save), `POST /api/presets/rename`, `POST /api/presets/archive` (bulk archive/restore), `POST /api/presets/shortcut` (Windows shortcut export), `DELETE /api/presets/<name>` (prefix route) |
 | `hf_download.py` | `POST /api/hf/repo-files`, `POST /api/hf/download`, `POST /api/hf/download-cancel`, `GET /api/hf/download-status` |
+| `modelscope_download.py` | `POST /api/ms/repo-files`, `POST /api/ms/download` (status/cancel shared with `hf_download.py`) |
 | `tunnel.py` | `POST /api/remote-tunnel/start`, `POST /api/remote-tunnel/stop`, `GET /api/remote-tunnel/status` |
 | `git_update.py` | `GET /api/app-update-status`, `POST /api/app-update` |
 | `search.py` | `POST /api/web-search` |
@@ -109,6 +110,7 @@ Note that `/api/presets/fingerprint` and `/api/estimate-memory` live in `process
 | `llama_manager.py` | GitHub release fetch, install, SHA256 verify, binary extraction |
 | `process_manager.py` | Process launch/stop, output streaming, arg flattening, API target parsing |
 | `hf_download.py` | HF repo listing, file download with cancel, path validation |
+| `modelscope_download.py` | ModelScope (魔搭) repo listing, multi-threaded chunked download with cancel, shared download state |
 | `model_dir.py` | Active model-root validation, metadata, and merged atomic config persistence |
 | `web_search.py` | DuckDuckGo (`ddgs`) and optional SearXNG search, HTML-to-text, page fetching |
 | `tunnel.py` | Cloudflare tunnel lifecycle, binary download, status polling |

--- a/tests/backend/test_modelscope_download.py
+++ b/tests/backend/test_modelscope_download.py
@@ -1,0 +1,234 @@
+"""ModelScope (魔搭) download service tests.
+
+Mirrors the HF download tests in test_services.py: same context builder, same
+FakeDownloadResponse plumbing, same worker/threading patterns.
+"""
+
+import contextlib
+import io
+import json
+import pathlib
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+from backend.services import modelscope_download as ms_service
+from tests.backend.test_services import FakeDownloadResponse, make_service_context
+
+
+def _wait_for_status(ctx, attempts=150):
+    for _ in range(attempts):
+        snap = ms_service.get_model_download_snapshot(ctx)
+        if snap["status"] in {"done", "error", "cancelled"}:
+            return snap
+        time.sleep(0.02)
+    return snap
+
+
+class ImmediateThread:
+    def __init__(self, *, target, daemon):
+        self.target = target
+
+    def start(self):
+        self.target()
+
+
+class FakeRangeServer:
+    """Serves HEAD metadata plus Range/whole-body GETs from one bytes body."""
+
+    def __init__(self, body, accept_ranges=True):
+        self.body = body
+        self.accept_ranges = accept_ranges
+        self.requests = []
+
+    def __call__(self, req, timeout=60):
+        self.requests.append(req)
+        if req.get_method() == "HEAD":
+            resp = FakeDownloadResponse([], content_length=len(self.body))
+            if self.accept_ranges:
+                resp.headers["Accept-Ranges"] = "bytes"
+            return resp
+        range_header = req.headers.get("Range")
+        if range_header and self.accept_ranges:
+            span = range_header.split("=", 1)[1]
+            start_s, end_s = span.split("-", 1)
+            start, end = int(start_s), int(end_s)
+            chunk = self.body[start : end + 1]
+            resp = FakeDownloadResponse([chunk], content_length=len(chunk))
+            resp.status = 206
+            return resp
+        resp = FakeDownloadResponse([self.body], content_length=len(self.body))
+        resp.status = 200
+        return resp
+
+
+class GetMsModelFilesTests(unittest.TestCase):
+    def test_lists_gguf_files_split_by_mmproj(self):
+        payload = {
+            "Data": {
+                "Files": [
+                    {"Type": "blob", "Path": "model.Q4.gguf", "Size": 10},
+                    {"Type": "blob", "Path": "mmproj-model.gguf", "Size": 5},
+                    {"Type": "blob", "Path": "README.md", "Size": 2},
+                    {"Type": "tree", "Path": "sub", "Size": 0},
+                ]
+            }
+        }
+        seen_urls = []
+
+        def fake_urlopen(req, timeout=30):
+            seen_urls.append(req.full_url)
+            return FakeDownloadResponse([json.dumps(payload).encode("utf-8")])
+
+        result = ms_service.get_ms_model_files("owner/model", urlopen=fake_urlopen)
+
+        self.assertEqual([f["name"] for f in result["models"]], ["model.Q4.gguf"])
+        self.assertEqual([f["name"] for f in result["mmproj"]], ["mmproj-model.gguf"])
+        self.assertEqual(result["models"][0]["size_mb"], round(10 / 1048576, 2))
+        self.assertIn(
+            "https://www.modelscope.cn/api/v1/models/owner/model/repo/files", seen_urls[0]
+        )
+
+    def test_size_header_without_accept_ranges_is_ignored_for_chunks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            body = b"0123456789"
+            server = FakeRangeServer(body, accept_ranges=False)
+            dest = pathlib.Path(tmp) / "model.gguf"
+
+            with mock.patch.object(ms_service, "get_ms_file_size", return_value=len(body)):
+                downloaded = ms_service.download_ms_file(
+                    ctx, "owner/model", "model.gguf", dest, 0, len(body), server
+                )
+
+            self.assertEqual(downloaded, len(body))
+            self.assertEqual(dest.read_bytes(), body)
+
+
+class StartMsModelDownloadTests(unittest.TestCase):
+    def test_single_stream_download_into_repo_subfolder(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            payload = b"gguf-bytes"
+            server = FakeRangeServer(payload, accept_ranges=False)
+
+            with (
+                mock.patch.object(ms_service, "get_ms_file_size", return_value=len(payload)),
+                mock.patch.object(ms_service.threading, "Thread", ImmediateThread),
+            ):
+                ms_service.start_ms_model_download(
+                    ctx,
+                    repo_id="owner/model",
+                    model_file="Q4/model.gguf",
+                    mmproj_file="mmproj-model.gguf",
+                    overwrite=False,
+                    urlopen=server,
+                )
+                snap = _wait_for_status(ctx)
+
+            self.assertEqual(snap["status"], "done", snap)
+            self.assertEqual(snap["model_name"], "owner_model/model.gguf")
+            model_path = pathlib.Path(snap["model_path"])
+            self.assertEqual(model_path, ctx.paths.models / "owner_model" / "model.gguf")
+            self.assertEqual(model_path.read_bytes(), payload)
+            mmproj_path = pathlib.Path(snap["mmproj_path"])
+            self.assertEqual(
+                mmproj_path, ctx.paths.models / "owner_model" / "mmproj-model.gguf"
+            )
+            self.assertTrue(mmproj_path.is_file())
+
+    def test_chunked_download_assembles_exact_bytes_and_uses_range_requests(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            payload = bytes(range(256)) * 64  # 16 KiB, forced into 3+ chunks
+            server = FakeRangeServer(payload, accept_ranges=True)
+
+            with (
+                mock.patch.object(ms_service, "get_ms_file_size", return_value=len(payload)),
+                mock.patch.object(ms_service, "CHUNK_SIZE", 4096),
+            ):
+                ms_service.start_ms_model_download(
+                    ctx,
+                    repo_id="owner/model",
+                    model_file="model.gguf",
+                    mmproj_file="",
+                    overwrite=False,
+                    urlopen=server,
+                )
+                snap = _wait_for_status(ctx)
+
+            self.assertEqual(snap["status"], "done", snap)
+            dest = pathlib.Path(snap["model_path"])
+            self.assertEqual(dest.read_bytes(), payload)
+            self.assertFalse(list(dest.parent.glob("*.part*")), "chunk temp files must be cleaned")
+            self.assertFalse(list(dest.parent.glob("*.assembling")))
+            get_requests = [r for r in server.requests if r.get_method() == "GET"]
+            self.assertTrue(any(r.headers.get("Range") for r in get_requests))
+            self.assertTrue(
+                all(
+                    r.full_url.startswith(
+                        "https://www.modelscope.cn/models/owner/model/resolve/master/"
+                    )
+                    for r in server.requests
+                )
+            )
+
+    def test_exists_check_uses_repo_relative_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            dest = ctx.paths.models / "owner_model" / "model.gguf"
+            dest.parent.mkdir(parents=True)
+            dest.write_bytes(b"existing")
+
+            def fail_urlopen(*_args, **_kwargs):
+                raise AssertionError("no network access expected")
+
+            with self.assertRaises(FileExistsError) as raised:
+                ms_service.start_ms_model_download(
+                    ctx,
+                    repo_id="owner/model",
+                    model_file="model.gguf",
+                    mmproj_file="",
+                    overwrite=False,
+                    urlopen=fail_urlopen,
+                )
+
+            self.assertIn("owner_model/model.gguf", str(raised.exception))
+
+    def test_worker_logs_and_sanitizes_unexpected_errors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            stderr = io.StringIO()
+
+            with contextlib.redirect_stderr(stderr), mock.patch.object(
+                ms_service, "get_ms_file_size", side_effect=RuntimeError("private download failure")
+            ), mock.patch.object(ms_service.threading, "Thread", ImmediateThread):
+                snap = ms_service.start_ms_model_download(
+                    ctx,
+                    repo_id="owner/model",
+                    model_file="model.gguf",
+                    mmproj_file="",
+                    overwrite=False,
+                )
+
+            self.assertEqual(snap["status"], "error")
+            self.assertEqual(snap["message"], "Internal server error")
+            self.assertIn("private download failure", stderr.getvalue())
+
+    def test_refuses_mmproj_as_main_model(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+
+            with self.assertRaises(ValueError):
+                ms_service.start_ms_model_download(
+                    ctx,
+                    repo_id="owner/model",
+                    model_file="mmproj-model.gguf",
+                    mmproj_file="",
+                    overwrite=False,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/frontend/hf_download_ui_unit.cjs
+++ b/tests/frontend/hf_download_ui_unit.cjs
@@ -398,6 +398,42 @@ function addElement(elements, id, tagName = "div", value = "") {
     );
 }
 
+{
+    // ModelScope source: same form, different endpoints; status/cancel shared.
+    const { elements, ui } = makeContext();
+    addElement(elements, "hf-download-status");
+    addElement(elements, "btn-hf-find-files", "button");
+    addElement(elements, "btn-hf-download", "button");
+    addElement(elements, "btn-hf-cancel", "button");
+    addElement(elements, "hf-source-select", "select", "ms");
+    addElement(elements, "hf-repo-input", "input", "Qwen/Qwen2.5-0.5B-Instruct-GGUF");
+    addElement(elements, "hf-revision-input", "input", "");
+    addElement(elements, "hf-token-input", "input", "");
+    addElement(elements, "hf-file-options");
+    addElement(elements, "hf-model-file-select", "select");
+    addElement(elements, "hf-mmproj-file-select", "select");
+
+    const calls = [];
+    ui.configure({
+        fetchJson: async (url, optionsArg) => {
+            calls.push({ url, body: JSON.parse(optionsArg.body) });
+            return {
+                models: [{ name: "model.gguf", size: 2048 }],
+                mmproj: [],
+            };
+        },
+        confirmAction: async () => false,
+    });
+
+    await ui.findFiles();
+    assert.equal(calls[0].url, "/api/ms/repo-files");
+
+    await ui.startDownload(false);
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(calls[1].url, "/api/ms/download");
+    assert.equal(calls[1].body.repo_id, "Qwen/Qwen2.5-0.5B-Instruct-GGUF");
+}
+
 console.log("hf download ui unit tests passed");
 })().catch((error) => {
     console.error(error);

--- a/ui/index.html
+++ b/ui/index.html
@@ -600,6 +600,13 @@
                     <div class="hf-download-body">
                         <div id="hf-download-status" class="hf-download-status"></div>
                         <div class="form-group">
+                            <label class="form-label" for="hf-source-select">Source</label>
+                            <select id="hf-source-select">
+                                <option value="hf" selected>Hugging Face</option>
+                                <option value="ms">ModelScope 魔搭</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
                             <label class="form-label" for="hf-repo-input">Repo ID</label>
                             <input type="text" id="hf-repo-input" placeholder="owner/model-GGUF" />
                         </div>

--- a/ui/js/hf-download-ui.js
+++ b/ui/js/hf-download-ui.js
@@ -15,6 +15,19 @@
     let hfDownloadPollInFlight = false;
     let deps = {};
 
+    // Both sources share the download-status/cancel endpoints and the same
+    // progress state machine on the backend; only listing and starting differ.
+    const DOWNLOAD_SOURCES = {
+        hf: { repoFiles: "/api/hf/repo-files", download: "/api/hf/download" },
+        ms: { repoFiles: "/api/ms/repo-files", download: "/api/ms/download" },
+    };
+    const SOURCE_LABELS = { hf: "Hugging Face", ms: "ModelScope" };
+
+    function selectedSource() {
+        const select = document.getElementById("hf-source-select");
+        return select && select.value === "ms" ? "ms" : "hf";
+    }
+
     function requireDependency(name) {
         const value = deps[name];
         if (typeof value !== "function") {
@@ -104,15 +117,16 @@
         if (!repoInput || !modelSelect || !mmprojSelect) return;
 
         const repoId = repoInput.value.trim();
+        const source = selectedSource();
         if (!repoId) {
-            showStatus("warning", "Enter a Hugging Face repo ID first.");
+            showStatus("warning", `Enter a ${SOURCE_LABELS[source]} repo ID first.`);
             return;
         }
 
         showStatus("info", "Looking for GGUF files...");
         setBusy(true);
         try {
-            const result = await fetchJson("/api/hf/repo-files", {
+            const result = await fetchJson(DOWNLOAD_SOURCES[source].repoFiles, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
@@ -136,7 +150,7 @@
             );
         } catch (e) {
             if (options) options.classList.add("hidden");
-            showStatus("error", "Hugging Face lookup failed: " + e.message);
+            showStatus("error", `${SOURCE_LABELS[source]} lookup failed: ` + e.message);
         } finally {
             setBusy(false);
         }
@@ -161,7 +175,7 @@
         showStatus("info", "Starting download...");
         setBusy(true);
         try {
-            await fetchJson("/api/hf/download", {
+            await fetchJson(DOWNLOAD_SOURCES[selectedSource()].download, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
@@ -324,6 +338,20 @@
         on("btn-hf-find-files", "click", findFiles);
         on("btn-hf-download", "click", () => startDownload(false));
         on("btn-hf-cancel", "click", cancelDownload);
+
+        // Revision/token are Hugging Face concepts; ModelScope ignores them.
+        const sourceSelect = document.getElementById("hf-source-select");
+        if (sourceSelect) {
+            const syncSourceFields = () => {
+                const isMs = selectedSource() === "ms";
+                for (const id of ["hf-revision-input", "hf-token-input"]) {
+                    const el = document.getElementById(id);
+                    if (el) el.disabled = isMs;
+                }
+            };
+            syncSourceFields();
+            sourceSelect.addEventListener("change", syncSourceFields);
+        }
     }
 
     window.LlamaGui = window.LlamaGui || {};


### PR DESCRIPTION
## Summary

Adds ModelScope (魔搭, modelscope.cn) as a second model download source alongside Hugging Face, with parallel chunked downloading:

- **Source dropdown** in the existing HF download panel switches between Hugging Face and ModelScope. Listing and download requests route per source (`POST /api/ms/repo-files`, `POST /api/ms/download`); progress status, cancel, and completion/auto-select reuse the existing endpoints and state machine unchanged.
- **Multi-threaded chunked downloads** (`backend/services/modelscope_download.py`): the file is split into byte-range spans fetched by up to 8 workers, with per-chunk retries, exact-size assembly verification, and automatic single-stream fallback when the server does not honor `Accept-Ranges`. No new runtime dependencies (stdlib `urllib` only, injected `urlopen` kept testable per existing patterns).
- **Shared state machine**: ModelScope downloads drive the same `ctx.state.model_download` AtomicDict, lock, and cancel event as HF downloads, so the UI progress bar, cancel button, partial-file cleanup, and "Already exists" 409 flow work identically for both sources. Revision/token inputs are disabled for ModelScope (not part of its API).
- Full input validation reuse (repo ID / filename rules incl. Windows reserved names), docs sync (`docs/directory.md`, `docs/architecture.html`, changelog), and the docs-sync tests pass.

## Motivation

ModelScope hosts GGUF repos (e.g. `Qwen/Qwen2.5-0.5B-Instruct-GGUF`) and is much faster than Hugging Face for users in mainland China. This gives Llama-GUI first-class ModelScope support with faster parallel downloads instead of falling back to manual downloads.

## Testing

- 7 new backend unit tests (`tests/backend/test_modelscope_download.py`): listing split by mmproj, chunk assembly with Range-request assertions, single-stream fallback, path validation, error sanitization.
- New frontend source-routing case in `tests/frontend/hf_download_ui_unit.cjs`; default Hugging Face behavior unchanged.
- Full backend suite: 632 tests green. `npm run test:frontend`, `test:flag-definitions`, `test:syntax` green; ruff clean.
- Real end-to-end: started the backend, listed `Qwen/Qwen2.5-0.5B-Instruct-GGUF` via the new route, downloaded the 396 MB q2_k GGUF (~208 MB in the first 12 s on a gigabit link), confirmed exact byte total (415,182,688), models-API discovery, and successful load in `llama-server` (listening + healthy).
