### PR TITLE
Add server-only per-slot context limit for unified KV cache

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,9 @@
 
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
+## 2026-09-01
+- Added an optional server-only Per-Slot Context Limit control for unified KV cache deployments. It emits `--kv-unified-per-slot` while preserving the configured total context window, giving concurrent slots a predictable maximum without enabling upstream automatic pool sizing.
+
 ## 2026-08-31
 - Removed llama-cli's obsolete `-cnv` Conversation Mode control; the existing supported `-st` Single Turn control remains available, and current llama-cli stays conversational by default.
 - Updated llama-server's built-in tool choices by removing the retired `get_datetime`, adding `get_info`, and preventing stale multi-select values from being emitted in launch commands.

--- a/docs/upstream-changes.md
+++ b/docs/upstream-changes.md
@@ -4,14 +4,6 @@ Track announced llama.cpp changes that may require coordinated Llama-GUI updates
 
 ## Pending
 
-### Unified KV per-slot context cap (`--kv-unified-per-slot`) — deferred
-
-- **Upstream:** [ggml-org/llama.cpp#24124](https://github.com/ggml-org/llama.cpp/pull/24124), merged on 2026-08-27 as commit `1844325`.
-- **Behavior:** Sets a maximum context length for each parallel server slot while retaining one unified KV pool. For example, `--parallel 4 --kv-unified-per-slot 16000` creates a 64K shared pool when `-c` / `--ctx-size` is omitted, while preventing any one slot from exceeding 16K tokens.
-- **Use case:** Gives multi-user servers predictable per-request context limits and prevents one unusually large prompt from monopolizing the shared KV cache. It adds little beyond `--ctx-size` for a single-slot server.
-- **Local interaction:** Llama-GUI currently emits its default `-c 64000`, so merely adding `--kv-unified-per-slot 16000` would keep the 64K pool and apply only the 16K per-slot cap. Upstream auto-sizing to `parallel × per-slot` requires omitting `-c` entirely; explicitly passing `-c 0` also prevents auto-sizing.
-- **Deferred decision:** If implemented, add an optional server integer beside the existing unified-KV controls. Decide whether it is intentionally cap-only or whether shared launch generation should omit `-c` while the per-slot value is active. Keep all writes in shared flag state and cover the command preview / launch arguments in `launch_args_unit.cjs` and `npm run test:frontend`.
-
 ### Native reasoning-effort support — residual compatibility window - - - Done
 
 - **Upstream:** [ggml-org/llama.cpp#26941](https://github.com/ggml-org/llama.cpp/pull/26941), merged on 2026-08-14 as commit `7e4c0a9`, first release `b10434`.

--- a/tests/frontend/flag_sync_smoke.cjs
+++ b/tests/frontend/flag_sync_smoke.cjs
@@ -685,6 +685,25 @@ async function main() {
         });
         await page.waitForFunction(() => window.LlamaGui.flagCore.getFlagValues().ctx_size === 100000);
         assert.match(await page.textContent("#command-preview-text"), /-c 100000/);
+
+        await page.fill("#config-search", "per-slot context");
+        await page.waitForSelector("#flag-kv_unified_per_slot", { state: "visible" });
+        assert.equal(await page.locator("#flag-kv_unified_per_slot").getAttribute("min"), "1");
+        await page.fill("#flag-kv_unified_per_slot", "16000");
+        await page.waitForFunction(() => window.LlamaGui.flagCore.getFlagValues().kv_unified_per_slot === 16000);
+        assert.match(await page.textContent("#command-preview-text"), /--kv-unified-per-slot 16000/);
+        assert.match(await page.textContent("#command-preview-text"), /-c 100000/);
+
+        await page.evaluate(() => window.LlamaGui.flagCore.setFlagValue("kv_unified", "disabled"));
+        await page.waitForFunction(() => document.querySelector("#flag-kv_unified_per_slot")?.disabled === true);
+        assert.doesNotMatch(await page.textContent("#command-preview-text"), /--kv-unified-per-slot/);
+        await page.evaluate(() => window.LlamaGui.flagCore.setFlagValue("kv_unified", "enabled"));
+        await page.waitForFunction(() => document.querySelector("#flag-kv_unified_per_slot")?.disabled === false);
+        assert.match(await page.textContent("#command-preview-text"), /--kv-unified-per-slot 16000/);
+
+        await page.fill("#flag-kv_unified_per_slot", "");
+        await page.waitForFunction(() => window.LlamaGui.flagCore.getFlagValues().kv_unified_per_slot === undefined);
+        await page.fill("#config-search", "");
         assert.equal(await page.inputValue("#flag-chat_template"), "phi4");
         await page.evaluate(() => {
             window.LlamaGui.flagCore.setMultipleFlagValues({

--- a/tests/frontend/launch_args_unit.cjs
+++ b/tests/frontend/launch_args_unit.cjs
@@ -93,6 +93,42 @@ function launchResult() {
 }
 
 {
+    let args = flatLaunchArgs();
+    assert.ok(!args.includes("--kv-unified-per-slot"), "unset per-slot KV cap should be omitted");
+
+    vm.runInContext(
+        'window.LlamaGui.flagCore.setFlagValue("kv_unified_per_slot", 16000)',
+        context
+    );
+    args = flatLaunchArgs();
+    const perSlotIndex = args.indexOf("--kv-unified-per-slot");
+    assert.notEqual(perSlotIndex, -1);
+    assert.equal(args[perSlotIndex + 1], "16000");
+    assert.ok(args.includes("-c") && args.includes("64000"), "per-slot cap should preserve total context");
+
+    vm.runInContext(
+        'window.LlamaGui.flagCore.setFlagValue("kv_unified", "disabled")',
+        context
+    );
+    args = flatLaunchArgs();
+    assert.ok(!args.includes("--kv-unified-per-slot"), "per-slot cap should be inert without unified KV");
+    vm.runInContext(
+        'window.LlamaGui.flagCore.setFlagValue("kv_unified", "enabled")',
+        context
+    );
+    assert.ok(flatLaunchArgs().includes("--kv-unified-per-slot"), "re-enabling unified KV should restore the cap");
+
+    vm.runInContext(`
+        window.LlamaGui.flagCore.setCurrentToolValue("llama-cli");
+    `, context);
+    assert.ok(!flatLaunchArgs().includes("--kv-unified-per-slot"), "per-slot KV cap is server-only");
+    vm.runInContext(`
+        window.LlamaGui.flagCore.setCurrentToolValue("llama-server");
+        window.LlamaGui.flagCore.replaceFlagValues(getDefaultValues());
+    `, context);
+}
+
+{
     const recognizedModelArgs = [
         [["-m", "models/local.gguf"]],
         [["--model", "models/local.gguf"]],

--- a/ui/js/config-flags-ui.js
+++ b/ui/js/config-flags-ui.js
@@ -990,6 +990,7 @@
                 continue;
             }
             if (!el) continue;
+            if (f.id === "kv_unified_per_slot") el.disabled = values.kv_unified === "disabled";
             if (f.type === "bool") {
                 el.checked = val === true;
                 const lbl = el.parentElement.querySelector("label");

--- a/ui/js/flag-core.js
+++ b/ui/js/flag-core.js
@@ -529,6 +529,7 @@
             if (f.tool !== "both" && f.tool !== toolBase) continue;
             if (f.id === "ngram_mod" || f.id === "ngram_map_k4v") continue;
             if (values.fit === "off" && (f.id === "fit_target" || f.id === "fit_ctx")) continue;
+            if (f.id === "kv_unified_per_slot" && values.kv_unified === "disabled") continue;
             if (typeof shouldOmitSpeculativeFlag === "function" && shouldOmitSpeculativeFlag(f, values)) continue;
             if (shouldOmitLegacyLoadFlag(f, values)) continue;
             const val = values[f.id];

--- a/ui/js/flags/definitions.js
+++ b/ui/js/flags/definitions.js
@@ -1311,6 +1311,17 @@ const FLAGS = [
 			{ value: "disabled", label: "Disabled" },
 		],
 	},
+	{
+		id: "kv_unified_per_slot",
+		flag: "--kv-unified-per-slot",
+		category: "kv",
+		type: "int",
+		label: "Per-Slot Context Limit",
+		desc: "Maximum context length for each server slot when using the unified KV cache. This caps each slot without changing the configured total context window.",
+		tool: "server",
+		min: 1,
+		placeholder: "No per-slot cap",
+	},
 
 	// Speculative Decoding
 	{


### PR DESCRIPTION
## Summary

- Add an optional server-only Per-Slot Context Limit control for unified KV cache deployments.
- Emit `--kv-unified-per-slot` only when unified KV is enabled, while preserving the total context window.
- Disable and omit the control for non-unified KV and llama-cli launches.
- Add launch-argument and frontend smoke-test coverage.
- Document the change in the changelog and upstream tracking notes.

## Testing

- Added frontend launch-argument unit coverage.
- Extended the frontend flag-sync smoke test for UI state, command preview, and enablement behavior.