### PR TITLE
Prevent Chat from using stale runtime status after Stop

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,8 @@ Please give a brief summary of changes made to the program (excluding documentat
 
 ## 2026-09-05
 
+- Fixed Chat briefly using stale running status after Stop, which could re-enable its controls and request properties from the stopped llama-server.
+
 - Fixed Linux Monitor polling failing with a tuple attribute error after the first disk I/O sample (#340).
 
 - Fixed install dropdowns overflowing into the adjacent card at narrower window sizes by constraining them to the available card width.

--- a/tests/frontend/chat_ui_unit.cjs
+++ b/tests/frontend/chat_ui_unit.cjs
@@ -358,7 +358,7 @@ function makeContext({
         },
         confirmAction: async () => true,
         getLatestStatus: () => mutable.status,
-        getLifecycleSnapshot: () => null,
+        getLifecycleSnapshot: () => mutable.lifecycle || null,
         snapshotStatsBaseline: () => {},
         getApiAuthorizationHeaders: (headers) => headers,
         switchTab: () => {},
@@ -371,6 +371,7 @@ function makeContext({
         getStoredConversations,
         setFlagValues: (values) => { mutable.flagValues = values; },
         setStatus: (value) => { mutable.status = value; },
+        setLifecycle: (value) => { mutable.lifecycle = value; },
     };
 }
 
@@ -753,6 +754,44 @@ async function runAbortScenario(action) {
         await oldRefresh;
         assert.equal(staleHint.textContent, "", "an older generation must not overwrite the current hint");
         assert.ok(staleHint.classList.contains("hidden"));
+    }
+
+    // Stop clears the lifecycle runtime before the shared status poll catches up.
+    // That stale running status must not restart props requests or unlock Chat.
+    {
+        let propsRequests = 0;
+        const { api, elements, setStatus, setLifecycle } = makeContext({
+            fetchImpl: makeFetch("complete", {
+                onPropsRequest: () => {
+                    propsRequests += 1;
+                    return Promise.resolve({ ok: true, json: async () => ({}) });
+                },
+            }),
+            extraElementIds: ["chat-status-badge", "chat-no-server-badge"],
+        });
+        let lifecycle = {
+            phase: "running", ready: true,
+            activeRuntime: { tool: "llama-server", generation: 1 },
+        };
+        setLifecycle(lifecycle);
+        await api.refreshTemplateCaps();
+        assert.equal(propsRequests, 1);
+
+        lifecycle = { ...lifecycle, phase: "stopping", ready: false };
+        setLifecycle(lifecycle);
+        api.updateStatusBadge();
+        lifecycle = { phase: "idle", ready: false, activeRuntime: null };
+        setLifecycle(lifecycle);
+        api.updateStatusBadge();
+        await api.refreshTemplateCaps();
+        assert.equal(propsRequests, 1, "stale running status must not probe the stopped server");
+        assert.equal(elements.get("chat-input").disabled, true, "Chat stays disabled after Stop");
+
+        setStatus({ running: false, external_chat_target: { connected: true } });
+        api.updateStatusBadge();
+        await api.refreshTemplateCaps();
+        assert.equal(propsRequests, 2, "an external server remains usable with an idle lifecycle");
+        assert.equal(elements.get("chat-input").disabled, false);
     }
 
     // Regeneration without a matching user turn must leave history intact.

--- a/tests/frontend/flag_sync_smoke.cjs
+++ b/tests/frontend/flag_sync_smoke.cjs
@@ -1153,9 +1153,11 @@ async function main() {
         assert.match(await page.textContent("#chat-no-server-note"), /Start llama-server/i);
         statusRunning = true;
         activeProcessTool = "llama-cli";
+        statusActiveRuntime = { tool: "llama-cli", generation: 43 };
         await page.evaluate(() => refreshRuntimeStatusPanels());
         assert.equal(await page.locator("#chat-input").isDisabled(), true);
         activeProcessTool = "llama-server";
+        statusActiveRuntime = { tool: "llama-server", generation: 44 };
         await page.evaluate(() => refreshRuntimeStatusPanels());
         assert.equal(await page.locator("#chat-input").isDisabled(), false);
         await page.evaluate(() => {
@@ -1763,6 +1765,7 @@ async function main() {
         // on its own, with no process running.
         statusRunning = false;
         activeProcessTool = "";
+        statusActiveRuntime = null;
         await page.evaluate(() => refreshRuntimeStatusPanels());
         assert.equal(await page.textContent("#external-server-badge"), "Not connected");
         assert.equal(

--- a/ui/js/chat-ui.js
+++ b/ui/js/chat-ui.js
@@ -254,7 +254,9 @@
             return lifecycle.ready === true;
         }
         const latestStatus = getLatestStatus ? getLatestStatus() : null;
-        if (latestStatus && latestStatus.running && latestStatus.active_process_tool === "llama-server") {
+        // Lifecycle clears the runtime before the shared status poll catches up
+        // after Stop. Only fall back when lifecycle state is unavailable.
+        if (!lifecycle && latestStatus && latestStatus.running && latestStatus.active_process_tool === "llama-server") {
             return true;
         }
         // A llama-server registered on the API tab is just as good a chat target


### PR DESCRIPTION
## Summary

- Prevented Chat from re-enabling controls or probing server properties when lifecycle state has already transitioned to stopping or idle.
- Preserved support for externally connected llama-server instances.
- Added unit and smoke coverage for lifecycle/status synchronization.

## Testing

- Updated frontend Chat unit tests and flag synchronization smoke tests.