### PR TITLE
Fix live context metrics and preserve preset metadata

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
 ## 2026-09-03
+- Prevented successful but temporarily incomplete preset-library refreshes from silently clearing favorites and usage history; that browser-local metadata is now removed only after a confirmed preset deletion or migrated after a rename.
 - Fixed native file-picker failures on Linux installations without Tk: the API now returns actionable package guidance instead of a generic server error, and the Unix installer warns without failing or installing privileged system packages. Windows' existing Tk picker and macOS' AppleScript picker are unchanged.
 
 ## 2026-09-02

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
 ## 2026-09-03
+- Fixed the live Context statistic to use the fullest llama-server slot's retained token count instead of adding lifetime prompt and generation counters, so context shifts now reduce the displayed value correctly; clarified that the adjacent token counts are cumulative processed/generated totals.
 - Prevented successful but temporarily incomplete preset-library refreshes from silently clearing favorites and usage history; that browser-local metadata is now removed only after a confirmed preset deletion or migrated after a rename.
 - Fixed native file-picker failures on Linux installations without Tk: the API now returns actionable package guidance instead of a generic server error, and the Unix installer warns without failing or installing privileged system packages. Windows' existing Tk picker and macOS' AppleScript picker are unchanged.
 

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -816,11 +816,11 @@ Live performance metrics are polled from `llama-server`'s Prometheus endpoint.
 
 ### Displayed Metrics
 
-- **Prompt tokens**: Total tokens processed in prompts (delta since baseline)
+- **Prompt tokens processed**: Total tokens processed in prompts (delta since baseline)
 - **Prompt speed**: Tokens per second during prompt ingestion
-- **Generated tokens**: Total tokens generated (delta since baseline)
+- **Tokens generated**: Total tokens generated (delta since baseline)
 - **Generation speed**: Tokens per second during generation
-- **Context usage**: Total prompt + generated tokens
+- **Context usage**: Tokens currently retained by the fullest server slot
 - **KV cache usage**: Percentage of KV cache filled
 
 The `snapshotStatsBaseline()` function resets the delta counter (called on conversation load and new chat).

