### PR TITLE
Add Lemonade stable ROCm description

### DIFF
--- a/backend/services/llama_manager.py
+++ b/backend/services/llama_manager.py
@@ -118,7 +118,7 @@ def build_backend_specs(current_platform: str, current_arch: str) -> dict[str, A
                 "asset": "llama-{tag}-bin-win-sycl-x64.zip",
             },
             "hip": {
-                "label": "ROCm 7.14 (AMD, Official)",
+                "label": "ROCm 7.14 (AMD, Official; separate runtime required)",
                 "asset": "llama-{tag}-bin-win-rocm-7.14-x64.zip",
             },
             "lemonade-rocm-10.0": {
@@ -160,7 +160,7 @@ def build_backend_specs(current_platform: str, current_arch: str) -> dict[str, A
                     "asset": "llama-{tag}-bin-ubuntu-vulkan-x64.tar.gz",
                 },
                 "rocm": {
-                    "label": "ROCm 7.14 (AMD, Official)",
+                    "label": "ROCm 7.14 (AMD, Official; separate runtime required)",
                     "asset": "llama-{tag}-bin-ubuntu-rocm-7.14-x64.tar.gz",
                 },
                 "lemonade-rocm-10.0": {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ Please give a brief summary of changes made to the program (excluding documentat
 ## 2026-08-30
 - Renamed the architecture-specific Lemonade install options from ROCm 7 to ROCm Nightly so their labels remain accurate as the bundled TheRock runtime advances.
 - Added Lemonade's stable-fork ROCm 10.0 binaries as one install option on Windows x64 and Linux x64, separate from the architecture-specific Lemonade nightlies; its label warns that a separate ROCm runtime is required.
+- Clarified that the official llama.cpp ROCm 7.14 install options also require a separately installed ROCm runtime.
 
 ## 2026-08-29
 - Moved Llama GUI's in-app update controls beside the llama.cpp installer at the top of Install and Update, tightened both cards into a responsive two-column layout, and removed the backend dropdown's ROCm description.

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -4297,7 +4297,7 @@ class InstallRouteTests(unittest.TestCase):
 
     def test_install_get_releases_filters_selected_backend_to_compatible_assets(self):
         self.ctx.services.backend_specs["rocm"] = {
-            "label": "ROCm 7.14 (AMD, Official)",
+            "label": "ROCm 7.14 (AMD, Official; separate runtime required)",
             "asset": "llama-{tag}-bin-win-rocm-7.14-x64.zip",
         }
         fake_releases = [
@@ -4322,7 +4322,7 @@ class InstallRouteTests(unittest.TestCase):
 
     def test_install_get_releases_pages_past_incompatible_release_window(self):
         self.ctx.services.backend_specs["rocm"] = {
-            "label": "ROCm 7.14 (AMD, Official)",
+            "label": "ROCm 7.14 (AMD, Official; separate runtime required)",
             "asset": "llama-{tag}-bin-ubuntu-rocm-7.14-x64.tar.gz",
         }
         first_page = [

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -369,7 +369,10 @@ class BuildBackendSpecsTests(unittest.TestCase):
         self.assertIn("openvino", specs)
         self.assertEqual(specs["cpu"]["label"], "CPU")
         self.assertIn("win-cpu-x64", specs["cpu"]["asset"])
-        self.assertEqual(specs["hip"]["label"], "ROCm 7.14 (AMD, Official)")
+        self.assertEqual(
+            specs["hip"]["label"],
+            "ROCm 7.14 (AMD, Official; separate runtime required)",
+        )
         self.assertEqual(
             specs["hip"]["asset"],
             "llama-{tag}-bin-win-rocm-7.14-x64.zip",
@@ -418,7 +421,10 @@ class BuildBackendSpecsTests(unittest.TestCase):
         self.assertIn("rocm", specs)
         self.assertIn("lemonade-rocm-10.0", specs)
         self.assertIn("openvino", specs)
-        self.assertEqual(specs["rocm"]["label"], "ROCm 7.14 (AMD, Official)")
+        self.assertEqual(
+            specs["rocm"]["label"],
+            "ROCm 7.14 (AMD, Official; separate runtime required)",
+        )
         self.assertEqual(
             specs["rocm"]["asset"],
             "llama-{tag}-bin-ubuntu-rocm-7.14-x64.tar.gz",


### PR DESCRIPTION
## Summary

- Clarify that official ROCm 7.14 and Lemonade stable binaries require a separate ROCm runtime.
- Update backend specification tests and changelog.

## Testing

- Updated backend service and extracted-route test expectations; tests not run (not requested).