### PR TITLE
Rename Lemonade ROCm 7 labels to ROCm Nightly

### DIFF
--- a/backend/services/llama_manager.py
+++ b/backend/services/llama_manager.py
@@ -32,7 +32,7 @@ SHA256_DIGEST_RE = re.compile(r"^sha256:([0-9a-fA-F]{64})$")
 RUNTIME_HEALTH_CACHE_TTL_SECONDS = 5.0
 
 # Optional llamacpp-rocm backend (https://github.com/lemonade-sdk/llamacpp-rocm).
-# Publishes nightly ROCm 7 llama.cpp archives for Windows and Ubuntu, one asset
+# Publishes nightly ROCm llama.cpp archives for Windows and Ubuntu, one asset
 # per AMD GPU target. Users must choose the target matching their GPU arch.
 LEMONADE_ROCM_REPO_API = (
     "https://api.github.com/repos/lemonade-sdk/llamacpp-rocm/releases"
@@ -53,7 +53,7 @@ LEMONADE_ROCM_TARGETS = [
 
 def _lemonade_rocm_backend(platform_token: str, gpu_target: str, family: str) -> dict[str, Any]:
     return {
-        "label": f"ROCm 7 {gpu_target} ({family}, Lemonade)",
+        "label": f"ROCm Nightly {gpu_target} ({family}, Lemonade)",
         "asset": f"llama-{{tag}}-{platform_token}-rocm-{gpu_target}-x64.zip",
         "provider": "lemonade-rocm",
         "repo_api": LEMONADE_ROCM_REPO_API,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,9 @@
 
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
+## 2026-08-30
+- Renamed the architecture-specific Lemonade install options from ROCm 7 to ROCm Nightly so their labels remain accurate as the bundled TheRock runtime advances.
+
 ## 2026-08-29
 - Moved Llama GUI's in-app update controls beside the llama.cpp installer at the top of Install and Update, tightened both cards into a responsive two-column layout, and removed the backend dropdown's ROCm description.
 - **Batch 1 low-severity follow-up (L6, L1, L3, M3 health):** fresh `cloudflared` helper downloads now fail closed unless GitHub's release metadata supplies the expected asset and a valid SHA256 digest, and mismatches are rejected before `chmod`/execution; a wedged `Thread.start()` can no longer leave install, model-download, or tunnel state stuck, with HF failures returned only through their sanitized status snapshot; launch-target DNS validation now runs before acquiring the install/process locks or starting the child; and the pinned runtime health probe preserves its generation recheck even when target validation fails.

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -4673,7 +4673,7 @@ class InstallRouteTests(unittest.TestCase):
 
     def test_get_releases_uses_backend_repo_api_for_lemonade(self):
         self.ctx.services.backend_specs["lemonade-rocm-gfx110X"] = {
-            "label": "ROCm 7 gfx110X (Lemonade)",
+            "label": "ROCm Nightly gfx110X (Lemonade)",
             "repo_api": llama_manager.LEMONADE_ROCM_REPO_API,
         }
         response = DummyResponse()
@@ -4725,7 +4725,7 @@ class InstallRouteTests(unittest.TestCase):
 
     def test_update_uses_installed_backend_repo_api_for_lemonade(self):
         self.ctx.services.backend_specs["lemonade-rocm-gfx110X"] = {
-            "label": "ROCm 7 gfx110X (Lemonade)",
+            "label": "ROCm Nightly gfx110X (Lemonade)",
             "repo_api": llama_manager.LEMONADE_ROCM_REPO_API,
         }
         self.ctx.services.load_config = lambda: {

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -495,6 +495,7 @@ class BuildBackendSpecsTests(unittest.TestCase):
         specs = llama_manager.build_backend_specs("win32", "x64")
 
         spec = specs["lemonade-rocm-gfx110X"]
+        self.assertEqual(spec["label"], "ROCm Nightly gfx110X (AMD RDNA3, Lemonade)")
         self.assertEqual(spec["provider"], "lemonade-rocm")
         self.assertEqual(spec["repo_api"], llama_manager.LEMONADE_ROCM_REPO_API)
         self.assertIs(spec["preserve_paths"], True)
@@ -2197,7 +2198,7 @@ class LlamaManagerDownloadTests(unittest.TestCase):
             }
             backend_specs = {
                 "lemonade-rocm-gfx110X": {
-                    "label": "ROCm 7 gfx110X (AMD RDNA3, Lemonade)",
+                    "label": "ROCm Nightly gfx110X (AMD RDNA3, Lemonade)",
                     "asset": "llama-{tag}-windows-rocm-gfx110X-x64.zip",
                     "provider": "lemonade-rocm",
                     "repo_api": llama_manager.LEMONADE_ROCM_REPO_API,


### PR DESCRIPTION
## Summary
- Rename Lemonade architecture-specific install labels from ROCm 7 to ROCm Nightly.
- Update backend tests and changelog to reflect the label change.

## Testing
- Not run (not requested)