### PR TITLE
Add Lemonade stable ROCm 10.0 backend options

### DIFF
--- a/backend/services/llama_manager.py
+++ b/backend/services/llama_manager.py
@@ -122,7 +122,7 @@ def build_backend_specs(current_platform: str, current_arch: str) -> dict[str, A
                 "asset": "llama-{tag}-bin-win-rocm-7.14-x64.zip",
             },
             "lemonade-rocm-10.0": {
-                "label": "ROCm 10.0 (AMD, Lemonade Stable)",
+                "label": "ROCm 10.0 (AMD, Lemonade Stable; separate runtime required)",
                 "asset": "llama-{tag}-bin-win-rocm-10.0-x64.zip",
                 "repo_api": LEMONADE_STABLE_ROCM_REPO_API,
             },
@@ -164,7 +164,7 @@ def build_backend_specs(current_platform: str, current_arch: str) -> dict[str, A
                     "asset": "llama-{tag}-bin-ubuntu-rocm-7.14-x64.tar.gz",
                 },
                 "lemonade-rocm-10.0": {
-                    "label": "ROCm 10.0 (AMD, Lemonade Stable)",
+                    "label": "ROCm 10.0 (AMD, Lemonade Stable; separate runtime required)",
                     "asset": "llama-{tag}-bin-ubuntu-rocm-10.0-x64.tar.gz",
                     "repo_api": LEMONADE_STABLE_ROCM_REPO_API,
                 },

--- a/backend/services/llama_manager.py
+++ b/backend/services/llama_manager.py
@@ -37,6 +37,9 @@ RUNTIME_HEALTH_CACHE_TTL_SECONDS = 5.0
 LEMONADE_ROCM_REPO_API = (
     "https://api.github.com/repos/lemonade-sdk/llamacpp-rocm/releases"
 )
+LEMONADE_STABLE_ROCM_REPO_API = (
+    "https://api.github.com/repos/lemonade-sdk/llama.cpp/releases"
+)
 CUSTOM_BACKEND_SPEC = {"label": "Custom (User-Provided)"}
 
 # (gpu_target, family label) for every target upstream publishes.
@@ -118,6 +121,11 @@ def build_backend_specs(current_platform: str, current_arch: str) -> dict[str, A
                 "label": "ROCm 7.14 (AMD, Official)",
                 "asset": "llama-{tag}-bin-win-rocm-7.14-x64.zip",
             },
