### PR TITLE
Omit inactive Auto Fit helper flags from launch commands

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
 ## 2026-08-28
+- Turning Auto Fit off now omits its inactive `-fitt` target-margin and `-fitc` context-floor helpers from generated launch commands while preserving their configured values for later reuse.
 - Added an Advanced Configure control for llama.cpp b10653+'s `--tensor-read-lazy` mode, with inert Auto-by-default behavior plus explicit lower-RAM On and keep-resident Off choices.
 
 ## 2026-08-27

--- a/tests/frontend/launch_args_unit.cjs
+++ b/tests/frontend/launch_args_unit.cjs
@@ -159,6 +159,24 @@ function launchResult() {
 {
     vm.runInContext(`
         window.LlamaGui.flagCore.replaceFlagValues(getDefaultValues());
+        window.LlamaGui.flagCore.setFlagValue("fit", "off");
+    `, context);
+    let args = flatLaunchArgs();
+    const fitIndex = args.indexOf("-fit");
+    assert.notEqual(fitIndex, -1);
+    assert.equal(args[fitIndex + 1], "off");
+    assert.ok(!args.includes("-fitt"), "disabled auto-fit should omit its target margin");
+    assert.ok(!args.includes("-fitc"), "disabled auto-fit should omit its context floor");
+
+    vm.runInContext(`window.LlamaGui.flagCore.setFlagValue("fit", "on")`, context);
+    args = flatLaunchArgs();
+    assert.ok(args.includes("-fitt"), "re-enabled auto-fit should restore its target margin");
+    assert.ok(args.includes("-fitc"), "re-enabled auto-fit should restore its context floor");
+}
+
+{
+    vm.runInContext(`
+        window.LlamaGui.flagCore.replaceFlagValues(getDefaultValues());
         window.LlamaGui.flagCore.setMultipleFlagValues({
             dry_multiplier: 0.8,
             dry_penalty_last_n: 2048,

--- a/ui/js/flag-core.js
+++ b/ui/js/flag-core.js
@@ -528,6 +528,7 @@
         for (const f of getFlags()) {
             if (f.tool !== "both" && f.tool !== toolBase) continue;
             if (f.id === "ngram_mod" || f.id === "ngram_map_k4v") continue;
+            if (values.fit === "off" && (f.id === "fit_target" || f.id === "fit_ctx")) continue;
             if (typeof shouldOmitSpeculativeFlag === "function" && shouldOmitSpeculativeFlag(f, values)) continue;
             if (shouldOmitLegacyLoadFlag(f, values)) continue;
             const val = values[f.id];


### PR DESCRIPTION
## Summary

- Omit `-fitt` and `-fitc` when Auto Fit is disabled.
- Preserve configured Auto Fit helper values so they return when Auto Fit is re-enabled.
- Add launch-argument coverage for disabled and re-enabled Auto Fit states.

## Testing

- Added and updated frontend launch-argument unit coverage for Auto Fit flag omission and restoration.