### PR TITLE
Accelerate Hugging Face downloads with Xet transfers

### DIFF
--- a/backend/services/hf_download.py
+++ b/backend/services/hf_download.py
@@ -137,18 +137,36 @@ def get_hf_gguf_files(repo_id: str, revision: str = "main", token: Optional[str]
 
 
 def get_hf_file_size(repo_id: str, filename: str, revision: str, token: Optional[str] = None) -> int:
+    metadata = get_hf_download_metadata(repo_id, filename, revision, token)
     try:
-        from huggingface_hub import get_hf_file_metadata, hf_hub_url
-    except ImportError:
+        return int(metadata.size or 0) if metadata is not None else 0
+    except (TypeError, ValueError):
         return 0
 
+
+def get_hf_download_metadata(
+    repo_id: str,
+    filename: str,
+    revision: str,
+    token: Optional[str] = None,
+) -> Any:
     try:
-        url = hf_hub_url(repo_id=repo_id, filename=filename, revision=revision)
-        metadata = get_hf_file_metadata(url, token=token or False, timeout=20)
-        return int(metadata.size or 0)
+        from huggingface_hub import get_hf_file_metadata
+    except ImportError:
+        return None
+
+    try:
+        return get_hf_file_metadata(
+            build_hf_download_url(repo_id, filename, revision),
+            token=token or False,
+            timeout=20,
+        )
     except Exception as exc:
-        print(f"[hf_download] failed to read file size for {repo_id}/{filename}: {exc}", file=sys.stderr)
-        return 0
+        print(
+            f"[hf_download] failed to read file metadata for {repo_id}/{filename}: {exc}",
+            file=sys.stderr,
+        )
+        return None
 
 
 def build_hf_download_url(repo_id: str, filename: str, revision: str) -> str:
@@ -201,9 +219,16 @@ def cancel_hf_model_download(ctx: AppContext) -> Mapping[str, Any]:
         }:
             return snapshot
         ctx.state.model_download_cancel.set()
