### PR TITLE
Show GUI defaults in the Presets saved-settings table

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 Please give a brief summary of changes made to the program (excluding documentation changes), include the date the changes were made.
 
+## 2026-09-09
+
+- Added Saved value and GUI default columns to the Presets tab's saved-settings table, showing defaults only for overrides. Fixed numeric strings matching numeric defaults and excluded credentials and retired draft context from override counts.
+
 ## 2026-09-08
 
 - Corrected the `-cram` label and help text to describe host-RAM prompt caching for reuse, clarifying that it does not increase the context window or limit VRAM.

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -569,6 +569,8 @@ Because warnings are computed at build time, `refreshModels()` calls `refreshMod
 
 With a preset selected: model and warnings, followed by **Load into Configure**, Favorite, and a keyboard-operable **More actions** disclosure containing a named Update action, Duplicate, Rename, Export, Windows Shortcut, Archive/Restore, and Delete. The launch-input summary shows tool, context, GPU offload, and K/V cache settings from shared flag definitions. Missing values are explicitly labeled as GUI defaults; Auto is not presented as a resolved runtime value. All saved settings are available in a separate disclosure, with API keys and the retired draft-context flag excluded, and HF tokens, sensitive flags, and Custom Launch Args masked.
 
+The saved-settings table has **Setting**, **Saved value**, and **GUI default** columns. Defaults come from the current shared flag definitions and appear only for non-default values; blank cells mean the saved value matches, and unavailable defaults are labeled explicitly. It reuses the override IDs used by the count and search, treating nonempty numeric strings as equal to numeric defaults without coercing blanks or booleans to zero. API keys, HF tokens, and retired draft context do not contribute to the override count.
+
 With nothing selected: a library summary — preset count, model groups, favorites, warnings, missing models, most recently used, and a health line. The summary describes the **visible** presets, not everything on disk, so its numbers always agree with the list and the count line. Any absolute claim about library health is suppressed while a filter is active or while the model list is unchecked.
 
 ### Editing And Saving

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -66,6 +66,8 @@ The smoke test also covers grouped sidebar navigation, current-page semantics, a
 
 Preset browser coverage includes loading into Configure, mirrored saved/modified identity, browsing without changing the edit source, masked comparisons, cancelling an update with focus restoration, saving the reviewed snapshot while newer edits remain pending, save-name collisions, rename/archive navigation, recoverable save failures, removal during a review, and containment at 390/900/1440px.
 
+Saved-settings coverage checks conditional GUI defaults, numeric-string equality, boolean/enum/Auto labels, unavailable defaults, hidden credentials and custom arguments, count consistency, safe text rendering, and table containment at 390/900/1440px. Preset unit tests cover numeric default comparisons, blank/invalid values, legacy reasoning values, excluded fields, search behavior, and preservation of the saved input.
+
 ```powershell
 .venv\Scripts\python.exe -m unittest discover tests -v
 ```

--- a/tests/frontend/flag_sync_smoke.cjs
+++ b/tests/frontend/flag_sync_smoke.cjs
@@ -360,7 +360,12 @@ async function verifyConfigureReset(page) {
 
 async function verifyPresetPolish(page) {
     const entries = [
-        { name: "Daily server", data: { tool: "llama-server", model: "smoke-model.gguf", flags: { temperature: 0.4, hf_token: "hidden-hf-token", custom_args: "--alias daily" } } },
+        { name: "Daily server", data: { tool: "llama-server", model: "smoke-model.gguf", flags: {
+            temperature: 0.4, batch_size: 1024, ubatch_size: "512", gpu_layers: "all",
+            flash_attn: "on", mlock: true, reasoning_preserve: false,
+            hf_token: "hidden-hf-token", api_key: "hidden-api-key", ctx_size_draft: 99,
+            custom_args: "--alias daily", unknown_legacy_flag: "<img src=x>" + "long-value".repeat(20),
+        } } },
         { name: "Another preset", data: { tool: "llama-server", model: "smoke-model.gguf", flags: { ctx_size: 0 } } },
     ];
     const writes = [];
@@ -407,7 +412,31 @@ async function verifyPresetPolish(page) {
         assert.equal(await page.getByRole("button", { name: "Duplicate", exact: true }).isVisible(), false);
         assert.match(await page.textContent(".preset-detail-stats"), /GUI default/);
         await page.locator(".preset-saved-settings > summary").click();
-        assert.doesNotMatch(await page.textContent(".preset-saved-settings"), /hidden-hf-token|--alias daily|ctx_size_draft/);
+        const table = page.locator(".preset-saved-values");
+        assert.deepEqual(await table.locator("thead th").allTextContents(), ["Setting", "Saved value", "GUI default"]);
+        for (const [label, saved, defaultValue] of [
+            ["Prompt Batch Size", "1024", "2048"],
+            ["Physical Batch Size", "512", ""],
+            ["GPU Layers", "All layers", "Auto"],
+            ["Flash Attention", "On", "Auto (default)"],
+            ["Lock Model in RAM", "Enabled", "Disabled"],
+            ["Preserve Reasoning", "Auto", ""],
+        ]) {
+            const row = table.getByRole("row").filter({ has: page.getByRole("rowheader", { name: label, exact: true }) });
+            assert.deepEqual(await row.locator("td").allTextContents(), [saved, defaultValue], label);
+        }
+        assert.equal(await table.locator("tbody tr").last().locator("td").last().textContent(), "Unavailable");
+        assert.equal(await table.locator("img").count(), 0, "saved values render as text");
+        assert.doesNotMatch(await page.textContent(".preset-saved-settings"), /hidden-hf-token|hidden-api-key|--alias daily|ctx_size_draft/);
+        const changedRows = await table.locator("tbody tr").evaluateAll(rows => rows.filter(row => row.lastElementChild.textContent !== "").length);
+        assert.match(await page.textContent(".preset-saved-settings > summary"), new RegExp(`${changedRows} non-default overrides`));
+        const viewport = page.viewportSize();
+        for (const width of [390, 900, 1440]) {
+            await page.setViewportSize({ width, height: 1000 });
+            assert.ok(await table.evaluate(el => el.getBoundingClientRect().width > 0 && el.scrollWidth <= el.clientWidth + 1), `saved settings fit at ${width}px`);
+            assert.ok(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 1), `preset page fits at ${width}px`);
+        }
+        await page.setViewportSize(viewport);
         await page.getByRole("button", { name: "Load into Configure", exact: true }).click();
         await config.waitFor({ state: "visible" });
         assert.equal(await config.locator("[data-preset-name]").textContent(), "Daily server");

--- a/tests/frontend/presets_unit.cjs
+++ b/tests/frontend/presets_unit.cjs
@@ -868,12 +868,33 @@ function createSearchContext() {
 }
 
 const searchContext = createSearchContext();
+for (const [flags, expected] of [
+    [{ batch_size: 1024, ubatch_size: "512" }, ["batch_size"]],
+    [{ batch_size: "2048", temperature: "0.8", dry_multiplier: "0" }, []],
+    [{ batch_size: "2048.0", temperature: "8e-1", dry_multiplier: 0 }, []],
+    [{ batch_size: "1024", temperature: "0.7" }, ["batch_size", "temperature"]],
+    [{ dry_multiplier: "" }, ["dry_multiplier"]],
+    [{ dry_multiplier: " " }, ["dry_multiplier"]],
+    [{ dry_multiplier: null }, ["dry_multiplier"]],
+    [{ dry_multiplier: false }, ["dry_multiplier"]],
+    [{ dry_multiplier: "invalid" }, ["dry_multiplier"]],
+    [{ mlock: false, reasoning_preserve: false }, []],
+    [{ mlock: true, reasoning_preserve: true }, ["mlock", "reasoning_preserve"]],
+    [{ api_key: "secret", hf_token: "secret", ctx_size_draft: 99 }, []],
+    [{ unknown_legacy_flag: 5 }, ["unknown_legacy_flag"]],
+]) {
+    searchContext.__comparisonPreset = { flags };
+    const original = JSON.stringify(flags);
+    const ids = vm.runInContext("getNonDefaultPresetFlagIds(__comparisonPreset)", searchContext);
+    assert.deepEqual(Array.from(ids), expected, `default comparison for ${original}`);
+    assert.equal(JSON.stringify(flags), original, "comparison must not rewrite saved values");
+}
 searchContext.__presets = [
     { name: "long-context", data: { model: "a.gguf", flags: { ctx_size: 200000 } } },
     { name: "speculative", data: { model: "b.gguf", flags: { draft_max: 24 } } },
     { name: "gpu-tuned", data: { model: "c.gguf", flags: { flash_attn: "on" } } },
     // Carries ctx_size at its shipping default, so it must not match "ctx".
-    { name: "plain", data: { model: "d.gguf", flags: { ctx_size: 64000 } } },
+    { name: "plain", data: { model: "d.gguf", flags: { ctx_size: "64000" } } },
 ];
 assert.equal(
     searchContext.window.LlamaGui.presets.getPresetLibrarySummary === undefined,

--- a/ui/css/style.css
+++ b/ui/css/style.css
@@ -3162,10 +3162,6 @@ dialog.config-reset-dialog {
 .preset-saved-settings > summary:focus-visible,
 .preset-review > summary:focus-visible { outline: 2px solid var(--accent-text); outline-offset: 3px; }
 .preset-saved-settings { border-top: 1px solid var(--border); padding-top: var(--space-3); margin-top: var(--space-4); }
-.preset-saved-values { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); font-size: 12px; margin-top: var(--space-3); }
-.preset-saved-values dt, .preset-saved-values dd { padding: var(--space-2) 0; border-bottom: 1px solid var(--border); overflow-wrap: anywhere; }
-.preset-saved-values dt { color: var(--fg-muted); padding-right: var(--space-3); }
-.preset-saved-values dd { margin: 0; font-family: var(--mono); }
 .preset-detail-subtitle + .preset-warning,
 .preset-detail-subtitle + .preset-detail-note { margin-top: var(--space-3); }
 .preset-detail-stats .preset-stat-value { font-size: 13px; overflow-wrap: anywhere; }
@@ -3184,6 +3180,10 @@ dialog.config-reset-dialog {
 .preset-comparison-table th, .preset-comparison-table td { text-align: left; padding: var(--space-2); border-bottom: 1px solid var(--border); vertical-align: top; overflow-wrap: anywhere; }
 .preset-comparison-table th { color: var(--fg-muted); background: var(--bg-raised); position: sticky; top: 0; }
 .preset-comparison-table td:not(:first-child) { font-family: var(--mono); }
+.preset-saved-values { margin-top: var(--space-3); }
+.preset-saved-values th:first-child { width: 50%; }
+.preset-saved-values tbody th { font-weight: 400; background: none; position: static; }
+.preset-saved-values caption { caption-side: bottom; text-align: left; color: var(--fg-muted); padding-top: var(--space-2); }
 dialog.preset-update-dialog { margin: auto; width: min(720px, calc(100% - 32px)); max-height: calc(100% - 32px); overflow: auto; color: var(--fg); }
 .preset-update-dialog h3 { overflow-wrap: anywhere; }
 .preset-update-dialog::backdrop { background: var(--scrim); backdrop-filter: blur(4px); }
@@ -4527,6 +4527,7 @@ body.chat-focus-mode .mobile-toggle { display: none !important; }
     .preset-checkbox,
     .preset-row-load { opacity: 1; }
     .preset-detail-actions .btn { flex: 1 1 45%; }
+    .preset-saved-values th:first-child { width: auto; }
     .modal-dialog .form-row { justify-content: stretch; }
     .stats-bar { gap: 8px; padding: 6px 12px; font-size: 11px; overflow-x: auto; }
     .page-header { flex-direction: column; align-items: flex-start; }

--- a/ui/js/presets.js
+++ b/ui/js/presets.js
@@ -729,22 +729,24 @@ function presetValuesEqual(left, right) {
             && left.length === right.length
             && left.every((value, index) => presetValuesEqual(value, right[index]));
     }
+    // Number controls can save strings. Do not coerce blanks or booleans to zero.
+    if (typeof right === "number" && typeof left === "string" && left.trim() !== "") {
+        return Number.isFinite(right) && Number(left) === right;
+    }
     return left === right;
 }
 
 function getNonDefaultPresetFlagIds(presetData) {
     const flags = (presetData && presetData.flags) || {};
     const core = getPresetFlagCore();
-    const definitions = Array.isArray(window.FLAGS)
-        ? window.FLAGS
-        : (typeof FLAGS !== "undefined" && Array.isArray(FLAGS) ? FLAGS : []);
     const defaults = new Map(
-        definitions
+        getPresetFlagDefinitions()
             .filter((flag) => flag && flag.id && Object.prototype.hasOwnProperty.call(flag, "default"))
             .map((flag) => [flag.id, flag.default])
     );
     return Object.keys(flags).filter((flagId) => (
-        !defaults.has(flagId) || !presetValuesEqual(core.normalizeStoredFlagValue(flagId, flags[flagId]), defaults.get(flagId))
+        !SENSITIVE_PRESET_FLAG_IDS.has(flagId) && flagId !== "ctx_size_draft"
+        && (!defaults.has(flagId) || !presetValuesEqual(core.normalizeStoredFlagValue(flagId, flags[flagId]), defaults.get(flagId)))
     ));
 }
 
@@ -1183,16 +1185,41 @@ function renderPresetDetailPanel() {
     settings.className = "preset-saved-settings";
     const settingsLabel = document.createElement("summary");
     settingsLabel.textContent = `All saved settings · ${entry.overrideCount} non-default overrides`;
-    const values = document.createElement("dl");
-    values.className = "preset-saved-values";
+    const values = document.createElement("table");
+    values.className = "preset-comparison-table preset-saved-values";
+    const caption = document.createElement("caption");
+    caption.textContent = "GUI defaults are shown only where saved values differ. Blank cells match the current GUI default.";
+    const head = document.createElement("thead");
+    const headings = document.createElement("tr");
+    for (const title of ["Setting", "Saved value", "GUI default"]) {
+        const heading = document.createElement("th");
+        heading.scope = "col";
+        heading.textContent = title;
+        headings.appendChild(heading);
+    }
+    head.appendChild(headings);
+    const body = document.createElement("tbody");
+    const definitions = new Map(getPresetFlagDefinitions().map(flag => [flag.id, flag]));
+    const overrides = new Set(entry.overrideFlagIds);
     for (const [id, value] of Object.entries(entry.data.flags)) {
         if (SENSITIVE_PRESET_FLAG_IDS.has(id) || id === "ctx_size_draft") continue;
-        const label = document.createElement("dt");
+        const row = document.createElement("tr");
+        const label = document.createElement("th");
+        label.scope = "row";
         label.textContent = getPresetFlagLabel(id);
-        const text = document.createElement("dd");
+        const text = document.createElement("td");
         text.textContent = formatSavedPresetValue(id, value);
-        values.append(label, text);
+        const defaultText = document.createElement("td");
+        if (overrides.has(id)) {
+            const definition = definitions.get(id);
+            defaultText.textContent = definition && Object.prototype.hasOwnProperty.call(definition, "default")
+                ? formatSavedPresetValue(id, definition.default)
+                : "Unavailable";
+        }
+        row.append(label, text, defaultText);
+        body.appendChild(row);
     }
+    values.append(caption, head, body);
     settings.append(settingsLabel, values);
     const settingsNote = document.createElement("p");
     settingsNote.className = "help-text";


### PR DESCRIPTION
## Summary

- Add Saved value and GUI default columns to the Presets saved-settings table.
- Show defaults only for non-default overrides, including an explicit Unavailable label when needed.
- Compare numeric strings with numeric defaults without mutating saved values.
- Exclude credentials and retired draft-context settings from override counts and display.
- Add responsive smoke-test coverage and unit tests for comparisons, masking, counts, and layout.

## Testing

- Expanded preset unit tests for numeric strings, blanks, booleans, invalid values, excluded fields, search behavior, and input preservation.
- Expanded frontend smoke coverage for table content, safe text rendering, override counts, and 390/900/1440px containment.