### PR TITLE
Handle upstream removal of legacy load flags (b10875)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
 - **Never expose or emit `-cd` / `ctx_size_draft`.** Keep stale preset values inert.
 - New llama.cpp flags: verify upstream (`common/arg.cpp` / `server.cpp`), add to `FLAGS` in `ui/js/flags/definitions.js`, match enum values exactly, and set `false_flag` for negated booleans.
 - Fork-only flags: track in `docs/upstream-changes.md`, set `fork_only: true`, and use booleans defaulting to false. Upstream binary compatibility checks exclude them.
+- Upstream-removed flags kept for older builds: set `removed_in: "bNNNNN"`, track in `docs/upstream-changes.md`. The installed-binary compatibility check exempts them on builds at or above the tag; gate any new-build behavior on `supportsLoadModeOnly()`-style build-tag checks.
 - Chat templates: add one `CHAT_TEMPLATE_PRESETS` entry in `ui/js/flags/chat-templates.js`; bundle `.jinja` files under `ui/templates/`. Emit `--chat-template` or `--chat-template-file`, never both, and reverse-map names/paths to the dropdown.
 - Custom launch args: edit `parseCustomLaunchArgs()` in `ui/js/flag-core.js`, extend its unit tests for new cases, and run them immediately. Parser errors must block launch and appear near the textarea.
 - Themes: add one palette block in `ui/css/tokens.css` and one `THEMES` entry in `ui/js/theme-ui.js`. Never add theme selectors or color literals to `ui/css/style.css`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ Please give a brief summary of changes made to the program (excluding documentat
 - Added a separate Chat window with shared main-window settings, an ownership-safe return action, and a dedicated Chat bootstrap.
 - Added Chat transfer snapshots, ownership guards, and recovery boundaries for the pop-out integration.
 - Removed unused CSS for retired controls and preset chips, including an unused status-dot animation.
+- Marked the legacy mmap/no-mmap, mlock, and Direct I/O flags as removed in llama.cpp b10875 (PR #28334); they stay available for older builds with --load-mode as the replacement.
+- Added a warn-only hint on b10875+ when Legacy load controls or custom args would emit a removed flag, covering the -ndio spelling too.
+- Translated benchmark legacy load toggles to --load-mode on b10875+ because llama-bench and llama-perplexity also dropped --no-mmap, -mmp, and -dio.
+- Exempted flags marked removed_in from the installed-binary compatibility check on builds at or above the removal tag, keeping npm test green on b10875+ installs.
 
 ## 2026-09-10
 

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -887,7 +887,7 @@ Upstream's `--spec-ngram-simple-min-hits` is deliberately not exposed: the curre
 
 ### Model Load Mode
 
-The Context & Memory category exposes `--load-mode` with llama.cpp's `none`, `mmap`, `mlock`, and `dio` modes. The deprecated mmap, mlock, and Direct I/O controls remain available for older builds. When an explicit load mode is selected, command generation suppresses those overlapping legacy arguments so only `--load-mode` is emitted.
+The Context & Memory category exposes `--load-mode` with llama.cpp's `none`, `mmap`, `mlock`, and `dio` modes. The legacy mmap (`--mmap` / `--no-mmap`), mlock, and Direct I/O (`-dio` / `-ndio` / `--direct-io` / `--no-direct-io`) controls remain available for builds at or below b10874; they were removed from `llama-server` / `llama-cli` in b10875 (PR #28334), and b10917 help output confirms `llama-bench` / `llama-perplexity` only advertise `--load-mode` as well. When an explicit load mode is selected, command generation suppresses those overlapping legacy arguments so only `--load-mode` is emitted. On b10875+ (detected via the installed build tag), emitting a removed flag via Legacy controls or custom args adds a warn-only hint to select a `--load-mode` instead, and benchmark commands translate the legacy toggles: perplexity Memory Mapping off emits `--load-mode none` instead of `--no-mmap`; llama-bench mmap on/off emits `--load-mode mmap` / `none` instead of `-mmp 1/0`; Direct I/O on emits `--load-mode dio` instead of `-dio 1`, and off emits nothing. The legacy definitions carry `removed_in: "b10875"` so the installed-binary compatibility check exempts them on newer builds.
 
 ---
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -145,7 +145,7 @@ Fast Node tests:
 - `module_namespace_unit.cjs`: frontend script load order and exported namespaces.
 - `flag_definitions_unit.cjs`: structural validation of flag/category definitions and representative invalid cases.
 - `llama_flags_runner_unit.cjs`: deterministic binary-selection fixtures, required-build failures, no fallback from explicit paths, custom-backend discovery, failed/timed-out help, negated flags, and fork-only exclusions.
-- `llama_flags_supported_unit.cjs`: compares GUI flags against real `llama-server` / `llama-cli` help output. CI requires the pinned CPU binaries; optional local discovery can skip with a message.
+- `llama_flags_supported_unit.cjs`: compares GUI flags against real `llama-server` / `llama-cli` help output. Flags marked `fork_only: true` are always exempt; flags marked `removed_in: "bNNNNN"` (upstream removals retained for older builds) are exempt when the probed binary reports a build at or above that tag, parsed from `--version`. CI requires the pinned CPU binaries; optional local discovery can skip with a message.
 - `js_syntax_check.cjs`: syntax-only check for frontend JavaScript.
 
 Browser smoke test:

--- a/docs/upstream-changes.md
+++ b/docs/upstream-changes.md
@@ -4,6 +4,12 @@ Track announced llama.cpp changes that may require coordinated Llama-GUI updates
 
 ## Pending
 
+### Legacy load flags removed in favor of --load-mode - - - Done
+
+- **Upstream:** b10875, Sep 9 (PR #28334): `--mmap` / `--no-mmap`, `--mlock`, and `-dio` / `-ndio` / `--direct-io` / `--no-direct-io` removed from `llama-cli` / `llama-server` in favor of `--load-mode`. Installed b10917 `--help` output confirms `llama-bench` / `llama-perplexity` also only advertise `--load-mode`.
+- **Status:** Implemented (2026-09-11). `--load-mode` was already the default (`auto`); the legacy `mmap`, `mlock`, and `direct_io` definitions are retained for builds at or below b10874 with updated descriptions pointing at `--load-mode`. Explicit load-mode selection still suppresses the legacy arguments via `shouldOmitLegacyLoadFlag()`. On b10875+ (gated by the installed build tag from `/api/status`, like the reasoning-effort gate), emitting a removed flag — via Legacy controls or custom args — adds a warn-only hint to select a `--load-mode` instead; older, custom, and unknown tags stay silent. Benchmark commands translate the legacy toggles on b10875+: perplexity Memory Mapping off emits `--load-mode none` instead of `--no-mmap`; llama-bench mmap on/off emits `--load-mode mmap` / `none` instead of `-mmp 1/0`; Direct I/O on emits `--load-mode dio` instead of `-dio 1`, and off emits nothing. The legacy definitions carry `removed_in: "b10875"`, which `llama_flags_supported_unit.cjs` honors by exempting them when the probed binary's build (parsed from `--version`) is at or above the tag.
+- **Remaining:** removal of the legacy definitions and their `removed_in` exemptions once the supported binary floor is past b10875.
+
 ### Native reasoning-effort support — residual compatibility window - - - Done
 
 - **Upstream:** [ggml-org/llama.cpp#26941](https://github.com/ggml-org/llama.cpp/pull/26941), merged on 2026-08-14 as commit `7e4c0a9`, first release `b10434`.

--- a/tests/frontend/benchmark_args_unit.cjs
+++ b/tests/frontend/benchmark_args_unit.cjs
@@ -392,6 +392,80 @@ function flat(result) {
     assert.equal(elements["benchmark-chunks"].value, "5");
 }
 
+{
+    // llama.cpp b10875+ removed the legacy load flags from llama-bench and
+    // llama-perplexity too, so benchmark commands must translate them into
+    // --load-mode values instead of emitting flags the tools would reject.
+    vm.runInContext(`window.LlamaGui.flagCore.setBinaryTag("b10917")`, context);
+
+    const ppl = adapter.buildBenchmarkArgs({
+        benchmarkType: "perplexity",
+        flags,
+        source: { model: "ppl-model.gguf", flags: {} },
+        promptFile: "eval.txt",
+        pplMmap: false,
+    });
+    assert.equal(ppl.error, null);
+    const pplFlat = flat(ppl);
+    assert.ok(!pplFlat.includes("--no-mmap"), "new builds must not emit --no-mmap for perplexity");
+    const pplLoadModeIndex = pplFlat.indexOf("--load-mode");
+    assert.notEqual(pplLoadModeIndex, -1, "mmap-off must translate to a load mode");
+    assert.equal(pplFlat[pplLoadModeIndex + 1], "none");
+    assert.ok(ppl.applied.some((item) => item.label === "Memory Mapping"
+        && item.value === "Off (--load-mode none)"), "the settings summary must show the translated flag");
+
+    const benchMmapOff = adapter.buildBenchmarkArgs({
+        benchmarkType: "bench",
+        flags,
+        source: { model: "tiny.gguf", flags: { load_mode: "", mmap: false } },
+        defaultFlags: { mmap: false },
+    });
+    assert.equal(benchMmapOff.error, null);
+    assert.ok(!flat(benchMmapOff).includes("-mmp"), "new builds must not emit -mmp");
+    assert.ok(flat(benchMmapOff).includes("--load-mode") && flat(benchMmapOff).includes("none"));
+
+    const benchMmapOn = adapter.buildBenchmarkArgs({
+        benchmarkType: "bench",
+        flags,
+        source: { model: "tiny.gguf", flags: { load_mode: "", mmap: true } },
+    });
+    assert.equal(benchMmapOn.error, null);
+    assert.ok(!flat(benchMmapOn).includes("-mmp"));
+    assert.ok(flat(benchMmapOn).includes("--load-mode") && flat(benchMmapOn).includes("mmap"));
+
+    const benchDio = adapter.buildBenchmarkArgs({
+        benchmarkType: "bench",
+        flags,
+        source: { model: "tiny.gguf", flags: { load_mode: "", direct_io: true } },
+    });
+    assert.equal(benchDio.error, null);
+    assert.ok(!flat(benchDio).includes("-dio"), "new builds must not emit -dio");
+    assert.ok(flat(benchDio).includes("--load-mode") && flat(benchDio).includes("dio"));
+
+    const benchDioOff = adapter.buildBenchmarkArgs({
+        benchmarkType: "bench",
+        flags,
+        source: { model: "tiny.gguf", flags: { load_mode: "", direct_io: false } },
+        defaultFlags: { direct_io: false },
+    });
+    assert.equal(benchDioOff.error, null);
+    assert.ok(!flat(benchDioOff).includes("-dio"));
+    assert.ok(!flat(benchDioOff).includes("--load-mode"),
+        "dio-off is the default load behavior on new builds; nothing may be emitted");
+
+    // An explicit load mode still suppresses the legacy toggles entirely.
+    const benchExplicitMode = adapter.buildBenchmarkArgs({
+        benchmarkType: "bench",
+        flags,
+        source: { model: "tiny.gguf", flags: { load_mode: "mmap+mlock", mmap: false, direct_io: true } },
+    });
+    assert.equal(benchExplicitMode.error, null);
+    assert.equal(flat(benchExplicitMode).filter((token) => token === "--load-mode").length, 1);
+    assert.ok(flat(benchExplicitMode).includes("mmap+mlock"));
+
+    vm.runInContext(`window.LlamaGui.flagCore.setBinaryTag("")`, context);
+}
+
 function trackedClassList(initial = []) {
     const values = new Set(initial);
     return {

--- a/tests/frontend/flag_sync_smoke.cjs
+++ b/tests/frontend/flag_sync_smoke.cjs
@@ -123,7 +123,7 @@ async function verifyConfigurePresentation(page) {
     assert.equal(numberColumns.length, 3);
     assert.ok(numberColumns.every(rect => Math.abs(rect.left - numberColumns[0].left) < 1
         && Math.abs(rect.right - numberColumns[0].right) < 1), "numeric controls share an aligned column");
-    assert.match(await page.locator('.flag-row[data-flag-id="mlock"] .flag-desc').textContent(), /Deprecated/);
+    assert.match(await page.locator('.flag-row[data-flag-id="mlock"] .flag-desc').textContent(), /Legacy.*b10875/);
 
     await page.fill("#config-search", "sampling");
     const submenu = page.locator('.accordion[data-category-id="sampling"] .flag-submenu-header').first();

--- a/tests/frontend/launch_args_unit.cjs
+++ b/tests/frontend/launch_args_unit.cjs
@@ -199,10 +199,10 @@ function launchResult() {
     assert.equal(
         vm.runInContext("window.LlamaGui.flagCore.getFlagValues().mmap", context),
         false,
-        "deprecated mmap control should be disabled by default"
+        "legacy mmap control should be disabled by default"
     );
     assert.ok(args.includes("--load-mode") && args.includes("auto"), "default launch args should use auto load mode");
-    assert.ok(!args.includes("--mmap") && !args.includes("--no-mmap"), "default launch args should not use deprecated mmap flags");
+    assert.ok(!args.includes("--mmap") && !args.includes("--no-mmap"), "default launch args should not use legacy mmap flags");
     assert.ok(args.includes("--jinja"), "default launch args should reflect llama.cpp's enabled Jinja default");
     assert.ok(!args.includes("--no-jinja"), "default launch args should not disable Jinja");
     const timeoutIndex = args.indexOf("-to");
@@ -586,6 +586,75 @@ function launchResult() {
     assert.ok(args.includes('{"preserve_thinking":true}'));
 
     vm.runInContext(`
+        window.LlamaGui.flagCore.replaceFlagValues(getDefaultValues());
+    `, context);
+}
+
+{
+    // llama.cpp b10875+ removed --mmap/--no-mmap, --mlock, and
+    // -dio/--direct-io/--no-direct-io from llama-server/llama-cli (PR #28334).
+    // Legacy controls stay for older builds; new builds get a warn-only hint.
+    assert.equal(vm.runInContext("window.LlamaGui.flagCore.supportsLoadModeOnly()", context), false);
+    vm.runInContext(`window.LlamaGui.flagCore.setBinaryTag("b10874")`, context);
+    assert.equal(vm.runInContext("window.LlamaGui.flagCore.supportsLoadModeOnly()", context), false);
+    vm.runInContext(`window.LlamaGui.flagCore.setBinaryTag("b10875")`, context);
+    assert.equal(vm.runInContext("window.LlamaGui.flagCore.supportsLoadModeOnly()", context), true);
+    vm.runInContext(`window.LlamaGui.flagCore.setBinaryTag("custom")`, context);
+    assert.equal(vm.runInContext("window.LlamaGui.flagCore.supportsLoadModeOnly()", context), false);
+
+    // Old builds stay silent on the legacy path.
+    vm.runInContext(`
+        window.LlamaGui.flagCore.setBinaryTag("b10874");
+        window.LlamaGui.flagCore.replaceFlagValues(getDefaultValues());
+        window.LlamaGui.flagCore.setMultipleFlagValues({ load_mode: "", mlock: true });
+    `, context);
+    let legacyResult = launchResult();
+    let legacyFlat = Array.from(legacyResult.args).flat().map(String);
+    assert.ok(legacyFlat.includes("--mlock"), "legacy mlock must still emit on old builds");
+    assert.equal(legacyResult.warnings.length, 0, "old builds must not warn about legacy load flags");
+
+    // New builds stay silent on the default auto path.
+    vm.runInContext(`
+        window.LlamaGui.flagCore.setBinaryTag("b10875");
+        window.LlamaGui.flagCore.replaceFlagValues(getDefaultValues());
+    `, context);
+    legacyResult = launchResult();
+    legacyFlat = Array.from(legacyResult.args).flat().map(String);
+    assert.ok(legacyFlat.includes("--load-mode") && legacyFlat.includes("auto"));
+    assert.ok(!legacyFlat.includes("--mlock") && !legacyFlat.includes("--mmap"));
+    assert.equal(legacyResult.warnings.filter((w) => String(w).includes("b10875")).length, 0);
+
+    // New builds warn (but still emit) on the legacy path.
+    vm.runInContext(`
+        window.LlamaGui.flagCore.setMultipleFlagValues({ load_mode: "", mlock: true });
+    `, context);
+    legacyResult = launchResult();
+    legacyFlat = Array.from(legacyResult.args).flat().map(String);
+    assert.ok(legacyFlat.includes("--mlock"), "legacy mlock must still emit so old presets round-trip");
+    assert.ok(legacyResult.warnings.some((w) => String(w).includes("b10875")), "new builds must warn about legacy load flags");
+
+    // Custom backends and unknown tags stay silent like the reasoning gate.
+    vm.runInContext(`window.LlamaGui.flagCore.setBinaryTag("custom")`, context);
+    legacyResult = launchResult();
+    assert.equal(legacyResult.warnings.filter((w) => String(w).includes("b10875")).length, 0);
+
+    // Custom args with removed spellings warn on new builds.
+    vm.runInContext(`
+        window.LlamaGui.flagCore.setBinaryTag("b10875");
+        window.LlamaGui.flagCore.replaceFlagValues(getDefaultValues());
+        window.LlamaGui.flagCore.setFlagValue("custom_args", "--no-mmap");
+    `, context);
+    legacyResult = launchResult();
+    assert.ok(legacyResult.warnings.some((w) => String(w).includes("b10875")), "custom legacy spellings must warn on new builds");
+
+    vm.runInContext(`
+        window.LlamaGui.flagCore.setFlagValue("custom_args", "-ndio");
+    `, context);
+    legacyResult = launchResult();
+    assert.ok(legacyResult.warnings.some((w) => String(w).includes("b10875")), "custom -ndio spellings must warn on new builds");
+
+    vm.runInContext(`
+        window.LlamaGui.flagCore.setBinaryTag("");
         window.LlamaGui.flagCore.replaceFlagValues(getDefaultValues());
     `, context);
 }

--- a/tests/frontend/llama_flags_runner_unit.cjs
+++ b/tests/frontend/llama_flags_runner_unit.cjs
@@ -9,8 +9,12 @@ const flags = [
     { id: "feature", flag: "--feature", false_flag: "--no-feature", tool: "both" },
     { id: "fork", flag: "--fork-only", tool: "both", fork_only: true },
 ];
+const removedFlags = [
+    { id: "feature", flag: "--feature", false_flag: "--no-feature", tool: "both" },
+    { id: "legacy", flag: "--legacy", false_flag: "--no-legacy", tool: "both", removed_in: "b10875" },
+];
 
-function run({ env = {}, files = [], config, help, required = false } = {}) {
+function run({ env = {}, files = [], config, help, version, flagDefs = flags, required = false } = {}) {
     const calls = [];
     const messages = [];
     let exitCode = 0;
@@ -19,12 +23,16 @@ function run({ env = {}, files = [], config, help, required = false } = {}) {
     const fakeFs = {
         existsSync: file => files.includes(file) || (file === "/repo/config.json" && config !== undefined),
         readFileSync: file => file === "/repo/config.json" ? JSON.stringify(config)
-            : file.endsWith("definitions.js") ? `const FLAGS = ${JSON.stringify(flags)};` : "",
+            : file.endsWith("definitions.js") ? `const FLAGS = ${JSON.stringify(flagDefs)};` : "",
     };
     const spawnSync = (file, args, options) => {
-        calls.push(file);
-        assert.deepEqual(Array.from(args), ["--help"]);
+        const argv = Array.from(args);
         assert.ok(options.timeout > 0 && options.timeout <= 60000, "a stalled binary must not hang CI");
+        if (argv[0] === "--version") {
+            return version || { status: 0, stdout: "" };
+        }
+        assert.deepEqual(argv, ["--help"]);
+        calls.push(file);
         return help || { status: 0, stdout: "--feature, --no-feature\n" };
     };
     try {
@@ -86,4 +94,26 @@ const selected02 = run({ config: { backend: "custom-02" }, files: [...custom02, 
 assert.equal(selected02.exitCode, 0);
 assert.deepEqual(selected02.calls, custom02, "the second slot must take precedence over the first and PATH");
 assert.equal(run({ files: both, env: { LLAMA_CPP_BIN_DIR: "/pin" } }).exitCode, 0);
+
+// removed_in exemption: builds at or above the removal tag may lack the flag;
+// older builds must still advertise it; unparseable versions stay strict.
+const removedPinned = { env: { LLAMA_GUI_LLAMA_BIN_DIR: "/pin" }, files: both, flagDefs: removedFlags };
+const newBuild = run({
+    ...removedPinned,
+    version: { status: 0, stdout: "version: 0.4.0-dev (build 10917, commit 8ea290247)\n" },
+});
+assert.equal(newBuild.exitCode, 0);
+assert.match(newBuild.output, /exempted 4 option\(s\) removed upstream/);
+assert.match(newBuild.output, /--legacy/);
+
+const oldBuild = run({
+    ...removedPinned,
+    version: { status: 0, stdout: "version: 0.4.0-dev (build 10826, commit abc1234)\n" },
+});
+assert.equal(oldBuild.exitCode, 1, "builds below the removal tag must still advertise removed_in flags");
+assert.match(oldBuild.output, /--no-legacy/);
+
+const unknownBuild = run({ ...removedPinned, version: { status: 0, stdout: "custom fork build\n" } });
+assert.equal(unknownBuild.exitCode, 1, "an unparseable binary version must keep the strict check");
+
 console.log("llama flag runner selection, strict failures and compatibility checks passed");

--- a/tests/frontend/llama_flags_supported_unit.cjs
+++ b/tests/frontend/llama_flags_supported_unit.cjs
@@ -85,6 +85,24 @@ function runHelp(executable) {
     return `${result.stdout || ""}\n${result.stderr || ""}`;
 }
 
+function parseToolBuildNumber(executable) {
+    const result = spawnSync(executable, ["--version"], {
+        cwd: ROOT,
+        encoding: "utf8",
+        windowsHide: true,
+        timeout: 30000,
+        maxBuffer: 1024 * 1024,
+    });
+    const text = stripAnsi(`${result.stdout || ""}\n${result.stderr || ""}`);
+    const match = /\bbuild\s+(\d+)\b/.exec(text) || /\bb(\d{3,})\b/.exec(text);
+    return match ? Number(match[1]) : null;
+}
+
+function parseRemovedInBuild(value) {
+    const match = /^b(\d+)$/.exec(String(value || "").trim());
+    return match ? Number(match[1]) : null;
+}
+
 function stripAnsi(value) {
     return String(value).replace(/\x1b\[[0-9;]*m/g, "");
 }
@@ -105,17 +123,27 @@ function expectedTools(flag) {
     return [flag.tool];
 }
 
-function collectUnsupportedFlags(flags, advertisedByTool) {
+function collectUnsupportedFlags(flags, advertisedByTool, buildByTool) {
     const unsupported = [];
+    const removedExemptions = [];
     for (const flag of flags) {
         // Fork-only flags (documented in docs/upstream-changes.md) are absent
         // from upstream builds on purpose; never hold them against a binary.
         if (flag.fork_only) continue;
+        const removedInBuild = parseRemovedInBuild(flag.removed_in);
         for (const option of [flag.flag, flag.false_flag].filter(Boolean)) {
             for (const tool of expectedTools(flag)) {
                 const advertised = advertisedByTool[tool];
                 if (!advertised) continue;
                 if (!advertised.has(option)) {
+                    // Flags removed upstream (removed_in, documented in
+                    // docs/upstream-changes.md) stay in the GUI for older
+                    // builds; builds at or above the removal tag may lack them.
+                    const build = buildByTool[tool];
+                    if (removedInBuild !== null && build !== null && build >= removedInBuild) {
+                        removedExemptions.push({ tool, id: flag.id, option, build, removedInBuild });
+                        continue;
+                    }
                     unsupported.push({
                         tool,
                         id: flag.id,
@@ -126,7 +154,7 @@ function collectUnsupportedFlags(flags, advertisedByTool) {
             }
         }
     }
-    return unsupported;
+    return { unsupported, removedExemptions };
 }
 
 assert.ok(!REQUIRE_BINARIES || EXPLICIT_BIN_DIR,
@@ -143,9 +171,11 @@ if (REQUIRE_BINARIES) {
 }
 
 const advertisedByTool = {};
+const buildByTool = {};
 for (const [tool, executable] of Object.entries(executables)) {
     if (!executable) continue;
     advertisedByTool[tool] = parseAdvertisedOptions(runHelp(executable));
+    buildByTool[tool] = parseToolBuildNumber(executable);
 }
 
 if (!advertisedByTool.server && !advertisedByTool.cli) {
@@ -156,7 +186,7 @@ if (!advertisedByTool.server && !advertisedByTool.cli) {
     process.exit(0);
 }
 
-const unsupported = collectUnsupportedFlags(flags, advertisedByTool);
+const { unsupported, removedExemptions } = collectUnsupportedFlags(flags, advertisedByTool, buildByTool);
 if (unsupported.length > 0) {
     console.error("Unsupported llama.cpp flags exposed by the GUI:");
     for (const item of unsupported) {
@@ -168,6 +198,12 @@ const forkOnlyCount = flags.filter((flag) => flag.fork_only).length;
 if (forkOnlyCount > 0) {
     console.log(
         `llama flag compatibility: skipped ${forkOnlyCount} fork-only flag(s) (fork_only: true; see docs/upstream-changes.md).`
+    );
+}
+if (removedExemptions.length > 0) {
+    console.log(
+        `llama flag compatibility: exempted ${removedExemptions.length} option(s) removed upstream (removed_in; see docs/upstream-changes.md): ` +
+        removedExemptions.map((item) => `${item.tool}: ${item.option} (build ${item.build} >= ${item.removedInBuild})`).join(", ")
     );
 }
 const checkedTools = Object.entries(executables)

--- a/ui/js/benchmark-ui.js
+++ b/ui/js/benchmark-ui.js
@@ -180,6 +180,18 @@
         });
     }
 
+    // llama.cpp b10875 removed --mmap/--no-mmap, --mlock, and the -dio family
+    // from every tool — llama-bench and llama-perplexity only advertise
+    // --load-mode on such builds — so legacy load toggles must translate.
+    function isLoadModeOnlyBuild() {
+        const core = root.flagCore;
+        return Boolean(core && typeof core.supportsLoadModeOnly === "function" && core.supportsLoadModeOnly());
+    }
+
+    function hasLoadModeArg(args) {
+        return args.some((entry) => Array.isArray(entry) && (entry[0] === "--load-mode" || entry[0] === "-lm"));
+    }
+
     function pushFlagArg(args, tool, flag, value) {
         if (isEmptyFlagValue(value)) return false;
 
@@ -197,10 +209,22 @@
                 }
             }
             if (flag.id === "mmap") {
+                if (isLoadModeOnlyBuild()) {
+                    if (hasLoadModeArg(args)) return false;
+                    args.push(["--load-mode", value ? "mmap" : "none"]);
+                    return true;
+                }
                 args.push(["-mmp", value ? "1" : "0"]);
                 return true;
             }
             if (flag.id === "direct_io") {
+                if (isLoadModeOnlyBuild()) {
+                    // "dio off" is the default load behavior on new builds, so
+                    // only the enabled state maps onto --load-mode.
+                    if (!value || hasLoadModeArg(args)) return false;
+                    args.push(["--load-mode", "dio"]);
+                    return true;
+                }
                 args.push(["-dio", value ? "1" : "0"]);
                 return true;
             }
@@ -353,7 +377,8 @@
                 if (flashAttention) args.push(["-fa", flashAttention]);
                 if (cacheTypeK) args.push(["-ctk", cacheTypeK]);
                 if (cacheTypeV) args.push(["-ctv", cacheTypeV]);
-                if (options.pplMmap === false) args.push(["--no-mmap"]);
+                const mmapOffArg = isLoadModeOnlyBuild() ? ["--load-mode", "none"] : ["--no-mmap"];
+                if (options.pplMmap === false) args.push(mmapOffArg);
                 args.push(["-f", String(options.promptFile)]);
                 if (options.chunks !== undefined && options.chunks !== "") args.push(["--chunks", String(options.chunks)]);
                 if (options.pplStride !== undefined && options.pplStride !== "") args.push(["--ppl-stride", String(options.pplStride)]);
@@ -366,7 +391,7 @@
                 if (flashAttention) applied.push({ label: "Flash Attention", value: flashAttention });
                 if (cacheTypeK) applied.push({ label: "K Cache Type", value: cacheTypeK });
                 if (cacheTypeV) applied.push({ label: "V Cache Type", value: cacheTypeV });
-                applied.push({ label: "Memory Mapping", value: options.pplMmap === false ? "Off (--no-mmap)" : "On" });
+                applied.push({ label: "Memory Mapping", value: options.pplMmap === false ? `Off (${mmapOffArg.join(" ")})` : "On" });
                 applied.push({ label: "Chunks", value: options.chunks === undefined || options.chunks === "" ? "-1" : String(options.chunks) });
                 applied.push({ label: "PPL Stride", value: options.pplStride === undefined || options.pplStride === "" ? "0" : String(options.pplStride) });
                 applied.push({ label: "Warmup", value: options.warmup === false ? "Off" : "On" });

--- a/ui/js/flag-core.js
+++ b/ui/js/flag-core.js
@@ -543,6 +543,17 @@
         return Boolean(match) && Number(match[1]) >= 10434;
     }
 
+    // Gate for llama.cpp b10875+, where --mmap/--no-mmap, --mlock, and
+    // -dio/--direct-io/--no-direct-io were removed from llama-server and
+    // llama-cli in favor of --load-mode (upstream PR 28334). The tag comes
+    // from /api/status like the reasoning-effort gate above: official
+    // releases use "bNNNNN"; custom slots use "custom". Anything
+    // unrecognized stays silent, keeping older and custom builds working.
+    function supportsLoadModeOnly() {
+        const match = /^b(\d+)$/.exec(binaryTag);
+        return Boolean(match) && Number(match[1]) >= 10875;
+    }
+
     function buildLaunchArgs(state) {
         const args = [];
         const warnings = [];
@@ -693,6 +704,17 @@
             args.push(["-m", localModel.path]);
         }
 
+        if (supportsLoadModeOnly()) {
+            const removedLoadFlags = new Set(["--mmap", "--no-mmap", "--mlock", "-dio", "-ndio", "--direct-io", "--no-direct-io"]);
+            const hasRemovedLoadFlag = args.some((entry) => {
+                if (Array.isArray(entry)) return removedLoadFlags.has(String(entry[0]));
+                return removedLoadFlags.has(getCustomArgFlagName(entry));
+            });
+            if (hasRemovedLoadFlag) {
+                warnings.push("Legacy load flags (--mmap/--no-mmap, --mlock, -dio/--direct-io) were removed in llama.cpp b10875 and will fail on this build. Select a --load-mode instead of Legacy controls.");
+            }
+        }
+
         return { args, error: null, warnings };
     }
 
@@ -827,6 +849,7 @@
         compareLaunchSettings,
         setBinaryTag,
         supportsNativeReasoningEffort,
+        supportsLoadModeOnly,
         updateCommandPreview,
         registerApi,
     };

--- a/ui/js/flags/definitions.js
+++ b/ui/js/flags/definitions.js
@@ -196,9 +196,12 @@ const FLAGS = [
 		category: "context",
 		type: "bool",
 		label: "Lock Model in RAM",
-		desc: "Deprecated by llama.cpp in favor of --load-mode mlock. Force the OS to keep the memory-mapped model in physical RAM and never swap it to disk.",
+		desc: "Legacy — removed in llama.cpp b10875 (PR #28334); retained for older builds. Use --load-mode mlock on newer builds. Force the OS to keep the memory-mapped model in physical RAM and never swap it to disk.",
 		tool: "both",
 		default: false,
+		// Removed upstream (docs/upstream-changes.md): the installed-binary
+		// compatibility check exempts this flag on builds at or above the tag.
+		removed_in: "b10875",
 	},
 	{
 		id: "mmap",
@@ -207,9 +210,12 @@ const FLAGS = [
 		category: "context",
 		type: "bool",
 		label: "Memory Map Model",
-		desc: "Deprecated by llama.cpp in favor of --load-mode mmap. Load the model using memory-mapped files for faster loading and lower RAM usage.",
+		desc: "Legacy — removed in llama.cpp b10875 (PR #28334); retained for older builds. Use --load-mode mmap on newer builds. --mmap / --no-mmap no longer exist in llama-server / llama-cli. Load the model using memory-mapped files for faster loading and lower RAM usage.",
 		tool: "both",
 		default: false,
+		// Removed upstream (docs/upstream-changes.md): the installed-binary
+		// compatibility check exempts this flag on builds at or above the tag.
+		removed_in: "b10875",
 	},
 	{
 		id: "direct_io",
@@ -217,9 +223,12 @@ const FLAGS = [
 		category: "context",
 		type: "bool",
 		label: "Direct I/O",
-		desc: "Deprecated by llama.cpp in favor of --load-mode dio. Bypass the OS page cache when loading the model, when supported.",
+		desc: "Legacy — removed in llama.cpp b10875 (PR #28334); retained for older builds. Use --load-mode dio on newer builds. -dio / -ndio / --direct-io / --no-direct-io no longer exist in llama-server / llama-cli. Bypass the OS page cache when loading the model, when supported.",
 		tool: "both",
 		default: false,
+		// Removed upstream (docs/upstream-changes.md): the installed-binary
+		// compatibility check exempts this flag on builds at or above the tag.
+		removed_in: "b10875",
 	},
 	{
 		id: "load_mode",
@@ -228,7 +237,7 @@ const FLAGS = [
 		type: "enum",
 		label: "Model Load Mode",
 		short_desc: "Choose llama.cpp's model loading strategy.",
-		desc: "Preferred replacement for the deprecated mmap, mlock, and Direct I/O switches. Selecting a mode suppresses those legacy arguments in the generated command.",
+		desc: "Preferred replacement for the removed mmap, mlock, and Direct I/O switches (removed in llama.cpp b10875). Selecting a mode suppresses those legacy arguments in the generated command. Select Legacy controls only for older builds that lack --load-mode.",
 		tool: "both",
 		default: "auto",
 		options: [


### PR DESCRIPTION
Detect llama.cpp b10875+ (where --mmap/--no-mmap, --mlock and -dio family were removed) and adapt the GUI: add flagCore.supportsLoadModeOnly(), emit a warn-only hint when legacy load flags are present on newer builds, translate legacy benchmark toggles to --load-mode, mark mmap/mlock/direct_io flags with removed_in: "b10875" and exempt them from compatibility checks for newer builds. Update docs, UI messages, and unit tests to cover translation, warnings, and build-tag probing; preserve silent behavior for older/custom builds.