-        return ctx.state.model_download.update(
+        xet_group = ctx.state.model_download_xet_group
+        snapshot = ctx.state.model_download.update(
             status="cancelling", message="Cancelling download..."
         )
+    if xet_group is not None:
+        try:
+            xet_group.abort()
+        except Exception as exc:
+            print(f"[hf_download] failed to abort Xet download: {exc}", file=sys.stderr)
+    return snapshot
 
 
 def _content_length(resp: Any) -> Optional[int]:
@@ -217,6 +242,91 @@ def _content_length(resp: Any) -> Optional[int]:
     return size if size >= 0 else None
 
 
+def download_hf_file_xet(
+    ctx: AppContext,
+    filename: str,
+    token: Optional[str],
+    dest: pathlib.Path,
+    completed_bytes: int,
+    total_bytes: int,
+    metadata: Any,
+) -> Optional[int]:
+    """Use Xet's concurrent range downloader when the file and runtime support it."""
+    xet_data = getattr(metadata, "xet_file_data", None)
+    try:
+        expected_bytes = int(getattr(metadata, "size", 0) or 0)
+    except (TypeError, ValueError):
+        expected_bytes = 0
+    if xet_data is None or expected_bytes <= 0:
+        return None
+
+    try:
+        import hf_xet
+        from huggingface_hub import constants as hf_constants
+    except ImportError:
+        return None
+    if getattr(hf_constants, "HF_HUB_DISABLE_XET", False):
+        return None
+    session_type = getattr(hf_xet, "XetSession", None)
+    file_info_type = getattr(hf_xet, "XetFileInfo", None)
+    if not callable(session_type) or not callable(file_info_type):
+        return None
+
+    tmp_path = dest.with_suffix(dest.suffix + ".part")
+    tmp_path.unlink(missing_ok=True)
+    headers = {"User-Agent": "Llama-GUI"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    def _update_progress(group_report: Any, _item_reports: Any = None) -> None:
+        downloaded = int(getattr(group_report, "total_bytes_completed", 0) or 0)
+        set_model_download_state(
+            ctx,
+            downloaded=completed_bytes + min(downloaded, expected_bytes),
+            total=total_bytes,
+            current_file=pathlib.PurePosixPath(filename).name,
+        )
+
+    group = session_type().new_file_download_group(
+        token_refresh_url=xet_data.refresh_route,
+        token_refresh_headers=headers,
+        custom_headers={"User-Agent": "Llama-GUI"},
+        progress_callback=_update_progress,
+    )
+    try:
+        with group:
+            with ctx.state.model_download_lock:
+                ctx.state.model_download_xet_group = group
+                cancelled = ctx.state.model_download_cancel.is_set()
+            if cancelled:
+                raise InterruptedError("Download cancelled.")
+            group.start_download_file(
+                file_info_type(xet_data.file_hash, expected_bytes),
+                str(tmp_path),
+            )
+    except InterruptedError:
+        raise
+    except Exception as exc:
+        if ctx.state.model_download_cancel.is_set():
+            raise InterruptedError("Download cancelled.") from exc
+        raise
+    finally:
+        with ctx.state.model_download_lock:
+            if ctx.state.model_download_xet_group is group:
+                ctx.state.model_download_xet_group = None
+
+    if ctx.state.model_download_cancel.is_set():
+        raise InterruptedError("Download cancelled.")
+    actual_bytes = tmp_path.stat().st_size
+    if actual_bytes != expected_bytes:
+        raise OSError(
+            f"Download of {filename} was incomplete: got {actual_bytes} bytes, "
+            f"expected {expected_bytes}."
+        )
+    tmp_path.replace(dest)
+    return actual_bytes
+
+
 def download_hf_file(
     ctx: AppContext,
     repo_id: str,
@@ -227,7 +337,20 @@ def download_hf_file(
     completed_bytes: int,
     total_bytes: int,
     urlopen: UrlOpen = urllib.request.urlopen,
+    metadata: Any = None,
 ) -> int:
+    xet_downloaded = download_hf_file_xet(
+        ctx,
+        filename,
+        token,
+        dest,
+        completed_bytes,
+        total_bytes,
+        metadata,
+    )
+    if xet_downloaded is not None:
+        return xet_downloaded
+
     url = build_hf_download_url(repo_id, filename, revision)
     headers = {"User-Agent": "Llama-GUI"}
     if token:
@@ -327,9 +450,12 @@ def start_hf_model_download(
             destinations.append(mmproj_dest)
         try:
             model_dest.parent.mkdir(parents=True, exist_ok=True)
-            total = get_hf_file_size(repo_id, model_file, revision, token)
+            model_metadata = get_hf_download_metadata(repo_id, model_file, revision, token)
+            total = int(getattr(model_metadata, "size", 0) or 0)
+            mmproj_metadata = None
             if mmproj_file:
-                total += get_hf_file_size(repo_id, mmproj_file, revision, token)
+                mmproj_metadata = get_hf_download_metadata(repo_id, mmproj_file, revision, token)
+                total += int(getattr(mmproj_metadata, "size", 0) or 0)
             reset_model_download_state(
                 ctx,
                 status="downloading",
@@ -337,7 +463,18 @@ def start_hf_model_download(
                 total=total,
                 downloaded=0,
             )
-            completed = download_hf_file(ctx, repo_id, model_file, revision, token, model_dest, 0, total, urlopen)
+            completed = download_hf_file(
+                ctx,
+                repo_id,
+                model_file,
+                revision,
+                token,
+                model_dest,
+                0,
+                total,
+                urlopen,
+                model_metadata,
+            )
             mmproj_path = ""
             if mmproj_file and mmproj_dest:
                 set_model_download_state(ctx, message=f"Downloading {mmproj_dest.name}...")
@@ -351,6 +488,7 @@ def start_hf_model_download(
                     completed,
                     total,
                     urlopen,
+                    mmproj_metadata,
                 )
                 mmproj_path = str(mmproj_dest)
             set_model_download_state(
@@ -377,6 +515,7 @@ def start_hf_model_download(
             )
         finally:
             with ctx.state.model_download_lock:
+                ctx.state.model_download_xet_group = None
                 ctx.state.model_download_in_progress = False
                 ctx.state.model_download_cancel.clear()
 
@@ -384,6 +523,7 @@ def start_hf_model_download(
         threading.Thread(target=_worker, daemon=True).start()
     except Exception as exc:
         with ctx.state.model_download_lock:
+            ctx.state.model_download_xet_group = None
             ctx.state.model_download_in_progress = False
             ctx.state.model_download_cancel.clear()
         set_model_download_state(

--- a/backend/state.py
+++ b/backend/state.py
@@ -118,6 +118,7 @@ class ServerState:
     model_download_in_progress: bool = False
     model_download_lock: threading.Lock = field(default_factory=threading.Lock)
     model_download_cancel: threading.Event = field(default_factory=threading.Event)
+    model_download_xet_group: Any = None
 
     gui_server: Any = None
     remote_tunnel_process: Any = None

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
 ## 2026-08-30
+- Corrected the Xet downloader dependency bounds to versions published on PyPI with Python 3.9 wheels, keeping Linux CI and older supported Python installs resolvable.
 - Accelerated Hugging Face model and projector downloads with the standard Xet concurrent range-transfer backend when available, while preserving progress, scoped cancellation, atomic partial-file handling, and the existing HTTP fallback on unsupported systems.
 - Updated the Advanced Configure lazy tensor-reading control for llama.cpp PR #27969: it now emits `--lazy-mode` instead of the removed `--tensor-read-lazy` name while preserving existing saved preset values.
 - Renamed the architecture-specific Lemonade install options from ROCm 7 to ROCm Nightly so their labels remain accurate as the bundled TheRock runtime advances.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
 ## 2026-08-30
+- Accelerated Hugging Face model and projector downloads with the standard Xet concurrent range-transfer backend when available, while preserving progress, scoped cancellation, atomic partial-file handling, and the existing HTTP fallback on unsupported systems.
 - Updated the Advanced Configure lazy tensor-reading control for llama.cpp PR #27969: it now emits `--lazy-mode` instead of the removed `--tensor-read-lazy` name while preserving existing saved preset values.
 - Renamed the architecture-specific Lemonade install options from ROCm 7 to ROCm Nightly so their labels remain accurate as the bundled TheRock runtime advances.
 - Added Lemonade's stable-fork ROCm 10.0 binaries as one install option on Windows x64 and Linux x64, separate from the architecture-specific Lemonade nightlies; its label warns that a separate ROCm runtime is required.

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -648,7 +648,7 @@ Model discovery, Open Models, model-related file pickers, and HF model/projector
 ### Backend API
 
 - `POST /api/hf/repo-files`: Takes `repo_id`, `revision`, `token`. Uses `huggingface_hub.HfApi.model_info()` to list GGUF files. Returns separated model and mmproj file lists.
-- `POST /api/hf/download`: Takes `repo_id`, `revision`, `model_file`, `mmproj_file`, `token`, `overwrite`. Downloads in a background thread with cancellation support. Validates filenames and repo IDs.
+- `POST /api/hf/download`: Takes `repo_id`, `revision`, `model_file`, `mmproj_file`, `token`, `overwrite`. Downloads in a background thread with cancellation support. Xet-backed files use concurrent range transfers with scoped group cancellation; unsupported or non-Xet files retain the streaming HTTP fallback. Validates filenames and repo IDs.
 - `GET /api/hf/download-status`: Returns current download progress (total, downloaded, status, current_file, model_name, model_path, mmproj_path).
 - `POST /api/hf/download-cancel`: Sets cancellation event to abort in-progress download.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 certifi>=2026.5.20
 ddgs>=7.0.0
-huggingface_hub>=0.24.0
+huggingface_hub>=1.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 certifi>=2026.5.20
 ddgs>=7.0.0
-huggingface_hub>=1.24.0
+huggingface_hub>=0.32.0
+hf-xet>=1.5.1,<2.0.0

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -3480,6 +3480,127 @@ class DownloadHfFileLengthTests(unittest.TestCase):
             self.assertEqual(dest.read_bytes(), b"abc")
 
 
+class DownloadHfFileXetTests(unittest.TestCase):
+    @staticmethod
+    def _fake_xet(payload, on_start=None):
+        calls = {}
+
+        class FakeGroup:
+            def __init__(self, progress_callback):
+                self.progress_callback = progress_callback
+                self.abort_calls = 0
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                if exc_type is not None:
+                    self.abort()
+                return False
+
+            def start_download_file(self, file_info, dest_path):
+                calls["file_info"] = file_info
+                calls["dest_path"] = dest_path
+                if on_start is not None:
+                    on_start(self)
+                pathlib.Path(dest_path).write_bytes(payload)
+                self.progress_callback(
+                    SimpleNamespace(total_bytes_completed=len(payload)),
+                    {},
+                )
+
+            def abort(self):
+                self.abort_calls += 1
+
+        class FakeSession:
+            def new_file_download_group(self, **kwargs):
+                calls["group_kwargs"] = kwargs
+                group = FakeGroup(kwargs["progress_callback"])
+                calls["group"] = group
+                return group
+
+        return SimpleNamespace(
+            XetSession=FakeSession,
+            XetFileInfo=lambda file_hash, size: (file_hash, size),
+        ), calls
+
+    def test_uses_xet_progress_and_preserves_destination_layout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            payload = b"xet-gguf"
+            dest = pathlib.Path(tmp) / "model.gguf"
+            metadata = SimpleNamespace(
+                size=len(payload),
+                xet_file_data=SimpleNamespace(
+                    file_hash="xet-hash",
+                    refresh_route="https://example.test/xet-token",
+                ),
+            )
+            fake_xet, calls = self._fake_xet(payload)
+
+            with mock.patch.dict("sys.modules", {"hf_xet": fake_xet}):
+                downloaded = hf_service.download_hf_file(
+                    ctx,
+                    repo_id="owner/model",
+                    filename="Q4/model.gguf",
+                    revision="main",
+                    token="hf_test",
+                    dest=dest,
+                    completed_bytes=4,
+                    total_bytes=4 + len(payload),
+                    urlopen=lambda *_args, **_kwargs: self.fail("HTTP fallback used"),
+                    metadata=metadata,
+                )
+
+            self.assertEqual(downloaded, len(payload))
+            self.assertEqual(dest.read_bytes(), payload)
+            self.assertFalse(dest.with_suffix(".gguf.part").exists())
+            self.assertEqual(calls["file_info"], ("xet-hash", len(payload)))
+            self.assertEqual(
+                calls["group_kwargs"]["token_refresh_headers"]["Authorization"],
+                "Bearer hf_test",
+            )
+            snapshot = hf_service.get_model_download_snapshot(ctx)
+            self.assertEqual(snapshot["downloaded"], 4 + len(payload))
+            self.assertEqual(snapshot["total"], 4 + len(payload))
+            self.assertEqual(snapshot["current_file"], "model.gguf")
+            self.assertIsNone(ctx.state.model_download_xet_group)
+
+    def test_cancel_aborts_active_xet_group(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_service_context(tmp)
+            ctx.state.model_download_in_progress = True
+            ctx.state.model_download.update(status="downloading")
+            metadata = SimpleNamespace(
+                size=8,
+                xet_file_data=SimpleNamespace(
+                    file_hash="xet-hash",
+                    refresh_route="https://example.test/xet-token",
+                ),
+            )
+
+            def cancel_after_start(_group):
+                hf_service.cancel_hf_model_download(ctx)
+                raise RuntimeError("Xet group aborted")
+
+            fake_xet, calls = self._fake_xet(b"xet-gguf", cancel_after_start)
+            with mock.patch.dict("sys.modules", {"hf_xet": fake_xet}):
+                with self.assertRaises(InterruptedError):
+                    hf_service.download_hf_file_xet(
+                        ctx,
+                        filename="model.gguf",
+                        token=None,
+                        dest=pathlib.Path(tmp) / "model.gguf",
+                        completed_bytes=0,
+                        total_bytes=8,
+                        metadata=metadata,
+                    )
+
+            self.assertGreaterEqual(calls["group"].abort_calls, 1)
+            self.assertTrue(ctx.state.model_download_cancel.is_set())
+            self.assertIsNone(ctx.state.model_download_xet_group)
+
+
 class StartHfModelDownloadPathTests(unittest.TestCase):
     def test_downloads_into_repo_subfolder(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -3490,7 +3611,11 @@ class StartHfModelDownloadPathTests(unittest.TestCase):
                 return FakeDownloadResponse([payload], content_length=len(payload))
 
             with (
-                mock.patch.object(hf_service, "get_hf_file_size", return_value=len(payload)),
+                mock.patch.object(
+                    hf_service,
+                    "get_hf_download_metadata",
+                    return_value=SimpleNamespace(size=len(payload), xet_file_data=None),
+                ),
                 mock.patch.object(
                     hf_service,
                     "build_hf_download_url",
@@ -3563,12 +3688,18 @@ class StartHfModelDownloadPathTests(unittest.TestCase):
                 def start(self):
                     self.target()
 
-            with mock.patch.object(hf_service.threading, "Thread", ImmediateThread), mock.patch.object(
-                hf_service, "get_hf_file_size", return_value=len(payload)
-            ), mock.patch.object(
-                hf_service,
-                "build_hf_download_url",
-                return_value="https://example.test/model.gguf",
+            with (
+                mock.patch.object(hf_service.threading, "Thread", ImmediateThread),
+                mock.patch.object(
+                    hf_service,
+                    "get_hf_download_metadata",
+                    return_value=SimpleNamespace(size=len(payload), xet_file_data=None),
+                ),
+                mock.patch.object(
+                    hf_service,
+                    "build_hf_download_url",
+                    return_value="https://example.test/model.gguf",
+                ),
             ):
                 hf_service.start_hf_model_download(
                     ctx,
@@ -3605,7 +3736,7 @@ class StartHfModelDownloadPathTests(unittest.TestCase):
                 hf_service.threading, "Thread", ImmediateThread
             ), mock.patch.object(
                 hf_service,
-                "get_hf_file_size",
+                "get_hf_download_metadata",
                 side_effect=RuntimeError("private download failure"),
             ):
                 snapshot = hf_service.start_hf_model_download(


### PR DESCRIPTION
## Summary

- Add Xet concurrent range downloads for supported Hugging Face files.
- Preserve HTTP streaming fallback, progress reporting, atomic partial-file handling, and cancellation.
- Upgrade `huggingface_hub` and add backend coverage for Xet behavior.
- Update project documentation and changelog.

## Testing

- Added unit tests for Xet progress, destination handling, and cancellation.
- Existing backend service tests updated for metadata-based downloads.