--- a/tests/frontend/flag_sync_smoke.cjs
+++ b/tests/frontend/flag_sync_smoke.cjs
@@ -885,6 +885,7 @@ async function main() {
         assert.equal(await page.textContent("#stats-prompt-tokens"), "40",
             "fresh launches must retain tokens processed before the first stats poll");
         assert.equal(await page.textContent("#stats-gen-tokens"), "20");
+        assert.equal(await page.textContent("#stats-context"), "60");
 
         statsMetrics = {
             promptTokens: 1000,
@@ -902,6 +903,8 @@ async function main() {
         assert.equal(await page.textContent("#stats-prompt-tokens"), "0",
             "pre-poll chat resets must not expose lifetime prompt counters after reconnect");
         assert.equal(await page.textContent("#stats-gen-tokens"), "0");
+        assert.equal(await page.textContent("#stats-context"), "125",
+            "context must use the fullest live slot instead of lifetime token counters");
         assert.equal(await page.textContent("#stats-kv-usage"), "13%");
 
         statsMetrics.processing = 1;
@@ -922,6 +925,7 @@ async function main() {
         const liveGenSpeed = Number(await page.textContent("#stats-gen-speed"));
         assert.ok(liveGenSpeed > 20 && liveGenSpeed < 35,
             `generation speed must use live slot deltas, got ${liveGenSpeed}`);
+        assert.equal(await page.textContent("#stats-context"), "140");
 
         await page.evaluate(() => stopStatsPolling());
         assert.equal(metricsHeaders.at(-1).authorization, "Bearer first-secret");

--- a/tests/frontend/presets_unit.cjs
+++ b/tests/frontend/presets_unit.cjs
@@ -351,6 +351,22 @@ assert.equal(
     "renaming a preset with no local state must not invent entries"
 );
 
+const deleteContext = createStoredContext({
+    llama_gui_preset_favorites_v1: JSON.stringify({ Deleted: true, Kept: true }),
+    llama_gui_preset_last_used_v1: JSON.stringify({ Deleted: 1234, Kept: 99 }),
+});
+vm.runInContext("deletePresetLocalState('Deleted')", deleteContext);
+assert.equal(
+    vm.runInContext("JSON.stringify(loadPresetJsonMap('llama_gui_preset_favorites_v1'))", deleteContext),
+    JSON.stringify({ Kept: true }),
+    "confirmed deletion must remove only that preset's favorite"
+);
+assert.equal(
+    vm.runInContext("JSON.stringify(loadPresetJsonMap('llama_gui_preset_last_used_v1'))", deleteContext),
+    JSON.stringify({ Kept: 99 }),
+    "confirmed deletion must remove only that preset's usage history"
+);
+
 // bulk favorite/unfavorite: one storage write for the whole selection
 function countWrites(ctx) {
     return vm.runInContext("__writes", ctx);
@@ -938,6 +954,39 @@ function createPresetLoadElement() {
     return element;
 }
 
+async function testPresetRefreshPreservesMissingFavorite() {
+    const store = {
+        llama_gui_preset_favorites_v1: JSON.stringify({ Visible: true, TemporarilyMissing: true }),
+    };
+    const container = createPresetLoadElement();
+    const ctx = {
+        window: {},
+        document: {
+            getElementById: (id) => (id === "presets-list" ? container : null),
+        },
+        console: { ...console, debug: () => {}, warn: () => {} },
+        localStorage: {
+            getItem: (key) => (Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null),
+            setItem: (key, value) => { store[key] = String(value); },
+        },
+        FLAGS: [],
+        fetchJson: async () => [{ name: "Visible", data: { model: "", flags: {} } }],
+    };
+    ctx.window = ctx;
+    ctx.window.LlamaGui = { manager: { getKnownModelNames: () => null } };
+    vm.createContext(ctx);
+    vm.runInContext(source, ctx, { filename: "presets.js" });
+    vm.runInContext("renderPresetGroups = () => {}", ctx);
+
+    await vm.runInContext("loadPresets()", ctx);
+
+    assert.equal(
+        store.llama_gui_preset_favorites_v1,
+        JSON.stringify({ Visible: true, TemporarilyMissing: true }),
+        "an incomplete successful refresh must not discard favorites"
+    );
+}
+
 async function testPresetLoadFailureClearsAuxiliaryState() {
     const elements = new Map();
     for (const id of [
@@ -1043,6 +1092,7 @@ async function testSetPresetArchivedPostsBatchPayload() {
 }
 
 testSetPresetArchivedPostsBatchPayload()
+    .then(() => testPresetRefreshPreservesMissingFavorite())
     .then(() => testPresetLoadFailureClearsAuxiliaryState())
     .then(() => console.log("presets unit tests passed"))
     .catch((error) => {

--- a/ui/index.html
+++ b/ui/index.html
@@ -1407,11 +1407,11 @@
     <span class="stats-dot"></span>
     <span class="stats-label">Running</span>
     <span class="stats-sep"></span>
-    <span class="stats-item"><span class="stats-value" id="stats-prompt-tokens">--</span> prompt tokens</span>
+    <span class="stats-item"><span class="stats-value" id="stats-prompt-tokens">--</span> prompt tokens processed</span>
     <span class="stats-sep"></span>
     <span class="stats-item"><span class="stats-value" id="stats-prompt-speed">--</span> tok/s prompt</span>
     <span class="stats-sep"></span>
-    <span class="stats-item"><span class="stats-value" id="stats-gen-tokens">--</span> gen tokens</span>
+    <span class="stats-item"><span class="stats-value" id="stats-gen-tokens">--</span> tokens generated</span>
     <span class="stats-sep"></span>
     <span class="stats-item"><span class="stats-value" id="stats-gen-speed">--</span> tok/s gen</span>
     <span class="stats-sep"></span>

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -1090,8 +1090,8 @@ async function pollStats(epoch = statsEpoch) {
         if (effectiveGenSpeed !== undefined) {
             document.getElementById("stats-gen-speed").textContent = effectiveGenSpeed.toFixed(1);
         }
-        if (deltaPrompt !== null && deltaGen !== null) {
-            document.getElementById("stats-context").textContent = (deltaPrompt + deltaGen).toLocaleString();
+        if (slotStats?.contextTokens !== undefined) {
+            document.getElementById("stats-context").textContent = slotStats.contextTokens.toLocaleString();
         }
         if (kvUsage !== undefined) {
             document.getElementById("stats-kv-usage").textContent = (kvUsage * 100).toFixed(0) + "%";
@@ -1152,6 +1152,8 @@ async function fetchSlotStats(host, port, signal) {
 function getSlotStats(slots) {
     if (!Array.isArray(slots)) return undefined;
     let maxUsage;
+    let maxContextUsage;
+    let contextTokens;
     let processing = 0;
     const samples = [];
     for (const slot of slots) {
@@ -1175,14 +1177,19 @@ function getSlotStats(slots) {
         // tokens). Older builds only expose generated tokens via next_token,
         // which is an object in current builds and was an array before.
         let used = Number(slot?.n_prompt_tokens);
-        if (!Number.isFinite(used) || used < 0) {
+        const hasContextTokens = Number.isFinite(used) && used >= 0;
+        if (!hasContextTokens) {
             used = Number(nextToken?.n_decoded);
         }
         if (!Number.isFinite(used) || used < 0) continue;
         const usage = Math.max(0, Math.min(1, used / nCtx));
         maxUsage = maxUsage === undefined ? usage : Math.max(maxUsage, usage);
+        if (hasContextTokens && (maxContextUsage === undefined || usage > maxContextUsage)) {
+            maxContextUsage = usage;
+            contextTokens = used;
+        }
     }
-    return { kvUsage: maxUsage, processing, samples };
+    return { kvUsage: maxUsage, contextTokens, processing, samples };
 }
 
 async function pollOutput() {

--- a/ui/js/presets.js
+++ b/ui/js/presets.js
@@ -466,6 +466,15 @@ function renamePresetLocalState(oldName, newName) {
     }
 }
 
+function deletePresetLocalState(name) {
+    for (const storageKey of [PRESET_FAVORITES_STORAGE_KEY, PRESET_LAST_USED_STORAGE_KEY]) {
+        const map = loadPresetJsonMap(storageKey);
+        if (!Object.prototype.hasOwnProperty.call(map, name)) continue;
+        delete map[name];
+        savePresetJsonMap(storageKey, map);
+    }
+}
+
 function buildDuplicatePresetName(name, existingNames) {
     // Duck-typed rather than `instanceof Set`, which is false for a Set built in
     // another realm (an iframe/worker). The fallback copies any iterable, so
@@ -492,20 +501,6 @@ function buildDuplicatePresetName(name, existingNames) {
     let suffix = 2;
     while (isTaken(`${base} ${suffix}`)) suffix++;
     return `${base} ${suffix}`;
-}
-
-function prunePresetLocalState(existingNames) {
-    for (const storageKey of [PRESET_FAVORITES_STORAGE_KEY, PRESET_LAST_USED_STORAGE_KEY]) {
-        const map = loadPresetJsonMap(storageKey);
-        let changed = false;
-        for (const name of Object.keys(map)) {
-            if (!existingNames.has(name)) {
-                delete map[name];
-                changed = true;
-            }
-        }
-        if (changed) savePresetJsonMap(storageKey, map);
-    }
 }
 
 function getModelQuantLabel(modelLabel) {
@@ -1621,7 +1616,6 @@ async function loadPresets() {
         if (requestId !== loadPresetsRequestId) return;
         presetArchivedCount = presets.filter((preset) => preset.archived === true).length;
         renderPresetArchiveChip();
-        prunePresetLocalState(new Set(presets.map((preset) => preset.name)));
         currentPresetGroups = buildPresetGroups(presets);
         const visibleEntries = getVisiblePresetEntries();
         const visibleNames = new Set(visibleEntries.map((entry) => entry.name));
@@ -1957,6 +1951,7 @@ async function deletePreset(name) {
     if (!ok) return;
     try {
         await fetchJson("/api/presets/" + encodeURIComponent(name), { method: "DELETE" });
+        deletePresetLocalState(name);
         loadPresets();
         showPresetActionStatus(`Deleted preset \"${name}\"`, "success");
     } catch (e) {
@@ -2044,6 +2039,7 @@ async function deleteSelectedPresets() {
     try {
         for (const name of names) {
             await fetchJson("/api/presets/" + encodeURIComponent(name), { method: "DELETE" });
+            deletePresetLocalState(name);
         }
         selectedPresetNames.clear();
         if (names.includes(selectedPresetName)) {


### PR DESCRIPTION
## Summary
- Calculate live context usage from the fullest llama-server slot rather than cumulative prompt and generation counters.
- Clarify cumulative token metric labels in the UI and documentation.
- Preserve favorites and usage history during incomplete preset refreshes; remove metadata only after confirmed deletion and migrate it on rename.

## Testing
- Extended frontend smoke and unit coverage for live context values, preset deletion cleanup, and incomplete refresh preservation.