### PR TITLE
Align llama.cpp controls with current CLI and server options

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,11 @@
 
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
+## 2026-08-31
+- Removed llama-cli's obsolete `-cnv` Conversation Mode control; the existing supported `-st` Single Turn control remains available, and current llama-cli stays conversational by default.
+- Updated llama-server's built-in tool choices by removing the retired `get_datetime`, adding `get_info`, and preventing stale multi-select values from being emitted in launch commands.
+- Aligned Model Load Mode with current llama.cpp: Auto is now the default, `mmap+mlock` is selectable, and `mlock` is correctly labeled as lock-only without mmap.
+
 ## 2026-08-30
 - Corrected the Xet downloader dependency bounds to versions published on PyPI with Python 3.9 wheels, keeping Linux CI and older supported Python installs resolvable.
 - Accelerated Hugging Face model and projector downloads with the standard Xet concurrent range-transfer backend when available, while preserving progress, scoped cancellation, atomic partial-file handling, and the existing HTTP fallback on unsupported systems.

--- a/docs/upstream-changes.md
+++ b/docs/upstream-changes.md
@@ -4,6 +4,14 @@ Track announced llama.cpp changes that may require coordinated Llama-GUI updates
 
 ## Pending
 
+### Unified KV per-slot context cap (`--kv-unified-per-slot`) — deferred
+
+- **Upstream:** [ggml-org/llama.cpp#24124](https://github.com/ggml-org/llama.cpp/pull/24124), merged on 2026-08-27 as commit `1844325`.
+- **Behavior:** Sets a maximum context length for each parallel server slot while retaining one unified KV pool. For example, `--parallel 4 --kv-unified-per-slot 16000` creates a 64K shared pool when `-c` / `--ctx-size` is omitted, while preventing any one slot from exceeding 16K tokens.
+- **Use case:** Gives multi-user servers predictable per-request context limits and prevents one unusually large prompt from monopolizing the shared KV cache. It adds little beyond `--ctx-size` for a single-slot server.
+- **Local interaction:** Llama-GUI currently emits its default `-c 64000`, so merely adding `--kv-unified-per-slot 16000` would keep the 64K pool and apply only the 16K per-slot cap. Upstream auto-sizing to `parallel × per-slot` requires omitting `-c` entirely; explicitly passing `-c 0` also prevents auto-sizing.
+- **Deferred decision:** If implemented, add an optional server integer beside the existing unified-KV controls. Decide whether it is intentionally cap-only or whether shared launch generation should omit `-c` while the per-slot value is active. Keep all writes in shared flag state and cover the command preview / launch arguments in `launch_args_unit.cjs` and `npm run test:frontend`.
+
 ### Native reasoning-effort support — residual compatibility window - - - Done
 
 - **Upstream:** [ggml-org/llama.cpp#26941](https://github.com/ggml-org/llama.cpp/pull/26941), merged on 2026-08-14 as commit `7e4c0a9`, first release `b10434`.
@@ -49,4 +57,4 @@ Track announced llama.cpp changes that may require coordinated Llama-GUI updates
 - **Recheck when:** Upstream changes the actual default or a bundled llama.cpp release includes that change.
 - **Local decision:** Either keep Llama-GUI's explicit 8080 default or change the frontend, backend target fallback, external-server form, tests, and documentation to 9931 together.
 
-Last checked: 2026-08-25.
+Last checked: 2026-08-31.

--- a/tests/frontend/flag_definitions_unit.cjs
+++ b/tests/frontend/flag_definitions_unit.cjs
@@ -233,7 +233,6 @@ const current = loadCurrentDefinitions();
 assert.deepEqual(validateFlags(current.flags, current.categories), {
     errors: [],
     warnings: [
-        'Category id "conversation" collides with flag id "conversation".',
         'Category id "lora" collides with flag id "lora".',
         'Category id "grammar" collides with flag id "grammar".',
     ],
@@ -258,6 +257,20 @@ assert.equal(nCpuFfn.tool, "both");
 
     const tools = current.flags.find((flag) => flag.id === "tools");
     assert.ok(!tools.options.some((option) => option.value === "apply_diff"));
+    assert.ok(!tools.options.some((option) => option.value === "get_datetime"));
+    assert.ok(tools.options.some((option) => option.value === "get_info"));
+
+    const loadMode = current.flags.find((flag) => flag.id === "load_mode");
+    assert.equal(loadMode.default, "auto");
+    assert.deepEqual(
+        Array.from(loadMode.options, (option) => option.value),
+        ["", "auto", "none", "mmap", "mlock", "mmap+mlock", "dio"]
+    );
+
+    const singleTurn = current.flags.find((flag) => flag.id === "single_turn");
+    assert.equal(singleTurn.flag, "-st");
+    assert.equal(singleTurn.tool, "cli");
+    assert.ok(!current.flags.some((flag) => flag.id === "conversation" || flag.flag === "-cnv"));
 }
 
 // Configure keeps exactly these six sampling flags at the top level; every other sampling

--- a/tests/frontend/launch_args_unit.cjs
+++ b/tests/frontend/launch_args_unit.cjs
@@ -67,6 +67,21 @@ function launchResult() {
 }
 
 {
+    vm.runInContext(`
+        window.LlamaGui.flagCore.setCurrentToolValue("llama-cli");
+        window.LlamaGui.flagCore.replaceFlagValues(getDefaultValues());
+        window.LlamaGui.flagCore.setFlagValue("single_turn", true);
+    `, context);
+    const args = flatLaunchArgs();
+    assert.ok(args.includes("-st"));
+    assert.ok(!args.includes("-cnv"));
+    vm.runInContext(`
+        window.LlamaGui.flagCore.setCurrentToolValue("llama-server");
+        window.LlamaGui.flagCore.replaceFlagValues(getDefaultValues());
+    `, context);
+}
+
+{
     vm.runInContext(
         'window.LlamaGui.flagCore.setFlagValue("mmproj_device", "Vulkan0")',
         context
@@ -128,7 +143,7 @@ function launchResult() {
         false,
         "deprecated mmap control should be disabled by default"
     );
-    assert.ok(args.includes("--load-mode") && args.includes("mmap"), "default launch args should use mmap load mode");
+    assert.ok(args.includes("--load-mode") && args.includes("auto"), "default launch args should use auto load mode");
     assert.ok(!args.includes("--mmap") && !args.includes("--no-mmap"), "default launch args should not use deprecated mmap flags");
     assert.ok(args.includes("--jinja"), "default launch args should reflect llama.cpp's enabled Jinja default");
     assert.ok(!args.includes("--no-jinja"), "default launch args should not disable Jinja");
@@ -205,12 +220,35 @@ function launchResult() {
 {
     vm.runInContext(`
         window.LlamaGui.flagCore.replaceFlagValues(getDefaultValues());
-        window.LlamaGui.flagCore.setFlagValue("load_mode", "dio");
     `, context);
-    const args = flatLaunchArgs();
+    let args = flatLaunchArgs();
+    let loadModeIndex = args.indexOf("--load-mode");
+    assert.notEqual(loadModeIndex, -1);
+    assert.equal(args[loadModeIndex + 1], "auto");
+
+    vm.runInContext(`window.LlamaGui.flagCore.setFlagValue("load_mode", "mmap+mlock")`, context);
+    args = flatLaunchArgs();
+    loadModeIndex = args.indexOf("--load-mode");
+    assert.equal(args[loadModeIndex + 1], "mmap+mlock");
+
+    vm.runInContext(`window.LlamaGui.flagCore.setFlagValue("load_mode", "dio")`, context);
+    args = flatLaunchArgs();
     assert.ok(args.includes("--load-mode") && args.includes("dio"));
     assert.ok(!args.includes("--mmap") && !args.includes("--no-mmap"));
     assert.ok(!args.includes("--mlock") && !args.includes("-dio"));
+}
+
+{
+    vm.runInContext(`
+        window.LlamaGui.flagCore.replaceFlagValues(getDefaultValues());
+        window.LlamaGui.flagCore.setFlagValue("tools", ["get_datetime", "get_info"]);
+    `, context);
+    const result = launchResult();
+    const args = Array.from(result.args).flat().map(String);
+    const toolsIndex = args.indexOf("--tools");
+    assert.notEqual(toolsIndex, -1);
+    assert.equal(args[toolsIndex + 1], "get_info");
+    assert.ok(Array.from(result.warnings).some((warning) => warning.includes('get_datetime')));
 }
 
 {
@@ -867,7 +905,7 @@ console.log("launch args unit tests passed");
     assert.equal(
         vm.runInContext("window.LlamaGui.flagCore.getFlagValues().load_mode", context),
         "",
-        "loading the preset must restore Legacy controls, not the mmap default"
+        "loading the preset must restore Legacy controls, not the auto default"
     );
     const roundTripArgs = flatLaunchArgs();
     assert.ok(roundTripArgs.includes("--mlock"), "legacy mlock must survive a Legacy-controls preset round-trip");

--- a/ui/js/config-flags-ui.js
+++ b/ui/js/config-flags-ui.js
@@ -486,7 +486,7 @@
             } else if (f.id === "load_mode") {
                 // "" ("Legacy controls") is a deliberate choice, not "unset":
                 // undefined would delete the key, so a saved preset would lose
-                // it and loading would resurrect the "mmap" default, silently
+                // it and loading would resurrect the "auto" default, silently
                 // suppressing the legacy mlock/mmap/direct_io switches saved
                 // alongside it.
                 getFlagCore().setFlagValue(f.id, sel.value);

--- a/ui/js/flag-core.js
+++ b/ui/js/flag-core.js
@@ -575,9 +575,14 @@
                     args.push([f.flag]);
                 }
             } else if (f.type === "multi_enum") {
-                const values = normalizeMultiEnumValue(val);
-                if (values.length > 0) {
-                    args.push([f.flag, values.join(",")]);
+                const selectedValues = normalizeMultiEnumValue(val);
+                const allowedValues = new Set((f.options || []).map(option => String(option.value)));
+                const supportedValues = selectedValues.filter(value => allowedValues.has(value));
+                for (const value of selectedValues.filter(value => !allowedValues.has(value))) {
+                    warnings.push(`Unsupported ${f.label || f.id} value "${value}" — omitted.`);
+                }
+                if (supportedValues.length > 0) {
+                    args.push([f.flag, supportedValues.join(",")]);
                 }
             } else if (f.type === "text_list") {
                 const items = Array.isArray(val) ? val : String(val).split(/\r?\n/);

--- a/ui/js/flags/categories.js
+++ b/ui/js/flags/categories.js
@@ -1,4 +1,4 @@
-// NOTE: "conversation", "lora", and "grammar" are used as both category ids and flag ids.
+// NOTE: "lora" and "grammar" are used as both category ids and flag ids.
 // This is intentional and harmless: categories and flags occupy separate data domains
 // (FLAG_CATEGORIES vs FLAGS). The structural definition test explicitly allows these collisions.
 // Do not add another collision without reviewing tests/frontend/flag_definitions_unit.cjs.

--- a/ui/js/flags/definitions.js
+++ b/ui/js/flags/definitions.js
@@ -229,12 +229,14 @@ const FLAGS = [
 		short_desc: "Choose llama.cpp's model loading strategy.",
 		desc: "Preferred replacement for the deprecated mmap, mlock, and Direct I/O switches. Selecting a mode suppresses those legacy arguments in the generated command.",
 		tool: "both",
-		default: "mmap",
+		default: "auto",
 		options: [
 			{ value: "", label: "Legacy controls" },
+			{ value: "auto", label: "Auto (Recommended)" },
 			{ value: "none", label: "None" },
 			{ value: "mmap", label: "Memory map" },
-			{ value: "mlock", label: "Memory map + lock" },
+			{ value: "mlock", label: "Lock in RAM (No mmap)" },
+			{ value: "mmap+mlock", label: "Memory map + lock" },
 			{ value: "dio", label: "Direct I/O" },
 		],
 	},
@@ -1038,16 +1040,6 @@ const FLAGS = [
 
 	// Conversation & Chat
 	{
-		id: "conversation",
-		flag: "-cnv",
-		category: "conversation",
-		type: "bool",
-		label: "Conversation Mode",
-		desc: "Run in interactive conversation mode",
-		tool: "cli",
-		default: false,
-	},
-	{
 		id: "system_prompt",
 		flag: "-sys",
 		category: "conversation",
@@ -1211,7 +1203,7 @@ const FLAGS = [
 		category: "conversation",
 		type: "bool",
 		label: "Single Turn",
-		desc: "Run for a single turn then exit",
+		desc: "Exit after one response instead of continuing the interactive CLI conversation.",
 		tool: "cli",
 		default: false,
 	},
@@ -1719,7 +1711,7 @@ const FLAGS = [
 			},
 			{ value: "write_file", label: "Write File", risk: "high" },
 			{ value: "edit_file", label: "Edit File", risk: "high" },
-			{ value: "get_datetime", label: "Get Date & Time" },
+			{ value: "get_info", label: "Get Runtime Info" },
 		],
 	},
 	{


### PR DESCRIPTION
## Summary

- Remove the obsolete llama-cli Conversation Mode (`-cnv`) control while retaining Single Turn (`-st`).
- Update server tool choices, replacing `get_datetime` with `get_info`.
- Filter unsupported stale multi-select values and warn when omitting them from launch commands.
- Make Auto the default Model Load Mode and add `mmap+mlock` with corrected labels.
- Update changelog and upstream tracking documentation.

## Testing

- Expanded frontend flag-definition and launch-argument unit coverage for the updated controls and compatibility behavior.