### PR TITLE
Update lazy tensor reading to use llama.cpp's --lazy-mode flag

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
 ## 2026-08-30
+- Updated the Advanced Configure lazy tensor-reading control for llama.cpp PR #27969: it now emits `--lazy-mode` instead of the removed `--tensor-read-lazy` name while preserving existing saved preset values.
 - Renamed the architecture-specific Lemonade install options from ROCm 7 to ROCm Nightly so their labels remain accurate as the bundled TheRock runtime advances.
 - Added Lemonade's stable-fork ROCm 10.0 binaries as one install option on Windows x64 and Linux x64, separate from the architecture-specific Lemonade nightlies; its label warns that a separate ROCm runtime is required.
 - Clarified that the official llama.cpp ROCm 7.14 install options also require a separately installed ROCm runtime.

--- a/tests/frontend/launch_args_unit.cjs
+++ b/tests/frontend/launch_args_unit.cjs
@@ -150,7 +150,7 @@ function launchResult() {
         "--mirostat-ent",
         "--mtmd-batch-max-tokens",
         "--reasoning-format",
-        "--tensor-read-lazy",
+        "--lazy-mode",
     ]) {
         assert.ok(!args.includes(flag), `default launch args should omit ${flag}`);
     }
@@ -219,13 +219,13 @@ function launchResult() {
         window.LlamaGui.flagCore.setFlagValue("tensor_read_lazy", "on");
     `, context);
     let args = flatLaunchArgs();
-    let flagIndex = args.indexOf("--tensor-read-lazy");
+    let flagIndex = args.indexOf("--lazy-mode");
     assert.notEqual(flagIndex, -1);
     assert.equal(args[flagIndex + 1], "on");
 
     vm.runInContext(`window.LlamaGui.flagCore.setFlagValue("tensor_read_lazy", "off")`, context);
     args = flatLaunchArgs();
-    flagIndex = args.indexOf("--tensor-read-lazy");
+    flagIndex = args.indexOf("--lazy-mode");
     assert.notEqual(flagIndex, -1);
     assert.equal(args[flagIndex + 1], "off");
 }

--- a/ui/js/flags/definitions.js
+++ b/ui/js/flags/definitions.js
@@ -1887,12 +1887,12 @@ const FLAGS = [
 	// Advanced
 	{
 		id: "tensor_read_lazy",
-		flag: "--tensor-read-lazy",
+		flag: "--lazy-mode",
 		category: "advanced",
 		type: "enum",
-		label: "Lazy Tensor Reading",
+		label: "Lazy Mode",
 		short_desc: "Read eligible model tensors from disk on demand to reduce resident RAM use.",
-		desc: "Controls on-demand reading for tensors marked as eligible by the model architecture, such as large per-layer embedding tables. Requires mmap. Auto uses llama.cpp's default behavior (lazy only above 4 GiB); On trades some inference speed for lower resident RAM; Off keeps eligible tensors resident. Available in llama.cpp b10653+.",
+		desc: "Controls on-demand reading for tensors marked as eligible by the model architecture, such as large per-layer embedding tables. Requires mmap. Auto uses llama.cpp's default behavior (lazy only above 4 GiB); On trades some inference speed for lower resident RAM; Off keeps eligible tensors resident.",
 		tool: "both",
 		default: "",
 		options: [


### PR DESCRIPTION
## Summary

- Replace the removed `--tensor-read-lazy` flag with `--lazy-mode`.
- Rename the Advanced Configure label to “Lazy Mode” and update its description.
- Preserve compatibility with existing saved `tensor_read_lazy` preset values.
- Update launch argument coverage and changelog documentation.

## Testing

- Updated frontend launch argument unit tests to verify `--lazy-mode` emission and default omission.
- Not run (not requested)