### PR TITLE
Add Advanced Configure control for lazy tensor reading

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,9 @@
 
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
+## 2026-08-28
+- Added an Advanced Configure control for llama.cpp b10653+'s `--tensor-read-lazy` mode, with inert Auto-by-default behavior plus explicit lower-RAM On and keep-resident Off choices.
+
 ## 2026-08-27
 - Added the new llama.cpp `-ncffn` / `--n-cpu-ffn` control for keeping dense FFN weights from the first N model layers on CPU.
 

--- a/tests/frontend/launch_args_unit.cjs
+++ b/tests/frontend/launch_args_unit.cjs
@@ -150,6 +150,7 @@ function launchResult() {
         "--mirostat-ent",
         "--mtmd-batch-max-tokens",
         "--reasoning-format",
+        "--tensor-read-lazy",
     ]) {
         assert.ok(!args.includes(flag), `default launch args should omit ${flag}`);
     }
@@ -192,6 +193,23 @@ function launchResult() {
     assert.ok(args.includes("--load-mode") && args.includes("dio"));
     assert.ok(!args.includes("--mmap") && !args.includes("--no-mmap"));
     assert.ok(!args.includes("--mlock") && !args.includes("-dio"));
+}
+
+{
+    vm.runInContext(`
+        window.LlamaGui.flagCore.replaceFlagValues(getDefaultValues());
+        window.LlamaGui.flagCore.setFlagValue("tensor_read_lazy", "on");
+    `, context);
+    let args = flatLaunchArgs();
+    let flagIndex = args.indexOf("--tensor-read-lazy");
+    assert.notEqual(flagIndex, -1);
+    assert.equal(args[flagIndex + 1], "on");
+
+    vm.runInContext(`window.LlamaGui.flagCore.setFlagValue("tensor_read_lazy", "off")`, context);
+    args = flatLaunchArgs();
+    flagIndex = args.indexOf("--tensor-read-lazy");
+    assert.notEqual(flagIndex, -1);
+    assert.equal(args[flagIndex + 1], "off");
 }
 
 {

--- a/ui/js/flags/definitions.js
+++ b/ui/js/flags/definitions.js
@@ -1886,6 +1886,22 @@ const FLAGS = [
 
 	// Advanced
 	{
+		id: "tensor_read_lazy",
+		flag: "--tensor-read-lazy",
+		category: "advanced",
+		type: "enum",
+		label: "Lazy Tensor Reading",
+		short_desc: "Read eligible model tensors from disk on demand to reduce resident RAM use.",
+		desc: "Controls on-demand reading for tensors marked as eligible by the model architecture, such as large per-layer embedding tables. Requires mmap. Auto uses llama.cpp's default behavior (lazy only above 4 GiB); On trades some inference speed for lower resident RAM; Off keeps eligible tensors resident. Available in llama.cpp b10653+.",
+		tool: "both",
+		default: "",
+		options: [
+			{ value: "", label: "Auto (Recommended)" },
+			{ value: "on", label: "On (Lower RAM)" },
+			{ value: "off", label: "Off (Keep Resident)" },
+		],
+	},
+	{
 		id: "override_kv",
 		flag: "--override-kv",
 		category: "advanced",


### PR DESCRIPTION
## Summary

- Add an Advanced Configure control for llama.cpp b10653+ `--tensor-read-lazy`.
- Support Auto, lower-RAM On, and keep-resident Off options.
- Keep Auto inert so the upstream default behavior is preserved.
- Add launch-argument coverage for explicit `on` and `off` values.
- Update the changelog.

## Testing

- Added frontend launch-argument unit coverage for the new flag.