+            "lemonade-rocm-10.0": {
+                "label": "ROCm 10.0 (AMD, Lemonade Stable)",
+                "asset": "llama-{tag}-bin-win-rocm-10.0-x64.zip",
+                "repo_api": LEMONADE_STABLE_ROCM_REPO_API,
+            },
             "openvino": {
                 "label": "OpenVINO",
                 "asset": "llama-{tag}-bin-win-openvino-2026.2.1-x64.zip",
@@ -154,6 +162,11 @@ def build_backend_specs(current_platform: str, current_arch: str) -> dict[str, A
                 "rocm": {
                     "label": "ROCm 7.14 (AMD, Official)",
                     "asset": "llama-{tag}-bin-ubuntu-rocm-7.14-x64.tar.gz",
+                },
+                "lemonade-rocm-10.0": {
+                    "label": "ROCm 10.0 (AMD, Lemonade Stable)",
+                    "asset": "llama-{tag}-bin-ubuntu-rocm-10.0-x64.tar.gz",
+                    "repo_api": LEMONADE_STABLE_ROCM_REPO_API,
                 },
                 "openvino": {
                     "label": "OpenVINO",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ Please give a brief summary of changes made to the program (excluding documentat
 
 ## 2026-08-30
 - Renamed the architecture-specific Lemonade install options from ROCm 7 to ROCm Nightly so their labels remain accurate as the bundled TheRock runtime advances.
+- Added Lemonade's stable-fork ROCm 10.0 binaries as one install option on Windows x64 and Linux x64, separate from the architecture-specific Lemonade nightlies.
 
 ## 2026-08-29
 - Moved Llama GUI's in-app update controls beside the llama.cpp installer at the top of Install and Update, tightened both cards into a responsive two-column layout, and removed the backend dropdown's ROCm description.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@ Please give a brief summary of changes made to the program (excluding documentat
 
 ## 2026-08-30
 - Renamed the architecture-specific Lemonade install options from ROCm 7 to ROCm Nightly so their labels remain accurate as the bundled TheRock runtime advances.
-- Added Lemonade's stable-fork ROCm 10.0 binaries as one install option on Windows x64 and Linux x64, separate from the architecture-specific Lemonade nightlies.
+- Added Lemonade's stable-fork ROCm 10.0 binaries as one install option on Windows x64 and Linux x64, separate from the architecture-specific Lemonade nightlies; its label warns that a separate ROCm runtime is required.
 
 ## 2026-08-29
 - Moved Llama GUI's in-app update controls beside the llama.cpp installer at the top of Install and Update, tightened both cards into a responsive two-column layout, and removed the backend dropdown's ROCm description.

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -365,6 +365,7 @@ class BuildBackendSpecsTests(unittest.TestCase):
         self.assertIn("vulkan", specs)
         self.assertIn("sycl", specs)
         self.assertIn("hip", specs)
+        self.assertIn("lemonade-rocm-10.0", specs)
         self.assertIn("openvino", specs)
         self.assertEqual(specs["cpu"]["label"], "CPU")
         self.assertIn("win-cpu-x64", specs["cpu"]["asset"])
@@ -372,6 +373,14 @@ class BuildBackendSpecsTests(unittest.TestCase):
         self.assertEqual(
             specs["hip"]["asset"],
             "llama-{tag}-bin-win-rocm-7.14-x64.zip",
+        )
+        self.assertEqual(
+            specs["lemonade-rocm-10.0"],
+            {
+                "label": "ROCm 10.0 (AMD, Lemonade Stable)",
+                "asset": "llama-{tag}-bin-win-rocm-10.0-x64.zip",
+                "repo_api": llama_manager.LEMONADE_STABLE_ROCM_REPO_API,
+            },
         )
         self.assertIn("openvino-2026.2.1", specs["openvino"]["asset"])
 
@@ -407,11 +416,20 @@ class BuildBackendSpecsTests(unittest.TestCase):
         self.assertIn("cpu", specs)
         self.assertIn("vulkan", specs)
         self.assertIn("rocm", specs)
+        self.assertIn("lemonade-rocm-10.0", specs)
         self.assertIn("openvino", specs)
         self.assertEqual(specs["rocm"]["label"], "ROCm 7.14 (AMD, Official)")
         self.assertEqual(
             specs["rocm"]["asset"],
             "llama-{tag}-bin-ubuntu-rocm-7.14-x64.tar.gz",
+        )
+        self.assertEqual(
+            specs["lemonade-rocm-10.0"],
+            {
+                "label": "ROCm 10.0 (AMD, Lemonade Stable)",
+                "asset": "llama-{tag}-bin-ubuntu-rocm-10.0-x64.tar.gz",
+                "repo_api": llama_manager.LEMONADE_STABLE_ROCM_REPO_API,
+            },
         )
         self.assertIn("openvino-2026.2.1", specs["openvino"]["asset"])
 

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -377,7 +377,7 @@ class BuildBackendSpecsTests(unittest.TestCase):
         self.assertEqual(
             specs["lemonade-rocm-10.0"],
             {
-                "label": "ROCm 10.0 (AMD, Lemonade Stable)",
+                "label": "ROCm 10.0 (AMD, Lemonade Stable; separate runtime required)",
                 "asset": "llama-{tag}-bin-win-rocm-10.0-x64.zip",
                 "repo_api": llama_manager.LEMONADE_STABLE_ROCM_REPO_API,
             },
@@ -426,7 +426,7 @@ class BuildBackendSpecsTests(unittest.TestCase):
         self.assertEqual(
             specs["lemonade-rocm-10.0"],
             {
-                "label": "ROCm 10.0 (AMD, Lemonade Stable)",
+                "label": "ROCm 10.0 (AMD, Lemonade Stable; separate runtime required)",
                 "asset": "llama-{tag}-bin-ubuntu-rocm-10.0-x64.tar.gz",
                 "repo_api": llama_manager.LEMONADE_STABLE_ROCM_REPO_API,
             },


### PR DESCRIPTION
## Summary

- Add Lemonade stable-fork ROCm 10.0 binaries for Windows x64 and Linux x64.
- Keep the stable option separate from architecture-specific Lemonade nightlies.
- Update backend specification tests and the changelog.

## Testing

- Added coverage verifying the new backend specs, labels, assets, and release API.