### PR TITLE
Handle missing Tk dependencies in native file pickers

### DIFF
--- a/backend/routes/file_picker.py
+++ b/backend/routes/file_picker.py
@@ -25,6 +25,8 @@ def select_file(request, response, ctx):
                 "path": selected_path,
             }
         )
+    except file_picker.NativePickerUnavailableError as exc:
+        response.error(str(exc), 503)
     except ValueError as exc:
         response.error(str(exc), 409)
     except Exception as exc:
@@ -42,5 +44,7 @@ def select_folder(request, response, ctx):
             initial_dir=initial_dir,
         )
         response.json({"selected": bool(selected_path), "path": selected_path})
+    except file_picker.NativePickerUnavailableError as exc:
+        response.error(str(exc), 503)
     except Exception as exc:
         response.error(sanitize_error(exc, 500), 500)

--- a/backend/services/file_picker.py
+++ b/backend/services/file_picker.py
@@ -13,6 +13,38 @@ from backend.services import model_dir
 FileTypes = Sequence[Tuple[str, str]]
 
 
+class NativePickerUnavailableError(RuntimeError):
+    """The platform-native picker cannot start because its GUI runtime is missing."""
+
+
+def _native_picker_unavailable_message() -> str:
+    if platform.system() == "Linux":
+        return (
+            "Native file picker unavailable because Python cannot load Tk. "
+            "Install it with your system package manager "
+            "(Arch/CachyOS: sudo pacman -S tk; Debian/Ubuntu: sudo apt install python3-tk), "
+            "then restart Llama GUI."
+        )
+    return (
+        "Native file picker unavailable because this Python installation cannot load Tcl/Tk. "
+        "Repair or reinstall Python with Tcl/Tk support, then restart Llama GUI."
+    )
+
+
+def _create_tk_root():
+    try:
+        import tkinter as tk
+        from tkinter import filedialog
+
+        return tk.Tk(), filedialog
+    except Exception as exc:
+        print(
+            f"[file_picker] native picker unavailable: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        raise NativePickerUnavailableError(_native_picker_unavailable_message()) from exc
+
+
 def _extensions_from_filetypes(filetypes: Optional[FileTypes]) -> list[str]:
     extensions: list[str] = []
     seen = set()
@@ -77,26 +109,20 @@ def select_file_in_native_dialog(
     if platform.system() == "Darwin":
         return select_file_with_osascript(title, initial_dir, filetypes)
 
+    root, filedialog = _create_tk_root()
     try:
-        import tkinter as tk
-        from tkinter import filedialog
-    except Exception as exc:
-        raise RuntimeError(f"Native file picker unavailable: {exc}") from exc
+        root.withdraw()
+        try:
+            root.attributes("-topmost", True)
+        except Exception as exc:
+            print(f"[file_picker] failed to set dialog topmost: {exc}", file=sys.stderr)
 
-    root = tk.Tk()
-    root.withdraw()
-    try:
-        root.attributes("-topmost", True)
-    except Exception as exc:
-        print(f"[file_picker] failed to set dialog topmost: {exc}", file=sys.stderr)
+        dialog_options: dict[str, Any] = {"title": title, "parent": root}
+        if initial_dir:
+            dialog_options["initialdir"] = str(initial_dir)
+        if filetypes:
+            dialog_options["filetypes"] = filetypes
 
-    dialog_options: dict[str, Any] = {"title": title, "parent": root}
-    if initial_dir:
-        dialog_options["initialdir"] = str(initial_dir)
-    if filetypes:
-        dialog_options["filetypes"] = filetypes
-
-    try:
         root.update()
         selected = filedialog.askopenfilename(**dialog_options)
         return selected or ""
@@ -141,23 +167,17 @@ def select_folder_in_native_dialog(
     if platform.system() == "Darwin":
         return select_folder_with_osascript(title, initial_dir)
 
+    root, filedialog = _create_tk_root()
     try:
-        import tkinter as tk
-        from tkinter import filedialog
-    except Exception as exc:
-        raise RuntimeError(f"Native folder picker unavailable: {exc}") from exc
+        root.withdraw()
+        try:
+            root.attributes("-topmost", True)
+        except Exception as exc:
+            print(f"[file_picker] failed to set dialog topmost: {exc}", file=sys.stderr)
 
-    root = tk.Tk()
-    root.withdraw()
-    try:
-        root.attributes("-topmost", True)
-    except Exception as exc:
-        print(f"[file_picker] failed to set dialog topmost: {exc}", file=sys.stderr)
-
-    options: dict[str, Any] = {"title": title, "parent": root, "mustexist": True}
-    if initial_dir:
-        options["initialdir"] = str(initial_dir)
-    try:
+        options: dict[str, Any] = {"title": title, "parent": root, "mustexist": True}
+        if initial_dir:
+            options["initialdir"] = str(initial_dir)
         root.update()
         return filedialog.askdirectory(**options) or ""
     finally:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,9 @@
 
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
+## 2026-09-03
+- Fixed native file-picker failures on Linux installations without Tk: the API now returns actionable package guidance instead of a generic server error, and the Unix installer warns without failing or installing privileged system packages. Windows' existing Tk picker and macOS' AppleScript picker are unchanged.
+
 ## 2026-09-02
 - Added the official llama.cpp ROCm 10.0 binaries as a platform-aware Windows x64/Linux x64 install option, labeled to note that a separate ROCm runtime is required.
 

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,14 @@ if [ ! -x "$VENV_PYTHON" ]; then
     exit 1
 fi
 
+if [ "$(uname -s)" = "Linux" ] && ! "$VENV_PYTHON" -c 'import tkinter' >/dev/null 2>&1; then
+    echo
+    echo "[WARNING] Native file pickers need the optional Tk system package."
+    echo "  Arch/CachyOS: sudo pacman -S tk"
+    echo "  Debian/Ubuntu: sudo apt install python3-tk"
+    echo "Llama GUI will still install; add Tk and restart it to enable Browse/Change dialogs."
+fi
+
 echo "Upgrading pip..."
 "$VENV_PYTHON" -m pip install --upgrade pip
 

--- a/tests/backend/test_extracted_routes.py
+++ b/tests/backend/test_extracted_routes.py
@@ -4166,6 +4166,27 @@ class ExtractedRouteTests(unittest.TestCase):
             self.assertEqual(response.payload["error"], "Internal server error")
             self.assertIn("private picker failure", stderr.getvalue())
 
+    def test_file_picker_routes_report_missing_tk_as_actionable_503(self):
+        message = "Install Tk and restart Llama GUI."
+        cases = (
+            (file_picker.select_file, "select_file_in_native_dialog", "/api/select-file"),
+            (file_picker.select_folder, "select_folder_in_native_dialog", "/api/select-folder"),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = make_context(tmp)
+            for handler, native_name, path in cases:
+                with self.subTest(path=path):
+                    response = DummyResponse()
+                    with mock.patch.object(
+                        file_picker.file_picker,
+                        native_name,
+                        side_effect=file_picker.file_picker.NativePickerUnavailableError(message),
+                    ):
+                        handler(Request("POST", path, "", {}, body={}), response, ctx)
+
+                    self.assertEqual(response.status, 503)
+                    self.assertEqual(response.payload["error"], message)
+
     def test_file_picker_route_handles_initial_directory_creation_failure(self):
         with tempfile.TemporaryDirectory() as tmp:
             ctx = make_context(tmp)

--- a/tests/backend/test_server_baseline.py
+++ b/tests/backend/test_server_baseline.py
@@ -829,6 +829,14 @@ class ReleaseManifestTests(unittest.TestCase):
             self.assertIn(f'"{directory}"', release_script)
         self.assertIn("mkdir -p llama/custom/bin llama/custom/grammars", unix_installer)
 
+    def test_linux_installer_warns_when_optional_tk_is_missing(self):
+        root, _items = self._release_items()
+        unix_installer = (root / "install.sh").read_text(encoding="utf-8")
+
+        self.assertIn("import tkinter", unix_installer)
+        self.assertIn("Arch/CachyOS: sudo pacman -S tk", unix_installer)
+        self.assertIn("Llama GUI will still install", unix_installer)
+
 
 class ImportSmokeTests(unittest.TestCase):
     def test_server_py_is_compatibility_entrypoint(self):

--- a/tests/backend/test_services.py
+++ b/tests/backend/test_services.py
@@ -7,9 +7,11 @@ import os
 import pathlib
 import socket
 import subprocess
+import sys
 import tarfile
 import tempfile
 import threading
+import types
 import unittest
 import urllib.error
 import zipfile
@@ -2365,6 +2367,55 @@ class FilePickerServiceTests(unittest.TestCase):
         completed = SimpleNamespace(returncode=0, stdout="__CANCEL__", stderr="")
         with mock.patch.object(file_picker_service.subprocess, "run", return_value=completed):
             self.assertEqual(file_picker_service.select_folder_with_osascript(), "")
+
+    def test_linux_picker_reports_missing_tk_without_exposing_raw_error(self):
+        fake_tk = types.ModuleType("tkinter")
+        fake_tk.filedialog = SimpleNamespace()
+        fake_tk.Tk = mock.Mock(side_effect=RuntimeError("private libtk8.6.so failure"))
+        stderr = io.StringIO()
+
+        with (
+            contextlib.redirect_stderr(stderr),
+            mock.patch.dict(sys.modules, {"tkinter": fake_tk}),
+            mock.patch.object(file_picker_service.platform, "system", return_value="Linux"),
+            self.assertRaises(file_picker_service.NativePickerUnavailableError) as raised,
+        ):
+            file_picker_service.select_file_in_native_dialog()
+
+        self.assertIn("Arch/CachyOS: sudo pacman -S tk", str(raised.exception))
+        self.assertNotIn("private", str(raised.exception))
+        self.assertIn("private libtk8.6.so failure", stderr.getvalue())
+
+    def test_windows_picker_success_path_is_unchanged(self):
+        root = mock.Mock()
+        filedialog = SimpleNamespace(askopenfilename=mock.Mock(return_value=r"C:\models\test.gguf"))
+        fake_tk = types.ModuleType("tkinter")
+        fake_tk.filedialog = filedialog
+        fake_tk.Tk = mock.Mock(return_value=root)
+
+        with (
+            mock.patch.dict(sys.modules, {"tkinter": fake_tk}),
+            mock.patch.object(file_picker_service.platform, "system", return_value="Windows"),
+        ):
+            selected = file_picker_service.select_file_in_native_dialog(title="Pick Model")
+
+        self.assertEqual(selected, r"C:\models\test.gguf")
+        filedialog.askopenfilename.assert_called_once_with(title="Pick Model", parent=root)
+        root.destroy.assert_called_once_with()
+
+    def test_macos_native_picker_still_bypasses_tk(self):
+        with (
+            mock.patch.object(file_picker_service.platform, "system", return_value="Darwin"),
+            mock.patch.object(
+                file_picker_service,
+                "select_folder_with_osascript",
+                return_value="/Users/test/Models",
+            ) as picker,
+        ):
+            selected = file_picker_service.select_folder_in_native_dialog(title="Pick Folder")
+
+        self.assertEqual(selected, "/Users/test/Models")
+        picker.assert_called_once_with("Pick Folder", None)
 
 
 class GetLatestUserMessageTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Return actionable 503 errors when Linux/Windows native pickers cannot load Tk.
- Add Linux installer warnings with package-specific Tk installation guidance.
- Preserve existing Windows Tk and macOS AppleScript picker behavior.
- Add backend, installer, and platform regression tests.

## Testing
- Added coverage for missing-Tk errors, sanitized client messages, installer warnings, and Windows/macOS picker paths.